### PR TITLE
chore: fix storybook breakpoints switching

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -54,7 +54,7 @@ const customViewports = Object.entries(breakpoints).reduce(
     acc[key] = {
       name: key,
       styles: {
-        width: value,
+        width: `${value.em}em`,
         height: '100%',
       },
     };


### PR DESCRIPTION
#201 changed how breakpoints are exported. This broke the storybook configuration that relied on private export.