### PR TITLE
Stack

### DIFF
--- a/src/components/stack/index.stories.mdx
+++ b/src/components/stack/index.stories.mdx
@@ -1,0 +1,91 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Box } from '@chakra-ui/react';
+
+import Stack from './index.tsx';
+
+<Meta
+  title="Components/Layout/Stack"
+  component={Stack}
+  parameters={{
+    controls: {
+      sort: 'alpha',
+    },
+  }}
+  args={{
+    align: 'center',
+    direction: 'row',
+    spacing: 'md',
+    wrap: true,
+  }}
+  argTypes={{
+    align: {
+      options: ['start', 'center', 'end'],
+      control: { type: 'select' },
+    },
+    direction: {
+      options: ['row', 'column'],
+      control: { type: 'select' },
+    },
+    justify: {
+      options: [
+        'left',
+        'space-around',
+        'space-between',
+        'space-evenly',
+        'center',
+        'right',
+      ],
+      control: { type: 'select' },
+    },
+    spacing: {
+      options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
+      control: { type: 'select' },
+    },
+  }}
+/>
+
+export const Template = (args) => {
+  return (
+    <Stack {...args}>
+      <Box w="40px" h="40px" bg="blue.100">
+        1
+      </Box>
+      <Box w="50px" h="50px" bg="green.100">
+        2
+      </Box>
+      <Box w="60px" h="60px" bg="orange.100">
+        3
+      </Box>
+    </Stack>
+  );
+};
+
+# Stack
+
+## Overview
+
+<Canvas>
+  <Story name="Overview">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Overview" />
+
+## Responsive
+
+Default `col` direction switches to `row` on `md` viewport.
+
+<Canvas>
+  <Story
+    name="Responsive"
+    args={{ direction: { xs: 'column', md: 'row' } }}
+    argTypes={{
+      direction: {
+        table: {
+          disable: true,
+        },
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/stack/index.stories.mdx
+++ b/src/components/stack/index.stories.mdx
@@ -28,12 +28,12 @@ import Stack from './index.tsx';
     },
     justify: {
       options: [
-        'left',
+        'start',
         'space-around',
         'space-between',
         'space-evenly',
         'center',
-        'right',
+        'end',
       ],
       control: { type: 'select' },
     },

--- a/src/components/stack/index.tsx
+++ b/src/components/stack/index.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react';
+import { Stack as ChakraStack, StackProps } from '@chakra-ui/react';
+
+type Props = Pick<
+  StackProps,
+  'align' | 'children' | 'direction' | 'justify' | 'spacing' | 'wrap'
+>;
+
+const Stack: FC<Props> = ({ children, ...rest }) => (
+  <ChakraStack {...rest}>{children}</ChakraStack>
+);
+
+export default Stack;


### PR DESCRIPTION
## Motivation and context

Adds the `stack` component.

Since the new component is a simple wrapper on top `chakra-ui` stack that whitelists props tests were skipped.

## Before

No stack

## After

Habemus `stack`

<img width="1026" alt="Screenshot 2022-07-13 at 11 22 23" src="https://user-images.githubusercontent.com/144707/178700334-96c99abd-b4c9-4a26-85b5-3c537307cf80.png">
<img width="1025" alt="Screenshot 2022-07-13 at 11 22 15" src="https://user-images.githubusercontent.com/144707/178700344-5a2c848e-abd8-4360-94a4-eb3cfedd0fbe.png">



## How to test

Because we don't have branch deployments yet, running storybook locally is needed to test.