### PR TITLE
feat: create new story for base grid and make it full height

### DIFF
--- a/src/components/fullHeight/index.stories.mdx
+++ b/src/components/fullHeight/index.stories.mdx
@@ -3,7 +3,13 @@ import { Box } from '@chakra-ui/react';
 
 import FullHeight from './index.tsx';
 
-<Meta title="Layout/FullHeight" component={FullHeight} />
+<Meta
+  title="Layout/FullHeight"
+  component={FullHeight}
+  parameters={{
+    layout: 'fullscreen',
+  }}
+/>
 
 export const Template = () => {
   return (

--- a/src/components/fullHeight/index.tsx
+++ b/src/components/fullHeight/index.tsx
@@ -2,7 +2,9 @@ import React, { FC, PropsWithChildren } from 'react';
 import { Box } from '@chakra-ui/react';
 
 const FullHeight: FC<PropsWithChildren> = ({ children }) => (
-  <Box minHeight="100vh">{children}</Box>
+  <Box minHeight="100vh" height="100vh">
+    {children}
+  </Box>
 );
 
 export default FullHeight;

--- a/src/components/layout/BaseGrid.stories.mdx
+++ b/src/components/layout/BaseGrid.stories.mdx
@@ -1,0 +1,44 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Box, GridItem } from '@chakra-ui/react';
+
+import BaseGrid from './BaseGrid.tsx';
+import { FullHeight } from '../index';
+
+<Meta
+  title="Layout/Pages/Base grid"
+  component={BaseGrid}
+  parameters={{
+    layout: 'fullscreen',
+  }}
+/>
+
+export const Template = () => (
+  <FullHeight>
+    <Box bg="green.100" height="full">
+      <BaseGrid
+        gridTemplateRows={{
+          xs: 'repeat(12, 1fr)',
+          lg: '1fr',
+        }}
+        height="full"
+        bg="red.200"
+      >
+        {new Array(12).fill('column').map((item, index) => (
+          <GridItem key={index}>
+            <Box bg="blue.200" h="100%">
+              {index + 1}
+            </Box>
+          </GridItem>
+        ))}
+      </BaseGrid>
+    </Box>
+  </FullHeight>
+);
+
+# Base grid
+
+<Canvas>
+  <Story name="Base grid for XL layouts">
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/layout/BaseGrid.stories.mdx
+++ b/src/components/layout/BaseGrid.stories.mdx
@@ -38,7 +38,5 @@ export const Template = () => (
 # Base grid
 
 <Canvas>
-  <Story name="Base grid for XL layouts">
-    {Template.bind({})}
-  </Story>
+  <Story name="Base grid for XL layouts">{Template.bind({})}</Story>
 </Canvas>

--- a/src/components/layout/BaseGrid.tsx
+++ b/src/components/layout/BaseGrid.tsx
@@ -10,10 +10,11 @@ const BaseGridLayout: FC<PropsWithChildren<GridProps>> = (props) => {
   const { children, ...gridProps } = props;
 
   return (
-    <Center>
+    <Center height="full">
       <Container
         as="main"
         width="full"
+        height="full"
         maxWidth="container.xl"
         paddingY={{ xs: 'xl', lg: '2xl' }}
         paddingX={{ xs: 'md', lg: '4xl' }}

--- a/src/components/layout/WithVehicleReference.stories.mdx
+++ b/src/components/layout/WithVehicleReference.stories.mdx
@@ -3,6 +3,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import LayoutWithVehicleReference from './WithVehicleReference.tsx';
 import Stack from '../stack';
 import Input from '../input';
+import FormControl from '../formControl';
 
 <Meta
   title="Layout/Pages/Layout with vehicle reference"
@@ -18,9 +19,15 @@ import Input from '../input';
     },
     children: (
       <Stack spacing="md">
-        <Input name="name" placeholder="Name" />
-        <Input name="email" placeholder="E-Mail address" />
-        <Input name="phone" placeholder="Phone number" />
+        <FormControl id="name" label="Name">
+          <Input name="name" size="lg" />
+        </FormControl>
+        <FormControl id="email" label="E-Mail address">
+          <Input name="email" size="lg" />
+        </FormControl>
+        <FormControl id="phone" label="Phone number">
+          <Input name="phone" size="lg" />
+        </FormControl>
       </Stack>
     ),
   }}
@@ -30,6 +37,9 @@ import Input from '../input';
         disable: true,
       },
     },
+  }}
+  parameters={{
+    layout: 'fullscreen',
   }}
 />
 


### PR DESCRIPTION
References "Meeting discussion"

## Motivation and context

- Storybook adds 16px padding by default which makes it difficult to grasp the intended design for the page layouts
- Design wants to see the base grid

## Before

no story for base grid and default padding

## After

story for base grid and no default padding

## How to test

1. check the layouts under "Layouts / Pages"