### PR TITLE
Add utitily components

### DIFF
--- a/src/components/center/index.stories.mdx
+++ b/src/components/center/index.stories.mdx
@@ -1,0 +1,20 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Box } from '@chakra-ui/react';
+
+import Center from './index.tsx';
+
+<Meta title="Layout/Center" component={Center} />
+
+export const Template = () => {
+  return <Center>I am centerd!</Center>;
+};
+
+# Grid
+
+## Overview
+
+<Canvas>
+  <Story name="Overview">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Overview" />

--- a/src/components/center/index.stories.mdx
+++ b/src/components/center/index.stories.mdx
@@ -9,7 +9,7 @@ export const Template = () => {
   return <Center>I am centerd!</Center>;
 };
 
-# Grid
+# Center
 
 ## Overview
 

--- a/src/components/center/index.tsx
+++ b/src/components/center/index.tsx
@@ -1,0 +1,9 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { Center as ChakraCenter } from '@chakra-ui/react';
+
+const Center: FC<PropsWithChildren> = ({ children }) => (
+  <ChakraCenter>{children}</ChakraCenter>
+);
+
+export default Center;
+export { PropsWithChildren as CenterProps };

--- a/src/components/fullHeight/index.stories.mdx
+++ b/src/components/fullHeight/index.stories.mdx
@@ -1,0 +1,26 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Box } from '@chakra-ui/react';
+
+import FullHeight from './index.tsx';
+
+<Meta title="Layout/FullHeight" component={FullHeight} />
+
+export const Template = () => {
+  return (
+    <FullHeight>
+      <Box backgroundColor="brand.primary" minHeight="100vh">
+        I am full height container
+      </Box>
+    </FullHeight>
+  );
+};
+
+# Grid
+
+## Overview
+
+<Canvas>
+  <Story name="Overview">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Overview" />

--- a/src/components/fullHeight/index.stories.mdx
+++ b/src/components/fullHeight/index.stories.mdx
@@ -15,7 +15,7 @@ export const Template = () => {
   );
 };
 
-# Grid
+# Full Height
 
 ## Overview
 

--- a/src/components/fullHeight/index.tsx
+++ b/src/components/fullHeight/index.tsx
@@ -1,0 +1,9 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { Box } from '@chakra-ui/react';
+
+const FullHeight: FC<PropsWithChildren> = ({ children }) => (
+  <Box minHeight="100vh">{children}</Box>
+);
+
+export default FullHeight;
+export { PropsWithChildren as FullHeightProps };

--- a/src/components/grid/index.tsx
+++ b/src/components/grid/index.tsx
@@ -3,7 +3,7 @@ import { SimpleGrid, SimpleGridProps } from '@chakra-ui/react';
 
 type Props = Pick<
   SimpleGridProps,
-  'minChildWidth' | 'columns' | 'spacing' | 'spacingX' | 'spacingY'
+  'minChildWidth' | 'columns' | 'spacing' | 'spacingX' | 'spacingY' | 'children'
 >;
 
 const Grid: FC<Props> = (props) => <SimpleGrid {...props} />;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,9 @@
 export { default as ArticleTeaser } from './articleTeaser';
 export { default as Button } from './button';
+export { default as Center } from './center';
 export { default as Checkbox } from './checkbox';
 export { default as FormControl } from './formControl';
+export { default as FullHeight } from './fullHeight';
 export { default as Grid } from './grid';
 export { default as Input } from './input';
 export { default as Link } from './link';
@@ -11,7 +13,5 @@ export { default as Stack } from './stack';
 export { default as Textarea } from './textarea';
 export { default as ThemeProvider } from './themeProvider';
 export { default as VehicleReference } from './vehicleReference';
-export { default as Center } from './center';
-export { default as FullHeight } from './fullHeight';
 
 export * from './icons';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,5 +11,7 @@ export { default as Stack } from './stack';
 export { default as Textarea } from './textarea';
 export { default as ThemeProvider } from './themeProvider';
 export { default as VehicleReference } from './vehicleReference';
+export { default as Center } from './center';
+export { default as FullHeight } from './fullHeight';
 
 export * from './icons';


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/FE-13

## Motivation and context

As preparation for adding the components package to the next example project 

- Extracts children for gird component props
- Exports centre chakra component (centres an element)
- Exports full height component ensuring the content uses the available height at minimum

## After

![Screenshot 2022-08-02 at 16 02 04](https://user-images.githubusercontent.com/3371760/182394258-ac004c55-fb9e-4100-9dbb-84d2a04ba7b8.png)
![Screenshot 2022-08-02 at 16 01 58](https://user-images.githubusercontent.com/3371760/182394264-99b306e7-fa7d-4705-9c59-f83af329c1bb.png)


## How to test

Check the branch deployment or the integration in the next example project https://github.com/smg-automotive/next-example/pull/26 