### PR TITLE
fix: arrow icon overlaps text

### DIFF
--- a/src/themes/components/select.ts
+++ b/src/themes/components/select.ts
@@ -7,6 +7,7 @@ const selectStyles: StyleConfig = {
   baseStyle: {
     field: {
       ...Input.baseStyle.field,
+      paddingInlineEnd: '3xl',
     },
     icon: {
       right: 'md',


### PR DESCRIPTION
## Motivation and context

Fix arrow icon overlapping the text on the select.

## Before

![Screenshot 2022-10-11 at 15 08 44](https://user-images.githubusercontent.com/37380787/195099556-5bd6bda2-3db6-4b1c-8e4c-551188586c7a.png)

## After

![Screenshot 2022-10-11 at 15 09 44](https://user-images.githubusercontent.com/37380787/195099651-870ba02a-0ca3-4c6e-a10f-3eed2ec8184a.png)

## How to test

Please check the select component and play around with the text.

## Thank you 🦆
