### PR TITLE
feat: allow ReactNode as layout title

### DIFF
--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -3,7 +3,7 @@ import { Divider as ChakraDivider, ResponsiveValue } from '@chakra-ui/react';
 import { Sizes } from '../../themes';
 
 type Props = {
-  verticalSpacing: ResponsiveValue<Sizes>;
+  verticalSpacing?: ResponsiveValue<Sizes>;
 };
 
 const Divider: FC<Props> = ({ verticalSpacing }) => {

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -1,8 +1,13 @@
 import React, { FC } from 'react';
-import { Divider as ChakraDivider } from '@chakra-ui/react';
+import { Divider as ChakraDivider, ResponsiveValue } from '@chakra-ui/react';
+import { Sizes } from '../../themes';
 
-const Divider: FC = () => {
-  return <ChakraDivider />;
+type Props = {
+  verticalSpacing: ResponsiveValue<Sizes>;
+};
+
+const Divider: FC<Props> = ({ verticalSpacing }) => {
+  return <ChakraDivider my={verticalSpacing} />;
 };
 
 export default Divider;

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -1,14 +1,8 @@
 import React, { FC } from 'react';
-import { Divider as ChakraDivider, ResponsiveValue } from '@chakra-ui/react';
+import { Divider as ChakraDivider } from '@chakra-ui/react';
 
-import { Sizes } from '../../themes';
-
-type Props = {
-  verticalSpacing?: ResponsiveValue<Sizes>;
-};
-
-const Divider: FC<Props> = ({ verticalSpacing }) => {
-  return <ChakraDivider my={verticalSpacing} />;
+const Divider: FC = () => {
+  return <ChakraDivider />;
 };
 
 export default Divider;

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { Divider as ChakraDivider, ResponsiveValue } from '@chakra-ui/react';
+
 import { Sizes } from '../../themes';
 
 type Props = {

--- a/src/components/layout/TwoColumnsLayout.stories.mdx
+++ b/src/components/layout/TwoColumnsLayout.stories.mdx
@@ -3,6 +3,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import TwoColumnsLayout from './TwoColumnsLayout.tsx';
 import Text from '../text';
 import SimpleHeader from '../simpleHeader';
+import Section from '../section';
 
 <Meta
   title="Layout/Pages/Layout with two columns"
@@ -35,6 +36,16 @@ import SimpleHeader from '../simpleHeader';
       },
     },
     rightContent: {
+      table: {
+        disable: true,
+      },
+    },
+    title: {
+      control: {
+        type: 'text',
+      },
+    },
+    backLink: {
       table: {
         disable: true,
       },
@@ -73,3 +84,30 @@ export const Template = (args) => <TwoColumnsLayout {...args} />;
 </Canvas>
 
 <ArgsTable story="With empty right content" />
+
+## With custom title
+
+<Canvas>
+  <Story
+    name="With custom title"
+    args={{
+      title: (
+        <Section
+          title="This is a custom title element"
+          text="And some text that still belongs to the custom element"
+        />
+      ),
+    }}
+    argTypes={{
+      title: {
+        table: {
+          disable: true,
+        },
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="With custom title" />

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -10,7 +10,7 @@ import { ArrowLeftIcon } from '../icons';
 
 interface Props {
   header: ReactNode;
-  title?: string;
+  title?: string | ReactNode;
   backLink?: {
     text: string;
     url: string;
@@ -50,9 +50,13 @@ const TwoColumnsLayout: FC<Props> = ({
         ) : null}
         {title ? (
           <GridItem area="heading">
-            <Heading as="h1" textStyle="heading1">
-              {title}
-            </Heading>
+            {typeof title === 'string' ? (
+              <Heading as="h1" textStyle="heading1">
+                {title}
+              </Heading>
+            ) : (
+              title
+            )}
           </GridItem>
         ) : null}
         {rightContent ? (

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -5,7 +5,7 @@ import VehicleReference, { VehicleReferenceProps } from '../vehicleReference';
 import Stack from '../stack';
 
 interface Props {
-  title?: string;
+  title?: string | ReactNode;
   backLink?: {
     text: string;
     url: string;


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

For [this](https://www.figma.com/file/f0LWQupJueW6KHBQujVGe4/Lead-Form-Page-(Working-Title)?node-id=511%3A64352) design, we need to pass a Section component as the page title. This requires us to allow a ReactNode to be passed and not only a string

## Before

Only string allowed

## After

String and ReactNode allowed