### PR TITLE
feat: added new space token & reorder fontSize values

### DIFF
--- a/src/theme/shared/fontSizes.ts
+++ b/src/theme/shared/fontSizes.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 const fontSizes = {
-  '5xl': '4.75rem',
-  '4xl': '3.75rem',
-  '3xl': '3rem',
-  '2xl': '2.5rem',
-  xl: '2rem',
-  lg: '1.5rem',
-  md: '1.25rem',
-  base: '1rem',
-  sm: '0.875rem',
   xs: '0.75rem',
+  sm: '0.875rem',
+  base: '1rem',
+  md: '1.25rem',
+  lg: '1.5rem',
+  xl: '2rem',
+  '2xl': '2.5rem',
+  '3xl': '3rem',
+  '4xl': '3.75rem',
+  '5xl': '4.75rem',
 };
 export default fontSizes;

--- a/src/theme/shared/space.ts
+++ b/src/theme/shared/space.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 const space = {
+  xxs: '0.125rem',
   xs: '0.25rem',
   sm: '0.5rem',
   md: '0.75rem',

--- a/src/theme/stories/theme.stories.mdx
+++ b/src/theme/stories/theme.stories.mdx
@@ -167,7 +167,7 @@ import BorderRadiusShowcase from './borderRadiusShowcase.tsx';
   </Story>
 </Canvas>
 
-## Spacing Table
+## Spaces
 
 <Canvas>
   <Story name="space" args={{ theme: 'as24' }}>
@@ -186,6 +186,7 @@ import BorderRadiusShowcase from './borderRadiusShowcase.tsx';
           </Tr>
         </Thead>
         <Tbody>
+          <SpaceShowcase name="xxs" />
           <SpaceShowcase name="xs" />
           <SpaceShowcase name="sm" />
           <SpaceShowcase name="md" />


### PR DESCRIPTION
References:

figma: https://www.figma.com/file/WmNmJ7jdB0Z7tOjj516nFB/AS24-Tokens?node-id=3%3A4
figma-tokens: https://github.com/smg-automotive/figma-tokens/blob/main/tokens.json

## Motivation and context

After checking the button component with Sergiu we checked that we need a new space value `2px`. 

**Use case:**

![Screenshot 2022-05-31 at 14 04 30](https://user-images.githubusercontent.com/37380787/171168972-4ce3dff8-5e60-4e5d-bc18-b35052038b1e.png)


## Thank you 🌵
