### PR TITLE
BREAKING CHANGE: adjusted sizes & typography tokens

### DIFF
--- a/src/components/button/index.stories.mdx
+++ b/src/components/button/index.stories.mdx
@@ -28,7 +28,7 @@ export const Template = (args) => (
         defaultValue: 'primary',
       },
       size: {
-        options: ['md', 'lg', 'xl'],
+        options: ['md', 'lg'],
         control: { type: 'radio' },
         defaultValue: 'lg',
       },
@@ -45,7 +45,6 @@ export const Template = (args) => (
     <Box>
       <Button size="md">Medium</Button>
       <Button size="lg">Large</Button>
-      <Button size="xl">Extra Large</Button>
     </Box>
   </Story>
 </Canvas>

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -3,7 +3,7 @@ import { Button as ChakraButton } from '@chakra-ui/react';
 
 interface Props {
   variant?: 'primary';
-  size?: 'md' | 'lg' | 'xl';
+  size?: 'md' | 'lg';
   isDisabled?: boolean;
   onClick: (event: MouseEvent<HTMLElement>) => void;
   children: ReactNode;

--- a/src/themes/components/button.ts
+++ b/src/themes/components/button.ts
@@ -13,15 +13,11 @@ const baseStyle: SystemStyleObject = {
 const buttonSizes = {
   md: {
     height: sizes.md,
-    ...typography.heading5,
+    ...typography['button-sm'],
   },
   lg: {
     height: sizes.lg,
-    ...typography.heading4,
-  },
-  xl: {
-    height: sizes.xl,
-    ...typography.heading4,
+    ...typography.button,
   },
 };
 

--- a/src/themes/shared/sizes.ts
+++ b/src/themes/shared/sizes.ts
@@ -1,9 +1,7 @@
 export const sizes = {
-  xs: '1rem',
   sm: '1.5rem',
-  md: '2rem',
-  lg: '2.5rem',
-  xl: '3rem',
+  md: '2.25rem',
+  lg: '3rem',
   full: '100%',
   container: {
     sm: '640px',

--- a/src/themes/shared/typography.ts
+++ b/src/themes/shared/typography.ts
@@ -89,4 +89,16 @@ export const typography = {
     lineHeight: lineHeights.body,
     fontSize: fontSizes.xs,
   },
+  button: {
+    fontFamily: fonts.makeItSans,
+    fontWeight: fontWeights.bold,
+    lineHeight: lineHeights.body,
+    fontSize: fontSizes.base,
+  },
+  'button-sm': {
+    fontFamily: fonts.makeItSans,
+    fontWeight: fontWeights.bold,
+    lineHeight: lineHeights.body,
+    fontSize: fontSizes.sm,
+  },
 };


### PR DESCRIPTION
References:
[sizes-tokens in figma](https://www.figma.com/file/WmNmJ7jdB0Z7tOjj516nFB/AS24-Tokens?node-id=533%3A3)
[typography-token in figma](https://www.figma.com/file/WmNmJ7jdB0Z7tOjj516nFB/AS24-Tokens?node-id=25%3A93)
[Jira ticket]

## Motivation and context

1. After checking the button variations with Sergiu we found that we could remove one variation and unify and make more consistent our button component with ONLY two variations `md: 36px` and `lg: 48px`. Please be patience 🙏🏽 while we get our hands dirty we polish the work 🧼 and we make it more beautiful and perfect 🙌🏼

The following links on figma will be updated with the correct button size:
[ms24 button](https://www.figma.com/file/ZN4RxuKRVRHFEcN1xT00Kz/Components%3A-Web-MS24?node-id=2%3A860)
[as24 button](https://www.figma.com/file/CHU4fpMfXpiAW4qNFzi9y1/AS24-WebComponents?node-id=4%3A4226)
[lead-form](https://www.figma.com/file/f0LWQupJueW6KHBQujVGe4/Lead-Form-Page-(Working-Title)?node-id=2%3A58920)
[lead-form-templates](https://www.figma.com/file/f0LWQupJueW6KHBQujVGe4/Lead-Form-Page-(Working-Title)?node-id=97%3A62134)

2. After the discussion [Slack](https://automotivesmg.slack.com/archives/C03GK939L3V/p1655111982770689) I checked with Sergiu about the typography tokens and we introduce 2 more for the buttons. We were using `heading` for the text buttons and now we use the specific ones. We found some cases where we still need to use combinations with the partial fonts in future components. Therefore, we opted not to remove the exports for the partials of the typography (font, fontSize, fontWeight, lineHeight). We will first monitor the combination with the partials and the typography along the components, that process will give us a better view and the decision whether or not remove the partials exports. 

## Before

Sizes:

Typography:

<img width="294" alt="Screenshot 2022-06-16 at 07 18 52" src="https://user-images.githubusercontent.com/37380787/173996904-bb257adb-9a21-47fd-b171-5756f823ebeb.png">

Buttons: 

## After

Sizes:

<img width="1147" alt="Screenshot 2022-06-16 at 07 16 06" src="https://user-images.githubusercontent.com/37380787/173996573-e832489d-cdfb-4d0b-b0ff-1e6d6ed11686.png">

Typography:

<img width="316" alt="Screenshot 2022-06-16 at 07 17 05" src="https://user-images.githubusercontent.com/37380787/173996666-6cf9d27f-e3e6-4946-babf-2944d40f352f.png">

Buttons: 

<img width="248" alt="Screenshot 2022-06-16 at 07 17 28" src="https://user-images.githubusercontent.com/37380787/173996716-aad99cac-2f9d-458d-b1ab-624834f4fff0.png">

## How to test

The tokens work as before and the new button variations are applied.

## Thank you 🌵
