### PR TITLE
feat: release Stack component & export FormControl

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,4 +3,5 @@ export { default as Button } from './button';
 export { default as Link } from './link';
 export { default as Input } from './input';
 export { default as Checkbox } from './checkbox';
+export { default as Stack } from './stack';
 export * from './icons';


### PR DESCRIPTION
## Motivation and context

I missed exporting `stack` components from the package 🤦🏻  `formControl` was also not exported 🤦🏻 🤦🏻 
Also because I merged via VScode the commit wasn't semantic so the package wasn't released 🤦🏻 🤦🏻 🤦🏻 

## Before

Stack & FormControl were there but not released

## After

Stack & FormControl are released and importable

