### PR TITLE
feat: ArticleTeaser component

### DIFF
--- a/src/components/articleTeaser/__tests__/Index.Test.tsx
+++ b/src/components/articleTeaser/__tests__/Index.Test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ArticleTeaser from '..';
+
+const renderWrapper = ({
+  title = 'title',
+  text = 'text',
+  imageUrl = 'http://img.com',
+  url = 'http://link.com',
+} = {}) =>
+  render(
+    <ArticleTeaser title={title} text={text} imageUrl={imageUrl} url={url} />
+  );
+
+describe('ArticleTeaser', () => {
+  it('renders the title', () => {
+    const title = 'I am title';
+    renderWrapper({ title });
+
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+
+  it('renders the text', () => {
+    const text = 'I am a very long teaser text';
+    renderWrapper({ text });
+
+    expect(screen.getByText(text)).toBeInTheDocument();
+  });
+
+  it('renders the image', () => {
+    const imageUrl = 'https://placeholder.com/800x600';
+    renderWrapper({ imageUrl });
+
+    expect(screen.getByRole('img')).toHaveAttribute('src', imageUrl);
+  });
+
+  it('links to the article', () => {
+    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    renderWrapper({ url });
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', url);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/src/components/articleTeaser/index.stories.mdx
+++ b/src/components/articleTeaser/index.stories.mdx
@@ -1,0 +1,54 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+import { Box } from '@chakra-ui/react';
+
+import ArticleTeaser from './index.tsx';
+
+<Meta
+  title="Patterns/Data display/Article Teaser"
+  component={ArticleTeaser}
+  args={{
+    nativeImageSize: '320x320',
+    title: 'Placeholder.com',
+    text: 'A very cool service that provides placeholder images. You can learn more about the options and usage here.',
+    url: 'https://placeholder.com',
+    maxImgW: '4xl',
+  }}
+  argTypes={{
+    maxImgW: {
+      options: ['xl', '2xl', '3xl', '4xl', '5xl', '6xl'],
+      control: 'select',
+    },
+  }}
+/>
+
+export const Template = ({ nativeImageSize, ...args }) => (
+  <Box maxW={{ xs: '100%', lg: '600px' }}>
+    <ArticleTeaser
+      {...args}
+      imageUrl={`https://via.placeholder.com/${nativeImageSize}`}
+    />
+  </Box>
+);
+
+# ArticleTeaser
+
+## Overview
+
+<Canvas>
+  <Story name="Overview">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Overview" />
+
+## Responsive
+
+Bigger image on mobile viewport.
+
+<Canvas>
+  <Story name="Responsive" args={{ maxImgW: { sm: 'full', md: '3xl' } }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Responsive" />

--- a/src/components/articleTeaser/index.tsx
+++ b/src/components/articleTeaser/index.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from 'react';
+import { chakra, ResponsiveValue, useMultiStyleConfig } from '@chakra-ui/react';
+
+import Stack from '../stack';
+import { Sizes } from '../../themes';
+
+type Props = {
+  title: string;
+  text: string;
+  imageUrl: string;
+  url: string;
+  maxImgW?: ResponsiveValue<Sizes>;
+};
+
+const ArticleTeaser: FC<Props> = ({
+  title,
+  text,
+  imageUrl,
+  url,
+  maxImgW = '4xl',
+}) => {
+  const styles = useMultiStyleConfig('ArticleTeaser');
+
+  return (
+    <article>
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        <Stack
+          direction={{
+            xs: 'column',
+            md: 'row',
+          }}
+          spacing={{ md: 'lg' }}
+          align="center"
+        >
+          <chakra.img maxW={maxImgW} src={imageUrl} />
+          <Stack direction="column" spacing="sm">
+            <chakra.h2 __css={styles.title}>{title}</chakra.h2>
+            <chakra.span __css={styles.text}>{text}</chakra.span>
+          </Stack>
+        </Stack>
+      </a>
+    </article>
+  );
+};
+
+export default ArticleTeaser;

--- a/src/components/articleTeaser/index.tsx
+++ b/src/components/articleTeaser/index.tsx
@@ -27,9 +27,9 @@ const ArticleTeaser: FC<Props> = ({
         <Stack
           direction={{
             xs: 'column',
-            md: 'row',
+            lg: 'row',
           }}
-          spacing={{ md: 'lg' }}
+          spacing={{ lg: 'lg' }}
           align="center"
         >
           <chakra.img maxW={maxImgW} src={imageUrl} />

--- a/src/components/articleTeaser/index.tsx
+++ b/src/components/articleTeaser/index.tsx
@@ -29,7 +29,7 @@ const ArticleTeaser: FC<Props> = ({
             xs: 'column',
             lg: 'row',
           }}
-          spacing={{ lg: 'lg' }}
+          spacing="lg"
           align="center"
         >
           <chakra.img maxW={maxImgW} src={imageUrl} />

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as ArticleTeaser } from './articleTeaser';
 export { default as Button } from './button';
 export { default as Checkbox } from './checkbox';
 export { default as FormControl } from './formControl';

--- a/src/themes/components/articleTeaser.ts
+++ b/src/themes/components/articleTeaser.ts
@@ -1,0 +1,21 @@
+import { ComponentMultiStyleConfig, SystemStyleObject } from '@chakra-ui/react';
+
+const title: SystemStyleObject = {
+  textStyle: 'heading3',
+  color: 'blue.700',
+};
+const image: SystemStyleObject = {};
+const text: SystemStyleObject = {
+  textStyle: 'base',
+};
+
+const ArticleTeaser: ComponentMultiStyleConfig = {
+  parts: ['image', 'title', 'text'],
+  baseStyle: {
+    image,
+    title,
+    text,
+  },
+};
+
+export default ArticleTeaser;

--- a/src/themes/components/articleTeaser.ts
+++ b/src/themes/components/articleTeaser.ts
@@ -4,15 +4,13 @@ const title: SystemStyleObject = {
   textStyle: 'heading3',
   color: 'blue.700',
 };
-const image: SystemStyleObject = {};
 const text: SystemStyleObject = {
   textStyle: 'base',
 };
 
 const ArticleTeaser: ComponentMultiStyleConfig = {
-  parts: ['image', 'title', 'text'],
+  parts: ['title', 'text'],
   baseStyle: {
-    image,
     title,
     text,
   },

--- a/src/themes/components/articleTeaser.ts
+++ b/src/themes/components/articleTeaser.ts
@@ -6,6 +6,7 @@ const title: SystemStyleObject = {
 };
 const text: SystemStyleObject = {
   textStyle: 'base',
+  color: 'gray.900',
 };
 
 const ArticleTeaser: ComponentMultiStyleConfig = {

--- a/src/themes/components/articleTeaser.ts
+++ b/src/themes/components/articleTeaser.ts
@@ -5,7 +5,7 @@ const title: SystemStyleObject = {
   color: 'blue.700',
 };
 const text: SystemStyleObject = {
-  textStyle: 'base',
+  textStyle: 'body',
   color: 'gray.900',
 };
 

--- a/src/themes/components/index.ts
+++ b/src/themes/components/index.ts
@@ -8,8 +8,10 @@ import FormError from './formError';
 import Form from './form';
 import Checkbox from './checkbox';
 import Button from './button';
+import ArticleTeaser from './articleTeaser';
 
 export const components = {
+  ArticleTeaser,
   Button,
   Checkbox,
   Form,

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -11,3 +11,4 @@ export const motoScoutChakraTheme = extendTheme(
 export const autoScoutChakraTheme = extendTheme(
   Object.assign({}, autoScout24Theme, { name: 'AutoScout 24 with Chakra' })
 );
+export { Sizes } from './shared';

--- a/src/themes/shared/index.ts
+++ b/src/themes/shared/index.ts
@@ -29,3 +29,4 @@ export const shared = {
   fontSizes,
   fonts,
 };
+export { Sizes } from './sizes';

--- a/src/themes/shared/sizes.ts
+++ b/src/themes/shared/sizes.ts
@@ -1,9 +1,15 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 export const sizes = {
   xs: '1rem',
   sm: '1.5rem',
   md: '2.25rem',
   lg: '3rem',
-  xl: '5rem',
+  xl: '4rem',
+  '2xl': '6rem',
+  '3xl': '8rem',
+  '4xl': '10rem',
+  '5xl': '15rem',
+  '6xl': '20rem',
   full: '100%',
   container: {
     sm: '640px',

--- a/src/themes/shared/sizes.ts
+++ b/src/themes/shared/sizes.ts
@@ -18,3 +18,6 @@ export const sizes = {
     xl: '1280px',
   },
 };
+
+const sizeNames = Object.keys(sizes) as Array<keyof typeof sizes>;
+export type Sizes = Exclude<typeof sizeNames[number], 'container'>;


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-362

## Motivation and context

Implements `ArticleTeaser` component

## Before

No article teaser 😱 

## After

<img width="760" alt="Screenshot 2022-07-27 at 14 41 05" src="https://user-images.githubusercontent.com/144707/181249185-4c679e30-627c-4d46-9ab7-22a632ef491a.png">

## How to test

Play around with the article teaser in storybook

## Notes
- we want to give flexibility on image sizing, but we want to have some control of the allowed sizes, hence new `size` values
- existing designs will be adapted to use provided values
- the entire teaser is a link, this was clarified with Enrique
- changed the spacing between the image and the content to be the same on mobile as on desktop. Confirmed with Enrique