### PR TITLE
fix: use absolute url for fonts

### DIFF
--- a/src/styles/Fonts.tsx
+++ b/src/styles/Fonts.tsx
@@ -8,17 +8,17 @@ export const Fonts = () => (
         font-family: 'Make It Sans';
         font-style: regular;
         font-weight: 400;
-        src: url('../assets/fonts/MakeItSans-Regular.woff') format('woff'),
-            url('../assets/fonts/MakeItSans-Regular.woff2') format('woff2'),           
-            url('../assets/fonts/MakeItSans-Regular.otf') format('otf');
+        src: url('/assets/fonts/MakeItSans-Regular.woff') format('woff'),
+            url('/assets/fonts/MakeItSans-Regular.woff2') format('woff2'),
+            url('/assets/fonts/MakeItSans-Regular.otf') format('otf');
       }
       @font-face {
         font-family: 'Make It Sans';
         font-style: bold;
         font-weight: 700;
-        src: url('../assets/fonts/MakeItSans-Bold.woff') format('woff'),
-            url('../assets/fonts/MakeItSans-Bold.woff2') format('woff2'),           
-            url('../assets/fonts/MakeItSans-Bold.otf') format('otf');
+        src: url('/assets/fonts/MakeItSans-Bold.woff') format('woff'),
+            url('/assets/fonts/MakeItSans-Bold.woff2') format('woff2'),
+            url('/assets/fonts/MakeItSans-Bold.otf') format('otf');
       }
     `}
   />


### PR DESCRIPTION
Relative URL was used for font loading which resulted in 404s when accessing nested paths.