### PR TITLE
fix: breakpoint & word-break

### DIFF
--- a/src/components/articleTeaser/index.stories.mdx
+++ b/src/components/articleTeaser/index.stories.mdx
@@ -46,7 +46,7 @@ export const Template = ({ nativeImageSize, ...args }) => (
 Bigger image on mobile viewport.
 
 <Canvas>
-  <Story name="Responsive" args={{ maxImgW: { xxs: 'full', md: '3xl' } }}>
+  <Story name="Responsive" args={{ maxImgW: { xxs: 'full', sm: '3xl' } }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/articleTeaser/index.stories.mdx
+++ b/src/components/articleTeaser/index.stories.mdx
@@ -23,7 +23,7 @@ import ArticleTeaser from './index.tsx';
 />
 
 export const Template = ({ nativeImageSize, ...args }) => (
-  <Box maxW={{ xxs: '100%', md: '600px' }}>
+  <Box maxW={{ '2xs': '100%', md: '600px' }}>
     <ArticleTeaser
       {...args}
       imageUrl={`https://via.placeholder.com/${nativeImageSize}`}
@@ -46,7 +46,7 @@ export const Template = ({ nativeImageSize, ...args }) => (
 Bigger image on mobile viewport.
 
 <Canvas>
-  <Story name="Responsive" args={{ maxImgW: { xxs: 'full', sm: '3xl' } }}>
+  <Story name="Responsive" args={{ maxImgW: { '2xs': 'full', sm: '3xl' } }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/articleTeaser/index.stories.mdx
+++ b/src/components/articleTeaser/index.stories.mdx
@@ -23,7 +23,7 @@ import ArticleTeaser from './index.tsx';
 />
 
 export const Template = ({ nativeImageSize, ...args }) => (
-  <Box maxW={{ xs: '100%', lg: '600px' }}>
+  <Box maxW={{ xxs: '100%', md: '600px' }}>
     <ArticleTeaser
       {...args}
       imageUrl={`https://via.placeholder.com/${nativeImageSize}`}
@@ -46,7 +46,7 @@ export const Template = ({ nativeImageSize, ...args }) => (
 Bigger image on mobile viewport.
 
 <Canvas>
-  <Story name="Responsive" args={{ maxImgW: { sm: 'full', md: '3xl' } }}>
+  <Story name="Responsive" args={{ maxImgW: { xxs: 'full', md: '3xl' } }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/articleTeaser/index.tsx
+++ b/src/components/articleTeaser/index.tsx
@@ -26,8 +26,8 @@ const ArticleTeaser: FC<Props> = ({
       <a href={url} target="_blank" rel="noopener noreferrer">
         <Stack
           direction={{
-            xs: 'column',
-            lg: 'row',
+            xxs: 'column',
+            md: 'row',
           }}
           spacing="lg"
           align="center"

--- a/src/components/articleTeaser/index.tsx
+++ b/src/components/articleTeaser/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { FC } from 'react';
 import { chakra, ResponsiveValue, useMultiStyleConfig } from '@chakra-ui/react';
 
@@ -26,7 +27,7 @@ const ArticleTeaser: FC<Props> = ({
       <a href={url} target="_blank" rel="noopener noreferrer">
         <Stack
           direction={{
-            xxs: 'column',
+            '2xs': 'column',
             md: 'row',
           }}
           spacing="lg"

--- a/src/components/grid/index.stories.mdx
+++ b/src/components/grid/index.stories.mdx
@@ -77,10 +77,10 @@ export const Template = ({ maxW, ...args }) => {
 
 ## Responsive
 
-2 columns on `xxs` 3 on `sm`. The same approach can be taken for other props.
+2 columns on `2xs` 3 on `sm`. The same approach can be taken for other props.
 
 <Canvas>
-  <Story name="Responsive" args={{ columns: { xxs: 2, sm: 3 } }}>
+  <Story name="Responsive" args={{ columns: { '2xs': 2, sm: 3 } }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/grid/index.stories.mdx
+++ b/src/components/grid/index.stories.mdx
@@ -77,10 +77,10 @@ export const Template = ({ maxW, ...args }) => {
 
 ## Responsive
 
-2 columns on `xs` 3 on `md`. The same approach can be taken for other props.
+2 columns on `xxs` 3 on `sm`. The same approach can be taken for other props.
 
 <Canvas>
-  <Story name="Responsive" args={{ columns: { xs: 2, md: 3 } }}>
+  <Story name="Responsive" args={{ columns: { xxs: 2, sm: 3 } }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/layout/BaseGrid.stories.mdx
+++ b/src/components/layout/BaseGrid.stories.mdx
@@ -17,8 +17,8 @@ export const Template = () => (
     <Box bg="green.100" height="full">
       <BaseGrid
         gridTemplateRows={{
-          xs: 'repeat(12, 1fr)',
-          lg: '1fr',
+          xxs: 'repeat(12, 1fr)',
+          md: '1fr',
         }}
         height="full"
         bg="red.200"

--- a/src/components/layout/BaseGrid.stories.mdx
+++ b/src/components/layout/BaseGrid.stories.mdx
@@ -17,7 +17,7 @@ export const Template = () => (
     <Box bg="green.100" height="full">
       <BaseGrid
         gridTemplateRows={{
-          xxs: 'repeat(12, 1fr)',
+          '2xs': 'repeat(12, 1fr)',
           md: '1fr',
         }}
         height="full"

--- a/src/components/layout/BaseGrid.tsx
+++ b/src/components/layout/BaseGrid.tsx
@@ -16,11 +16,11 @@ const BaseGridLayout: FC<PropsWithChildren<GridProps>> = (props) => {
         width="full"
         height="full"
         maxWidth="container.xl"
-        paddingY={{ xs: 'md', lg: '2xl' }}
-        paddingX={{ xs: 'md', lg: '4xl' }}
+        paddingY={{ xxs: 'md', md: '2xl' }}
+        paddingX={{ xxs: 'md', md: '4xl' }}
       >
         <Grid
-          gridTemplateColumns={{ xs: '1fr', lg: 'repeat(12, 1fr)' }}
+          gridTemplateColumns={{ xxs: '1fr', md: 'repeat(12, 1fr)' }}
           gap="lg"
           {...gridProps}
         >

--- a/src/components/layout/BaseGrid.tsx
+++ b/src/components/layout/BaseGrid.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { FC, PropsWithChildren } from 'react';
 
 import { Center, Container, Grid, GridProps } from '@chakra-ui/react';
@@ -16,11 +17,11 @@ const BaseGridLayout: FC<PropsWithChildren<GridProps>> = (props) => {
         width="full"
         height="full"
         maxWidth="container.xl"
-        paddingY={{ xxs: 'md', md: '2xl' }}
-        paddingX={{ xxs: 'md', md: '4xl' }}
+        paddingY={{ '2xs': 'md', md: '2xl' }}
+        paddingX={{ '2xs': 'md', md: '4xl' }}
       >
         <Grid
-          gridTemplateColumns={{ xxs: '1fr', md: 'repeat(12, 1fr)' }}
+          gridTemplateColumns={{ '2xs': '1fr', md: 'repeat(12, 1fr)' }}
           gap="lg"
           {...gridProps}
         >

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { FC, ReactNode } from 'react';
 
 import { GridItem, Heading } from '@chakra-ui/react';
@@ -29,7 +30,7 @@ const TwoColumnsLayout: FC<Props> = ({
     <BaseLayout header={header}>
       <BaseGridLayout
         templateAreas={{
-          xxs: `"backlink" "heading" "rightContent" "leftContent"`,
+          '2xs': `"backlink" "heading" "rightContent" "leftContent"`,
           md: `
             "${repeatArea(12, 'backlink')}"
             "${repeatArea(6, 'heading')} . ${repeatArea(5, 'rightContent')}"

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -29,8 +29,8 @@ const TwoColumnsLayout: FC<Props> = ({
     <BaseLayout header={header}>
       <BaseGridLayout
         templateAreas={{
-          xs: `"backlink" "heading" "rightContent" "leftContent"`,
-          lg: `
+          xxs: `"backlink" "heading" "rightContent" "leftContent"`,
+          md: `
             "${repeatArea(12, 'backlink')}"
             "${repeatArea(6, 'heading')} . ${repeatArea(5, 'rightContent')}"
             "${repeatArea(6, 'leftContent')} . ${repeatArea(

--- a/src/components/section/index.tsx
+++ b/src/components/section/index.tsx
@@ -28,7 +28,7 @@ const Section: FC<Props> = ({
   const styles = useMultiStyleConfig(`Section`, { variant });
 
   return (
-    <Stack direction={{ xs: 'column', lg: 'row' }} spacing="xl">
+    <Stack direction={{ xxs: 'column', md: 'row' }} spacing="xl">
       {image ? <Box maxW={maxImgW}>{image}</Box> : null}
       <Stack spacing="md">
         <chakra.span __css={styles.title}>{title}</chakra.span>

--- a/src/components/section/index.tsx
+++ b/src/components/section/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { FC, ReactNode } from 'react';
 
 import {
@@ -28,7 +29,7 @@ const Section: FC<Props> = ({
   const styles = useMultiStyleConfig(`Section`, { variant });
 
   return (
-    <Stack direction={{ xxs: 'column', md: 'row' }} spacing="xl">
+    <Stack direction={{ '2xs': 'column', md: 'row' }} spacing="xl">
       {image ? <Box maxW={maxImgW}>{image}</Box> : null}
       <Stack spacing="md">
         <chakra.span __css={styles.title}>{title}</chakra.span>

--- a/src/components/simpleHeader/index.tsx
+++ b/src/components/simpleHeader/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { FC } from 'react';
 
 import {
@@ -26,8 +27,8 @@ const SimpleHeader: FC<Props> = ({ title, url }) => {
         <Container
           width="full"
           maxWidth="container.xl"
-          minHeight={{ xxs: 'xl', md: '2xl' }}
-          paddingX={{ xxs: 'md', md: '4xl' }}
+          minHeight={{ '2xs': 'xl', md: '2xl' }}
+          paddingX={{ '2xs': 'md', md: '4xl' }}
           centerContent
           flexDirection="row"
           justifyContent="space-between"

--- a/src/components/simpleHeader/index.tsx
+++ b/src/components/simpleHeader/index.tsx
@@ -26,8 +26,8 @@ const SimpleHeader: FC<Props> = ({ title, url }) => {
         <Container
           width="full"
           maxWidth="container.xl"
-          minHeight={{ xs: 'xl', lg: '2xl' }}
-          paddingX={{ xs: 'md', lg: '4xl' }}
+          minHeight={{ xxs: 'xl', md: '2xl' }}
+          paddingX={{ xxs: 'md', md: '4xl' }}
           centerContent
           flexDirection="row"
           justifyContent="space-between"
@@ -37,7 +37,7 @@ const SimpleHeader: FC<Props> = ({ title, url }) => {
             <Flex
               alignSelf="baseline"
               paddingLeft="md"
-              paddingTop={{ lg: 'sm' }}
+              paddingTop={{ md: 'sm' }}
             >
               <a href={url}>
                 <CloseIcon />

--- a/src/components/stack/index.stories.mdx
+++ b/src/components/stack/index.stories.mdx
@@ -77,7 +77,7 @@ Default `col` direction switches to `row` on `sm` viewport.
 <Canvas>
   <Story
     name="Responsive"
-    args={{ direction: { xxs: 'column', sm: 'row' } }}
+    args={{ direction: { '2xs': 'column', sm: 'row' } }}
     argTypes={{
       direction: {
         table: {

--- a/src/components/stack/index.stories.mdx
+++ b/src/components/stack/index.stories.mdx
@@ -72,12 +72,12 @@ export const Template = (args) => {
 
 ## Responsive
 
-Default `col` direction switches to `row` on `md` viewport.
+Default `col` direction switches to `row` on `sm` viewport.
 
 <Canvas>
   <Story
     name="Responsive"
-    args={{ direction: { xs: 'column', md: 'row' } }}
+    args={{ direction: { xxs: 'column', sm: 'row' } }}
     argTypes={{
       direction: {
         table: {

--- a/src/components/vehicleReference/index.stories.mdx
+++ b/src/components/vehicleReference/index.stories.mdx
@@ -10,7 +10,7 @@ import VehicleReference from './index.tsx';
 />
 
 export const Template = (args) => (
-  <Box maxW={{ xxs: '100%', md: '450px' }}>
+  <Box maxW={{ '2xs': '100%', md: '450px' }}>
     <VehicleReference {...args} />
   </Box>
 );

--- a/src/components/vehicleReference/index.stories.mdx
+++ b/src/components/vehicleReference/index.stories.mdx
@@ -10,7 +10,7 @@ import VehicleReference from './index.tsx';
 />
 
 export const Template = (args) => (
-  <Box maxW={{ xs: '100%', lg: '450px' }}>
+  <Box maxW={{ xxs: '100%', md: '450px' }}>
     <VehicleReference {...args} />
   </Box>
 );

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { FC, ReactNode } from 'react';
 
 import {
@@ -30,7 +31,7 @@ const VehicleReference: FC<Props> = ({
 
   return (
     <article>
-      <Stack direction={{ xxs: 'row', md: 'column' }} spacing="md">
+      <Stack direction={{ '2xs': 'row', md: 'column' }} spacing="md">
         <AspectRatio
           minW="2xl"
           ratio={4 / 3}
@@ -43,7 +44,7 @@ const VehicleReference: FC<Props> = ({
             <img data-testid="missing-image" src={missingImage} />
           )}
         </AspectRatio>
-        <Stack spacing={{ xxs: 'xs', md: 'md' }} justify="center">
+        <Stack spacing={{ '2xs': 'xs', md: 'md' }} justify="center">
           <chakra.h1 __css={styles.carTitle}>{vehicleTitle}</chakra.h1>
           <chakra.span __css={styles.price}>{price}</chakra.span>
           <Box>

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -30,7 +30,7 @@ const VehicleReference: FC<Props> = ({
 
   return (
     <article>
-      <Stack direction={{ xs: 'row', lg: 'column' }} spacing="md">
+      <Stack direction={{ xxs: 'row', md: 'column' }} spacing="md">
         <AspectRatio
           minW="2xl"
           ratio={4 / 3}
@@ -43,7 +43,7 @@ const VehicleReference: FC<Props> = ({
             <img data-testid="missing-image" src={missingImage} />
           )}
         </AspectRatio>
-        <Stack spacing={{ xs: 'xs', lg: 'md' }} justify="center">
+        <Stack spacing={{ xxs: 'xs', md: 'md' }} justify="center">
           <chakra.h1 __css={styles.carTitle}>{vehicleTitle}</chakra.h1>
           <chakra.span __css={styles.price}>{price}</chakra.span>
           <Box>

--- a/src/themes/components/simpleHeader.ts
+++ b/src/themes/components/simpleHeader.ts
@@ -9,7 +9,7 @@ const SimpleHeader: ComponentMultiStyleConfig = {
   baseStyle: {
     header: baseStyleHeader,
     title: {
-      textStyle: { xs: 'heading3', lg: 'heading1' },
+      textStyle: { xxs: 'heading3', md: 'heading1' },
       wordBreak: 'break-word',
     },
   },

--- a/src/themes/components/simpleHeader.ts
+++ b/src/themes/components/simpleHeader.ts
@@ -9,8 +9,8 @@ const SimpleHeader: ComponentMultiStyleConfig = {
   baseStyle: {
     header: baseStyleHeader,
     title: {
-      textStyle: { base: 'heading3', lg: 'heading1' },
-      wordBreak: 'break-all',
+      textStyle: { xs: 'heading3', lg: 'heading1' },
+      wordBreak: 'break-word',
     },
   },
 };

--- a/src/themes/components/simpleHeader.ts
+++ b/src/themes/components/simpleHeader.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { ComponentMultiStyleConfig, SystemStyleObject } from '@chakra-ui/react';
 
 const baseStyleHeader: SystemStyleObject = {
@@ -9,7 +10,7 @@ const SimpleHeader: ComponentMultiStyleConfig = {
   baseStyle: {
     header: baseStyleHeader,
     title: {
-      textStyle: { xxs: 'heading3', md: 'heading1' },
+      textStyle: { '2xs': 'heading3', md: 'heading1' },
       wordBreak: 'break-word',
     },
   },

--- a/src/themes/components/vehicleReference.ts
+++ b/src/themes/components/vehicleReference.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { ComponentStyleConfig } from '@chakra-ui/react';
 
 const parts = ['carTitle', 'price', 'dealerName', 'dealerAddress'];
@@ -7,24 +8,24 @@ const VehicleReference: ComponentStyleConfig = {
   baseStyle: {
     carTitle: {
       color: 'gray.900',
-      textStyle: { xxs: 'heading5', md: 'heading3' },
-      noOfLines: { xxs: 1, md: 'none' },
+      textStyle: { '2xs': 'heading5', md: 'heading3' },
+      noOfLines: { '2xs': 1, md: 'none' },
       wordBreak: 'break-word',
     },
     price: {
       color: 'gray.900',
-      textStyle: { xxs: 'heading3', md: 'heading1' },
+      textStyle: { '2xs': 'heading3', md: 'heading1' },
     },
     dealerName: {
       color: 'gray.900',
       textStyle: 'heading4',
-      display: { xxs: 'none', md: 'flex' },
+      display: { '2xs': 'none', md: 'flex' },
       wordBreak: 'break-word',
     },
     dealerAddress: {
       color: 'gray.900',
       textStyle: 'body',
-      display: { xxs: 'none', md: 'flex' },
+      display: { '2xs': 'none', md: 'flex' },
       wordBreak: 'break-word',
     },
   },

--- a/src/themes/components/vehicleReference.ts
+++ b/src/themes/components/vehicleReference.ts
@@ -7,24 +7,25 @@ const VehicleReference: ComponentStyleConfig = {
   baseStyle: {
     carTitle: {
       color: 'gray.900',
-      textStyle: { xs: 'heading5', lg: 'heading3' },
-      noOfLines: { xs: 1, lg: 'none' },
+      textStyle: { xxs: 'heading5', md: 'heading3' },
+      noOfLines: { xxs: 1, md: 'none' },
+      wordBreak: 'break-word',
     },
     price: {
       color: 'gray.900',
-      textStyle: { xs: 'heading3', lg: 'heading1' },
+      textStyle: { xxs: 'heading3', md: 'heading1' },
     },
     dealerName: {
       color: 'gray.900',
       textStyle: 'heading4',
-      display: { xs: 'none', lg: 'flex' },
-      wordBreak: 'break-all',
+      display: { xxs: 'none', md: 'flex' },
+      wordBreak: 'break-word',
     },
     dealerAddress: {
       color: 'gray.900',
       textStyle: 'body',
-      display: { xs: 'none', lg: 'flex' },
-      wordBreak: 'break-all',
+      display: { xxs: 'none', md: 'flex' },
+      wordBreak: 'break-word',
     },
   },
 };

--- a/src/themes/shared/breakpoints.ts
+++ b/src/themes/shared/breakpoints.ts
@@ -2,7 +2,7 @@ import { convertRemToPx } from '../../utilities';
 
 export const emBreakpoints = {
   base: '0em',
-  xs: '23.4375em',
+  xs: '20em',
   sm: '30em',
   md: '48em',
   lg: '64em',

--- a/src/themes/shared/breakpoints.ts
+++ b/src/themes/shared/breakpoints.ts
@@ -2,11 +2,12 @@ import { convertRemToPx } from '../../utilities';
 
 export const emBreakpoints = {
   base: '0em',
-  xs: '20em',
-  sm: '30em',
-  md: '48em',
-  lg: '64em',
-  xl: '80em',
+  xxs: '20em',
+  xs: '22.5em',
+  sm: '48em',
+  md: '64em',
+  lg: '80em',
+  xl: '120em',
 };
 
 type BreakpointName = keyof typeof emBreakpoints;

--- a/src/themes/shared/breakpoints.ts
+++ b/src/themes/shared/breakpoints.ts
@@ -1,8 +1,9 @@
-import { convertRemToPx } from '../../utilities';
+import { convertRemEmToPx } from '../../utilities';
 
+/* eslint-disable @typescript-eslint/naming-convention */
 export const emBreakpoints = {
   base: '0em',
-  xxs: '20em',
+  '2xs': '20em',
   xs: '22.5em',
   sm: '48em',
   md: '64em',
@@ -15,7 +16,7 @@ type BreakpointName = keyof typeof emBreakpoints;
 export const pxBreakpoints = Object.fromEntries(
   Object.entries(emBreakpoints).map(([name, emValue]) => [
     name,
-    `${convertRemToPx(emValue)}px`,
+    `${convertRemEmToPx(emValue)}px`,
   ])
 ) as Record<BreakpointName, string>;
 

--- a/src/themes/stories/BreakpointShowcase.tsx
+++ b/src/themes/stories/BreakpointShowcase.tsx
@@ -9,6 +9,8 @@ import {
   useTheme,
 } from '@chakra-ui/react';
 
+import { convertRemEmToPx } from '../../';
+
 const BreakpointShowCase: FC = () => {
   const theme = useTheme();
   return (
@@ -18,6 +20,7 @@ const BreakpointShowCase: FC = () => {
           <Tr border="1px" borderColor="gray.300">
             <Th>Name</Th>
             <Th>Value</Th>
+            <Th>Pixels</Th>
           </Tr>
         </Thead>
         {Object.entries(theme.breakpoints).map(([name, breakpoint]) => {
@@ -25,6 +28,7 @@ const BreakpointShowCase: FC = () => {
             <Tr key={name} border="1px" borderColor="gray.300">
               <Td>{name}</Td>
               <Td>{breakpoint as string}</Td>
+              <Td>{`${convertRemEmToPx(breakpoint as string)}px`}</Td>
             </Tr>
           );
         })}

--- a/src/themes/stories/SizeShowcase.tsx
+++ b/src/themes/stories/SizeShowcase.tsx
@@ -10,7 +10,7 @@ import {
   useTheme,
 } from '@chakra-ui/react';
 
-import { convertRemToPx } from '../../';
+import { convertRemEmToPx } from '../../';
 
 const SizingShowCase: FC = () => {
   const theme = useTheme();
@@ -35,7 +35,7 @@ const SizingShowCase: FC = () => {
             <Tr key={name} border="1px" borderColor="gray.300">
               <Td>{name}</Td>
               <Td>{`${size}`}</Td>
-              <Td>{`${convertRemToPx(size as string)}px`}</Td>
+              <Td>{`${convertRemEmToPx(size as string)}px`}</Td>
             </Tr>
           );
         })}

--- a/src/themes/stories/SpaceShowcase.tsx
+++ b/src/themes/stories/SpaceShowcase.tsx
@@ -10,7 +10,7 @@ import {
   useTheme,
 } from '@chakra-ui/react';
 
-import { convertRemToPx } from '../../utilities';
+import { convertRemEmToPx } from '../../utilities';
 
 const SpacingShowCase: FC = () => {
   const theme = useTheme();
@@ -31,7 +31,7 @@ const SpacingShowCase: FC = () => {
             <Tr key={name} border="1px" borderColor="gray.300">
               <Td>{name}</Td>
               <Td>{space as string}</Td>
-              <Td>{convertRemToPx(space as string)}</Td>
+              <Td>{`${convertRemEmToPx(space as string)}px`}</Td>
               <Td>
                 <Box bg="gray.200" p={space as string}>
                   <Box bg="white" textAlign="center" width="auto">
@@ -45,7 +45,5 @@ const SpacingShowCase: FC = () => {
       </Table>
     </TableContainer>
   );
-
-  return <Tr border="1px" borderColor="gray.100"></Tr>;
 };
 export default SpacingShowCase;

--- a/src/utilities/convertRemToPx.ts
+++ b/src/utilities/convertRemToPx.ts
@@ -1,5 +1,5 @@
-export const convertRemToPx = (value: string) => {
+export const convertRemEmToPx = (value: string) => {
   const baseFontSize = 16;
-  const unitRem = parseFloat(value);
-  return unitRem * baseFontSize;
+  const unitRemEm = parseFloat(value);
+  return unitRemEm * baseFontSize;
 };

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,1 +1,1 @@
-export { convertRemToPx } from './convertRemToPx';
+export { convertRemEmToPx } from './convertRemToPx';


### PR DESCRIPTION
Reference:
https://github.com/smg-automotive/listings-web/pull/38#issuecomment-1220742058

[Jira](https://autoricardo.atlassian.net/browse/DM-582)

[figma-breakpoint](https://www.figma.com/file/WmNmJ7jdB0Z7tOjj516nFB/AS24-Tokens?node-id=84%3A35) -> Note: Sancho is working on the clean up.

## Motivation and context

We are facing some overlapping issues in the break point 320px. We are still in an early stage where we can make this change without braking changes.

After the discussion with the designers we decided to go with the next breakpoints (please check the reason about adding them and in case that you have a concern/idea/suggestion please let us know. Nothing is set in a stone):

**Breakpoints:**
xxs: 320px.    REASON: we have traffic on this breakpoint
xs: 360px.      REASON: we have A LOT OF traffic on this breakpoint and the designer can have flexibility here
**WE REMOVED THE 480px**.      _REASON: we don't have traffic on this breakpoint and we can unify the design between the 360px and 768px_ 
sm: 768px. 
md: 1024px
lg: 1280px
xl: 1920px.      REASON: we have some traffic on this breakpoint and the designer can have flexibility here

# IMPORTANT👩🏼‍✈️
Adding the new breakpoints (320px, 360px and 1280px) DOES NOT mean that the designer will always implement different designer between them. This means that the designer will have more flexibility while designing and ONLY adapting a change when it's really necessary. Please, take into consideration that these changes are checked for the full header design as well.

## How to test
Please check the breakpoint in storybook going through the follow components (they MUST behave as before):
* Article Teaser
* Based Grid
* Two Columns Layout
* Section
* Simple Header
* Stack
* Vehicle Reference

## Thank you 🐥
