### PR TITLE
Refactor: reuse typography.body for link component

### DIFF
--- a/src/themes/components/link.ts
+++ b/src/themes/components/link.ts
@@ -2,10 +2,10 @@ import { ComponentMultiStyleConfig, SystemStyleObject } from '@chakra-ui/react';
 
 import { shared } from '../shared';
 
-const { fontSizes } = shared;
+const { typography } = shared;
 
 const linkBaseStyle: SystemStyleObject = {
-  fontSize: fontSizes.base,
+  ...typography.body,
   color: 'blue.700',
   verticalAlign: 'middle',
   _hover: {


### PR DESCRIPTION
## Motivation and context

- Reuse the pre-defined `typography` token as much as possible.
- Apply the `typography.body` for Link component

## How to test

- There's no new visual change affected in this PR
