### PR TITLE
fix: display link as inline-flex

### DIFF
--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -42,3 +42,15 @@ import { ArrowLeftIcon, ErrorIcon } from '../index.ts';
     </Link>
   </Story>
 </Canvas>
+
+## Link as part of a paragraph
+
+<Canvas>
+  <Story name="Link as part of a paragraph">
+    <p>
+      You need to accept
+      <Link>Terms & Conditions</Link>
+      before you proceed
+    </p>
+  </Story>
+</Canvas>

--- a/src/themes/components/link.ts
+++ b/src/themes/components/link.ts
@@ -3,7 +3,7 @@ import { ComponentMultiStyleConfig, SystemStyleObject } from '@chakra-ui/react';
 const linkBaseStyle: SystemStyleObject = {
   textStyle: 'body',
   color: 'blue.700',
-  display: 'flex',
+  display: 'inline-flex',
   flexDirection: 'row',
   _hover: {
     cursor: 'pointer',


### PR DESCRIPTION
## Before

<img width="201" alt="Screenshot 2022-10-06 at 12 39 23" src="https://user-images.githubusercontent.com/144707/194292928-c7cb2450-072f-4014-9ed0-0be2982122f6.png">

## After

<img width="465" alt="Screenshot 2022-10-06 at 12 39 32" src="https://user-images.githubusercontent.com/144707/194292925-525ebe57-c2dd-4625-b722-d4cbc00151cc.png">