### PR TITLE
feat: added spacing tokens in REM

### DIFF
--- a/src/theme/as24/index.ts
+++ b/src/theme/as24/index.ts
@@ -1,11 +1,12 @@
 import { extendTheme } from '@chakra-ui/react';
 
 import colors from './colors';
-import { basis } from '../shared';
+import { basis, spacing } from '../shared';
 
 export const theme = {
   ...basis,
   colors,
+  spacing,
   name: 'AutoScout 24',
 };
 

--- a/src/theme/ms24/index.ts
+++ b/src/theme/ms24/index.ts
@@ -1,11 +1,12 @@
 import { extendTheme } from '@chakra-ui/react';
 
 import colors from './colors';
-import { basis } from '../shared';
+import { basis, spacing } from '../shared';
 
 export const theme = {
   ...basis,
   colors,
+  spacing,
   name: 'MotoScout 24',
 };
 

--- a/src/theme/shared/index.ts
+++ b/src/theme/shared/index.ts
@@ -1,2 +1,3 @@
 export { default as basis } from './basis';
 export { default as colors } from './colors';
+export { default as spacing } from './spacing';

--- a/src/theme/shared/spacing.ts
+++ b/src/theme/shared/spacing.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+const spacing = {
+  xs: '0.25rem',
+  sm: '0.5rem',
+  md: '0.75rem',
+  lg: '1rem',
+  xl: '1.25rem',
+  '2xl': '1.5rem',
+  '3xl': '2rem',
+  '4xl': '3rem',
+};
+
+export default spacing;

--- a/src/theme/stories/spacingShowcase.tsx
+++ b/src/theme/stories/spacingShowcase.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react';
+import { Box, Td, Tr, useTheme } from '@chakra-ui/react';
+
+type Props = {
+  name: string;
+};
+
+const SpacingShowCase: FC<Props> = ({ name }) => {
+  const theme = useTheme();
+  const unitRem = parseFloat(theme.spacing[name]);
+  const unitPixel = unitRem / 0.0625;
+  return (
+    <Tr border="1px" borderColor={theme.colors.gray[100]}>
+      <Td>{name}</Td>
+      <Td>{`${unitRem}rem`}</Td>
+      <Td>{`${unitPixel}px`}</Td>
+      <Td>
+        <Box bg={theme.colors.gray[200]} p={theme.spacing[name]}>
+          <Box bg={theme.colors.white} textAlign="center" width="auto">
+            {name}
+          </Box>
+        </Box>
+      </Td>
+    </Tr>
+  );
+};
+export default SpacingShowCase;

--- a/src/theme/stories/theme.stories.mdx
+++ b/src/theme/stories/theme.stories.mdx
@@ -51,7 +51,10 @@ import BorderRadiusShowcase from './borderRadiusShowcase.tsx';
   <Story name="spacing" args={{ theme: 'as24' }}>
     <TableContainer>
       <Table>
-        <TableCaption>The pixel column is ONLY a reference to the values in figma. The pixel values are NOT computed.</TableCaption>
+        <TableCaption>
+          The pixel column is ONLY a reference to the values in figma. The pixel
+          values are NOT computed.
+        </TableCaption>
         <Thead>
           <Tr>
             <Th>Name</Th>

--- a/src/theme/stories/theme.stories.mdx
+++ b/src/theme/stories/theme.stories.mdx
@@ -9,6 +9,7 @@ import {
 import {
   Flex,
   Table,
+  TableCaption,
   TableContainer,
   Tbody,
   Th,
@@ -50,6 +51,7 @@ import BorderRadiusShowcase from './borderRadiusShowcase.tsx';
   <Story name="spacing" args={{ theme: 'as24' }}>
     <TableContainer>
       <Table>
+        <TableCaption>The pixel column is ONLY a reference to the values in figma. The pixel values are NOT computed.</TableCaption>
         <Thead>
           <Tr>
             <Th>Name</Th>

--- a/src/theme/stories/theme.stories.mdx
+++ b/src/theme/stories/theme.stories.mdx
@@ -6,6 +6,9 @@ import {
   Story,
 } from '@storybook/addon-docs';
 
+import { Table, TableContainer, Tbody, Th, Thead, Tr } from '@chakra-ui/react';
+
+import SpacingShowcase from './spacingShowcase.tsx';
 import ColorShowcase from './colorShowcase.tsx';
 
 <Meta title="Theme" />
@@ -30,3 +33,32 @@ import ColorShowcase from './colorShowcase.tsx';
 </Canvas>
 
 <ArgsTable story="colors" />
+
+## Spacing Table
+
+<Canvas>
+  <Story name="spacing" args={{ theme: 'as24' }}>
+    <TableContainer>
+      <Table>
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Rem</Th>
+            <Th>Pixels</Th>
+            <Th>Example</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <SpacingShowcase name="xs" />
+          <SpacingShowcase name="sm" />
+          <SpacingShowcase name="md" />
+          <SpacingShowcase name="lg" />
+          <SpacingShowcase name="xl" />
+          <SpacingShowcase name="2xl" />
+          <SpacingShowcase name="3xl" />
+          <SpacingShowcase name="4xl" />
+        </Tbody>
+      </Table>
+    </TableContainer>
+  </Story>
+</Canvas>


### PR DESCRIPTION
References:
> Jira https://autoricardo.atlassian.net/browse/DM-169

> Figma https://www.figma.com/file/WmNmJ7jdB0Z7tOjj516nFB/AS24-Tokens?node-id=3%3A4

> Figma tokens https://github.com/smg-automotive/figma-tokens/blob/main/tokens.json

## Motivation and context

Setup of base theme SPACING tokens as defined in the design system.

## Take into consideration
* I found a mistake in the figma tokens json. I checked with Sergiu and he already fixed, now the key is `2xl` instead `xxl` and it is in sync with figma as well. 
* I was checking about the unit that we'll use in the spacing tokens case. And after checking with Sergiu we decided to go with `REM` for this case, for the font-size and line-height. If we use `PX` the values don't scale with browser font-size adjustments. Please let me know if I need to bring this topic into a discussion or if we are fine merging this tokens with the `REM` unit.

## Before

No base theme for the spacing tokens

## After

Base theme for spacing tokens 🔭


## Thank you 🍦

