### PR TITLE
fix: button props

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,15 +1,15 @@
-import React, { FC, MouseEvent, ReactNode } from 'react';
-import { Button as ChakraButton } from '@chakra-ui/react';
+import React, { FC } from 'react';
+import {
+  Button as ChakraButton,
+  ButtonProps as ChakraButtonProps,
+} from '@chakra-ui/react';
 
-interface Props {
+export type ButtonProps = {
   variant?: 'primary' | 'secondary';
   size?: 'md' | 'lg';
-  isDisabled?: boolean;
-  onClick: (event: MouseEvent<HTMLElement>) => void;
-  children: ReactNode;
-}
+} & Pick<ChakraButtonProps, 'isDisabled' | 'onClick' | 'children'>;
 
-const Button: FC<Props> = ({
+const Button: FC<ButtonProps> = ({
   variant = 'primary',
   size = 'lg',
   isDisabled = false,


### PR DESCRIPTION
References -

## Motivation and context

The button exposes different props for the onChnage handler than the chakra component which yields to issue when passing trough props from other components that use the same definition as the chakra component
