### PR TITLE
fix: export FormControl

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,9 @@
-export { default as ThemeProvider } from './themeProvider';
 export { default as Button } from './button';
-export { default as Link } from './link';
-export { default as Input } from './input';
 export { default as Checkbox } from './checkbox';
+export { default as FormControl } from './formControl';
+export { default as Input } from './input';
+export { default as Link } from './link';
 export { default as Stack } from './stack';
+export { default as ThemeProvider } from './themeProvider';
+
 export * from './icons';


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

`FormControl` component wasn't exported from the package

I also re-arranged the exports in the index to make this easier to spot and control