### PR TITLE
fix: show error message with the hint

### DIFF
--- a/src/components/formControl/__tests__/FormControl.Test.tsx
+++ b/src/components/formControl/__tests__/FormControl.Test.tsx
@@ -104,12 +104,5 @@ describe('<FormControl>', () => {
 
       expect(errorMessage).toBeInTheDocument();
     });
-
-    it('hides the hint text if passed', () => {
-      renderWrapper({ errorMessage: 'I am error', hint: 'I am hint' });
-      const hint = screen.queryByText('I am hint');
-
-      expect(hint).toBe(null);
-    });
   });
 });

--- a/src/components/formControl/index.tsx
+++ b/src/components/formControl/index.tsx
@@ -40,8 +40,8 @@ const FormControl: FC<PropsWithChildren<Props>> = ({
         </FormLabel>
       ) : null}
       {children}
-      {hint && !isInvalid ? <FormHelperText>{hint}</FormHelperText> : null}
       <FormErrorMessage>{errorMessage}</FormErrorMessage>
+      {hint ? <FormHelperText>{hint}</FormHelperText> : null}
     </ChakraFormControl>
   );
 };


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-678

## Motivation and context

We decided to show both a hint and an error message in case the field has an error.

## Before

<img width="280" alt="Screenshot 2022-10-06 at 13 26 37" src="https://user-images.githubusercontent.com/144707/194302965-d41ea34b-670b-47f7-a2fb-31b4d28e8574.png">

## After

<img width="308" alt="Screenshot 2022-10-06 at 13 26 30" src="https://user-images.githubusercontent.com/144707/194302971-19ca133a-4483-4367-92a1-df1e790c2e79.png">
