### PR TITLE
feat: expose breakpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export { motoScout24Theme, autoScout24Theme } from './themes';
 export * from './components';
 export * from './utilities';
+
+export { breakpoints } from './themes';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-export { motoScout24Theme, autoScout24Theme } from './themes';
+export { motoScout24Theme, autoScout24Theme, breakpoints } from './themes';
 export * from './components';
 export * from './utilities';
-
-export { breakpoints } from './themes';

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -12,4 +12,4 @@ export const motoScoutChakraTheme = extendTheme(
 export const autoScoutChakraTheme = extendTheme(
   Object.assign({}, autoScout24Theme, { name: 'AutoScout 24 with Chakra' })
 );
-export { Sizes, shared } from './shared';
+export { Sizes, shared, breakpoints } from './shared';

--- a/src/themes/shared/breakpoints.ts
+++ b/src/themes/shared/breakpoints.ts
@@ -1,4 +1,4 @@
-export const breakpoints = {
+export const emBreakpoints = {
   base: '0em',
   xs: '23.4375em',
   sm: '30em',
@@ -6,3 +6,28 @@ export const breakpoints = {
   lg: '64em',
   xl: '80em',
 };
+
+type BreakpointName = keyof typeof emBreakpoints;
+
+export const pxBreakpoints = Object.fromEntries(
+  Object.entries(emBreakpoints).map(([name, emValue]) => [
+    name,
+    `${parseInt(emValue, 10) * 16}px`,
+  ])
+) as Record<BreakpointName, string>;
+
+export const breakpoints = Object.fromEntries(
+  Object.keys(emBreakpoints).map((name) => [
+    name,
+    {
+      em: parseInt(emBreakpoints[name as BreakpointName], 10),
+      px: parseInt(pxBreakpoints[name as BreakpointName], 10),
+    },
+  ])
+) as Record<
+  BreakpointName,
+  {
+    em: number;
+    px: number;
+  }
+>;

--- a/src/themes/shared/index.ts
+++ b/src/themes/shared/index.ts
@@ -8,7 +8,7 @@ import { fontWeights } from './fontWeights';
 import { fontSizes } from './fontSizes';
 import { fonts } from './fonts';
 import { colors } from './colors';
-import { breakpoints } from './breakpoints';
+import { emBreakpoints } from './breakpoints';
 import { borders } from './borders';
 import { radii } from './borderRadius';
 import { basis } from './basis';
@@ -16,7 +16,7 @@ import { basis } from './basis';
 export const shared = {
   ...basis,
   colors,
-  breakpoints,
+  breakpoints: emBreakpoints,
   textStyles,
   space,
   sizes,
@@ -30,3 +30,4 @@ export const shared = {
   fonts,
 };
 export { Sizes } from './sizes';
+export { breakpoints } from './breakpoints';


### PR DESCRIPTION
## Motivation and context

Exports `breakpoint` values in `em` and `px`.
In some cases (i.e. when configuring and using `next/image`) it is useful to be able to reference breakpoints directly. This allows us to:
-  configure [`device sizes`](https://nextjs.org/docs/api-reference/next/image#device-sizes)
- reference breakpoints in [`sizes` prop](https://nextjs.org/docs/api-reference/next/image#sizes) to be able to tweak the image source sets
without the need of reaching for the whole `theme` object and recalculation
