### PR TITLE
fix: image width for section

### DIFF
--- a/src/components/section/index.tsx
+++ b/src/components/section/index.tsx
@@ -31,7 +31,7 @@ const Section: FC<Props> = ({
   return (
     <Stack direction={{ '2xs': 'column', md: 'row' }} spacing="xl">
       {image ? (
-        <Box maxW={maxImgW} w={maxImgW}>
+        <Box maxW={maxImgW} flexShrink={0}>
           {image}
         </Box>
       ) : null}

--- a/src/components/section/index.tsx
+++ b/src/components/section/index.tsx
@@ -30,7 +30,11 @@ const Section: FC<Props> = ({
 
   return (
     <Stack direction={{ '2xs': 'column', md: 'row' }} spacing="xl">
-      {image ? <Box maxW={maxImgW}>{image}</Box> : null}
+      {image ? (
+        <Box maxW={maxImgW} w={maxImgW}>
+          {image}
+        </Box>
+      ) : null}
       <Stack spacing="md">
         <chakra.span __css={styles.title}>{title}</chakra.span>
         {text ? <chakra.span __css={styles.text}>{text}</chakra.span> : null}


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

When passing an img and not an svg as a component, the image shrinks due to the max-width even if a larger width is applied to it.

## Before

It shrinks

## After

It does not shrink anymore

## How to test

[Add a deep link and instructions how to verify the new behavior]
