### PR TITLE
fix: export select options type

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,7 +17,10 @@ export { default as Radio } from './radio';
 export { default as Section } from './section';
 export { default as SimpleHeader } from './simpleHeader';
 export { default as Stack } from './stack';
-export { default as Select } from './select';
+export {
+  default as Select,
+  Options,
+} from './select';
 export { default as Text } from './text';
 export { default as Textarea } from './textarea';
 export {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,7 +17,7 @@ export { default as Radio } from './radio';
 export { default as Section } from './section';
 export { default as SimpleHeader } from './simpleHeader';
 export { default as Stack } from './stack';
-export { default as Select, Options } from './select';
+export { default as Select, Option } from './select';
 export { default as Text } from './text';
 export { default as Textarea } from './textarea';
 export {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,10 +17,7 @@ export { default as Radio } from './radio';
 export { default as Section } from './section';
 export { default as SimpleHeader } from './simpleHeader';
 export { default as Stack } from './stack';
-export {
-  default as Select,
-  Options,
-} from './select';
+export { default as Select, Options } from './select';
 export { default as Text } from './text';
 export { default as Textarea } from './textarea';
 export {

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -6,11 +6,13 @@ import {
 
 import { ChevronIcon } from '../icons';
 
+export type Options<T extends string | number> = {
+  value: T;
+  label: string;
+}
+
 type OptionsAndValue<T extends string | number> = {
-  options: {
-    value: T;
-    label: string;
-  }[];
+  options: Options<T>[];
   value?: T;
 };
 

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -9,7 +9,7 @@ import { ChevronIcon } from '../icons';
 export type Options<T extends string | number> = {
   value: T;
   label: string;
-}
+};
 
 type OptionsAndValue<T extends string | number> = {
   options: Options<T>[];

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -6,13 +6,13 @@ import {
 
 import { ChevronIcon } from '../icons';
 
-export type Options<T extends string | number> = {
+export type Option<T extends string | number> = {
   value: T;
   label: string;
 };
 
 type OptionsAndValue<T extends string | number> = {
-  options: Options<T>[];
+  options: Option<T>[];
   value?: T;
 };
 


### PR DESCRIPTION
## Motivation and context

Export `Select` options type to use it outside of components pkg. Reference: https://github.com/smg-automotive/seller-web/pull/9

## Before

No exported options

## After

Exported options exists
