### PR TITLE
feat: carousel component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
         "@types/fs-extra": "9.0.13",
+        "embla-carousel-react": "^7.0.3",
         "framer-motion": "7.6.1",
         "fs-extra": "10.1.0",
         "merge-json-file": "1.0.1",
@@ -17875,6 +17876,22 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
+    },
+    "node_modules/embla-carousel": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-7.0.3.tgz",
+      "integrity": "sha512-Zo8E/qNb8J7n/jcfQxPrfdARlTgsMvmcXshn3J/2oxWVLwL/3N4cAhuqLQiud/oCjZzl+A8maCJDe2PDVlc/cA=="
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-7.0.3.tgz",
+      "integrity": "sha512-nvgAAmoFuXyCPuH2rSTnSdaTSMwFX/ilXDlfMCCDfdaj4X3u25+x8lMC1bINuk+4G2Hm6SOlrZ1eGkYdBg5HAg==",
+      "dependencies": {
+        "embla-carousel": "7.0.3"
+      },
+      "peerDependencies": {
+        "react": "^18.1.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.10.2",
@@ -52204,6 +52221,19 @@
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
+      }
+    },
+    "embla-carousel": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-7.0.3.tgz",
+      "integrity": "sha512-Zo8E/qNb8J7n/jcfQxPrfdARlTgsMvmcXshn3J/2oxWVLwL/3N4cAhuqLQiud/oCjZzl+A8maCJDe2PDVlc/cA=="
+    },
+    "embla-carousel-react": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-7.0.3.tgz",
+      "integrity": "sha512-nvgAAmoFuXyCPuH2rSTnSdaTSMwFX/ilXDlfMCCDfdaj4X3u25+x8lMC1bINuk+4G2Hm6SOlrZ1eGkYdBg5HAg==",
+      "requires": {
+        "embla-carousel": "7.0.3"
       }
     },
     "emittery": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
         "@types/fs-extra": "9.0.13",
-        "embla-carousel-react": "^7.0.3",
+        "embla-carousel-react": "7.0.3",
         "framer-motion": "7.6.1",
         "fs-extra": "10.1.0",
         "merge-json-file": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@emotion/react": "11.10.4",
     "@emotion/styled": "11.10.4",
     "@types/fs-extra": "9.0.13",
+    "embla-carousel-react": "7.0.3",
     "framer-motion": "7.6.1",
     "fs-extra": "10.1.0",
     "merge-json-file": "1.0.1",

--- a/src/components/carousel/NavigationButton.tsx
+++ b/src/components/carousel/NavigationButton.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react';
+import { chakra } from '@chakra-ui/react';
+
+import { ChevronDownLargeIcon } from '../icons';
+
+export type Direction = 'previous' | 'next';
+interface Props {
+  onClick: (direction: Direction) => void;
+  direction: Direction;
+}
+
+const NavigationButton: FC<Props> = ({ direction, onClick }) => {
+  const side = direction === 'previous' ? { left: '0' } : { right: '0' };
+
+  return (
+    <chakra.button
+      onClick={() => onClick(direction)}
+      position="absolute"
+      color="white"
+      top="0"
+      width="lg"
+      height="full"
+      aria-label={`${direction} slide`}
+      {...side}
+    >
+      <ChevronDownLargeIcon
+        transform={
+          direction === 'previous' ? 'rotate(90deg)' : 'rotate(-90deg)'
+        }
+        color="white"
+      />
+    </chakra.button>
+  );
+};
+
+export default NavigationButton;

--- a/src/components/carousel/NavigationButton.tsx
+++ b/src/components/carousel/NavigationButton.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { chakra } from '@chakra-ui/react';
 
 import { ChevronDownLargeIcon } from '../icons';
+import Flex from '../flex';
 
 export type Direction = 'previous' | 'next';
 interface Props {
@@ -16,19 +17,35 @@ const NavigationButton: FC<Props> = ({ direction, onClick }) => {
     <chakra.button
       onClick={() => onClick(direction)}
       position="absolute"
-      color="white"
       top="0"
+      {...side}
       width="lg"
       height="full"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      color="white"
+      visibility="hidden"
+      _groupHover={{ md: { visibility: 'visible' } }}
       aria-label={`${direction} slide`}
-      {...side}
     >
-      <ChevronDownLargeIcon
-        transform={
-          direction === 'previous' ? 'rotate(90deg)' : 'rotate(-90deg)'
-        }
-        color="white"
-      />
+      <Flex
+        justifyContent="center"
+        alignItems="center"
+        borderRadius="sm"
+        width="md"
+        height="md"
+        backgroundColor="gray.900"
+        opacity="40%"
+        _hover={{ opacity: '80%' }}
+      >
+        <ChevronDownLargeIcon
+          transform={
+            direction === 'previous' ? 'rotate(90deg)' : 'rotate(-90deg)'
+          }
+          color="white"
+        />
+      </Flex>
     </chakra.button>
   );
 };

--- a/src/components/carousel/NavigationButton.tsx
+++ b/src/components/carousel/NavigationButton.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { chakra } from '@chakra-ui/react';
 
-import { ChevronDownLargeIcon } from '../icons';
+import { ChevronLeftLargeIcon, ChevronRightLargeIcon } from '../icons';
 import Flex from '../flex';
 
 export type Direction = 'previous' | 'next';
@@ -39,12 +39,11 @@ const NavigationButton: FC<Props> = ({ direction, onClick }) => {
         opacity="40%"
         _hover={{ opacity: '80%' }}
       >
-        <ChevronDownLargeIcon
-          transform={
-            direction === 'previous' ? 'rotate(90deg)' : 'rotate(-90deg)'
-          }
-          color="white"
-        />
+        {direction === 'previous' ? (
+          <ChevronLeftLargeIcon color="white" />
+        ) : (
+          <ChevronRightLargeIcon color="white" />
+        )}
       </Flex>
     </chakra.button>
   );

--- a/src/components/carousel/Slide.tsx
+++ b/src/components/carousel/Slide.tsx
@@ -1,0 +1,34 @@
+import React, { FC, PropsWithChildren } from 'react';
+
+import Box from '../box';
+
+interface Props {
+  onClick: () => void;
+  slideIndex: number;
+  totalSlides: number;
+  isCurrent: boolean;
+}
+
+const Slide: FC<PropsWithChildren<Props>> = ({
+  onClick,
+  slideIndex,
+  totalSlides,
+  isCurrent,
+  children,
+}) => {
+  return (
+    <Box
+      flexGrow="0"
+      flexShrink="0"
+      flexBasis="full"
+      onClick={onClick}
+      aria-roledescription="slide"
+      aria-label={`${slideIndex + 1} of ${totalSlides}`}
+      aria-current={isCurrent}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default Slide;

--- a/src/components/carousel/__tests__/Index.Test.tsx
+++ b/src/components/carousel/__tests__/Index.Test.tsx
@@ -71,17 +71,4 @@ describe('<Carousel />', () => {
     await userEvent.click(screen.getByText('slide 1'));
     expect(mockOnClick).toHaveBeenCalledWith(0);
   });
-
-  it('should call the onChange handler when a slide changes', async () => {
-    const mockOnChange = jest.fn();
-    render(
-      <Carousel onSlideChange={mockOnChange}>
-        <div>slide 1</div>
-        <div>slide 2</div>
-        <div>slide 3</div>
-      </Carousel>
-    );
-    await userEvent.click(screen.getByRole('button', { name: 'next slide' }));
-    expect(mockOnChange).toHaveBeenCalledWith(1);
-  });
 });

--- a/src/components/carousel/__tests__/Index.Test.tsx
+++ b/src/components/carousel/__tests__/Index.Test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+
+import Carousel from '../index';
+
+describe('<Carousel />', () => {
+  it('should create the carousel in infinite mode', async () => {
+    render(
+      <Carousel onSlideClick={jest.fn} startIndex={2}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </Carousel>
+    );
+    expect(screen.getByLabelText('3 of 3')).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'next slide' }));
+    expect(screen.getByLabelText('1 of 3')).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'previous slide' })
+    );
+    expect(screen.getByLabelText('3 of 3')).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+  });
+
+  it('should use start index 0 if none has been given', () => {
+    render(
+      <Carousel onSlideClick={jest.fn}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </Carousel>
+    );
+    expect(screen.getByLabelText('1 of 3')).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+  });
+
+  it('should respect the start index', () => {
+    render(
+      <Carousel onSlideClick={jest.fn} startIndex={1}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </Carousel>
+    );
+    expect(screen.getByLabelText('2 of 3')).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+  });
+
+  it('should call the onClick handler when clicking a slide', async () => {
+    const mockOnClick = jest.fn();
+    render(
+      <Carousel onSlideClick={mockOnClick}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </Carousel>
+    );
+    await userEvent.click(screen.getByText('slide 1'));
+    expect(mockOnClick).toHaveBeenCalledWith(0);
+  });
+
+  it('should call the onChange handler when a slide changes', async () => {
+    const mockOnChange = jest.fn();
+    render(
+      <Carousel onSlideChange={mockOnChange}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </Carousel>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'next slide' }));
+    expect(mockOnChange).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/components/carousel/__tests__/Index.Test.tsx
+++ b/src/components/carousel/__tests__/Index.Test.tsx
@@ -1,10 +1,25 @@
 import React from 'react';
+import useEmblaCarousel from 'embla-carousel-react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
 import Carousel from '../index';
 
+jest.mock('embla-carousel-react', () => {
+  const embla = jest.requireActual('embla-carousel-react');
+
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: jest.fn(embla),
+  };
+});
+
 describe('<Carousel />', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should create the carousel in infinite mode', async () => {
     render(
       <Carousel onSlideClick={jest.fn} startIndex={2}>
@@ -17,14 +32,13 @@ describe('<Carousel />', () => {
       'aria-current',
       'true'
     );
-    await userEvent.click(screen.getByRole('button', { name: 'next slide' }));
+    await userEvent.hover(screen.getByLabelText('Carousel'));
+    await userEvent.click(screen.getByLabelText('next slide'));
     expect(screen.getByLabelText('1 of 3')).toHaveAttribute(
       'aria-current',
       'true'
     );
-    await userEvent.click(
-      screen.getByRole('button', { name: 'previous slide' })
-    );
+    await userEvent.click(screen.getByLabelText('previous slide'));
     expect(screen.getByLabelText('3 of 3')).toHaveAttribute(
       'aria-current',
       'true'
@@ -70,5 +84,49 @@ describe('<Carousel />', () => {
     );
     await userEvent.click(screen.getByText('slide 1'));
     expect(mockOnClick).toHaveBeenCalledWith(0);
+  });
+
+  it('should prerender a fallback slide on the server (emblaRef is undefined) when the start index is different than 0', () => {
+    (useEmblaCarousel as unknown as jest.Mock).mockReturnValueOnce([
+      undefined,
+      undefined,
+    ]);
+
+    render(
+      <Carousel onSlideClick={jest.fn} startIndex={1}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </Carousel>
+    );
+
+    expect(screen.queryByLabelText('Carousel')).toBeNull();
+    expect(screen.getByLabelText('2 of 3')).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.queryByLabelText('1 of 3')).toBeNull();
+    expect(screen.queryByLabelText('3 of 3')).toBeNull();
+  });
+
+  it('should prerender the carousel on the server if the start index is 0', () => {
+    (useEmblaCarousel as unknown as jest.Mock).mockReturnValueOnce([
+      undefined,
+      undefined,
+    ]);
+
+    render(
+      <Carousel onSlideClick={jest.fn} startIndex={0}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </Carousel>
+    );
+
+    expect(screen.getByLabelText('Carousel')).toBeInTheDocument();
+    expect(screen.getByLabelText('1 of 3')).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
   });
 });

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -15,13 +15,13 @@ export const Slide = ({ children }) => (
   >
     {children}
   </Flex>
-)
+);
 
 export const Template = (args) => (
   <Carousel
     {...args}
-    onSlideChange={args.onSlideChange ? action("onSlideChange") : undefined}
-    onSlideClick={args.onSlideClick ? action("onSlideClick") : undefined}
+    onSlideChange={args.onSlideChange ? action('onSlideChange') : undefined}
+    onSlideClick={args.onSlideClick ? action('onSlideClick') : undefined}
   >
     <Slide>Slide 1</Slide>
     <Slide>Slide 2</Slide>
@@ -42,7 +42,7 @@ export const Template = (args) => (
     args={{
       startIndex: 0,
       onSlideChange: true,
-      onSlideClick: true
+      onSlideClick: true,
     }}
   >
     {Template.bind({})}

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -20,7 +20,6 @@ export const Slide = ({ children }) => (
 export const Template = (args) => (
   <Carousel
     {...args}
-    onSlideChange={args.onSlideChange ? action('onSlideChange') : undefined}
     onSlideClick={args.onSlideClick ? action('onSlideClick') : undefined}
   >
     <Slide>Slide 1</Slide>
@@ -41,7 +40,6 @@ export const Template = (args) => (
     name="Overview"
     args={{
       startIndex: 0,
-      onSlideChange: true,
       onSlideClick: true,
     }}
   >

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { action } from '@storybook/addon-actions';
+
+import Carousel from './index.tsx';
+import Flex from '../flex';
+
+<Meta title="Components/Data display/Carousel" component={Carousel} />
+
+export const Slide = ({ children }) => (
+  <Flex
+    backgroundColor="red.500"
+    justifyContent="center"
+    alignItems="center"
+    height="300px"
+  >
+    {children}
+  </Flex>
+)
+
+export const Template = (args) => (
+  <Carousel
+    {...args}
+    onSlideChange={args.onSlideChange ? action("onSlideChange") : undefined}
+    onSlideClick={args.onSlideClick ? action("onSlideClick") : undefined}
+  >
+    <Slide>Slide 1</Slide>
+    <Slide>Slide 2</Slide>
+    <Slide>Slide 3</Slide>
+    <Slide>Slide 4</Slide>
+    <Slide>Slide 5</Slide>
+    <Slide>Slide 6</Slide>
+  </Carousel>
+);
+
+# Carousel
+
+## Overview
+
+<Canvas>
+  <Story
+    name="Overview"
+    args={{
+      startIndex: 0,
+      onSlideChange: true,
+      onSlideClick: true
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
 
+import Slide from './Slide';
 import NavigationButton, { Direction } from './NavigationButton';
 import Flex from '../flex';
 import Box from '../box';
@@ -69,27 +70,17 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
     embla.on('select', onSelect);
   }, [embla, onSelect]);
 
-  const renderSlide = (slide: ReactNode, index: number) => {
-    return (
-      <Box
-        key={`slide-${index}`}
-        flexGrow="0"
-        flexShrink="0"
-        flexBasis="full"
-        onClick={() => onClick(index)}
-        aria-roledescription="slide"
-        aria-label={`${index + 1} of ${numberOfSlides}`}
-        aria-current={index === selectedIndex}
-      >
-        {slide}
-      </Box>
-    );
-  };
-
   const prerenderFallbackSlide = startIndex !== 0 && !emblaRef;
 
   return prerenderFallbackSlide ? (
-    renderSlide(slides[startIndex], startIndex)
+    <Slide
+      slideIndex={startIndex}
+      onClick={() => onClick(startIndex)}
+      totalSlides={numberOfSlides}
+      isCurrent={startIndex === selectedIndex}
+    >
+      {slides[startIndex]}
+    </Slide>
   ) : (
     <Box
       ref={emblaRef}
@@ -99,7 +90,19 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
       aria-roledescription="Carousel"
       role="group"
     >
-      <Flex>{slides.map((slide, index) => renderSlide(slide, index))}</Flex>
+      <Flex>
+        {slides.map((slide, index) => (
+          <Slide
+            key={`slide-${index}`}
+            slideIndex={index}
+            onClick={() => onClick(index)}
+            totalSlides={numberOfSlides}
+            isCurrent={index === selectedIndex}
+          >
+            {slide}
+          </Slide>
+        ))}
+      </Flex>
       <NavigationButton onClick={scroll} direction="previous" />
       <NavigationButton onClick={scroll} direction="next" />
     </Box>

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -85,11 +85,6 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
     );
   };
 
-  /*
-   while emblaRef is not defined (e.g. on the server side) it will render slide 0 even if another start slide index has been given.
-   this would result in a flickering behavior and is bad for performance (as we would load an image that is not needed)
-   render a static slide improves LCP and UX
-  */
   const prerenderFallbackSlide = startIndex !== 0 && !emblaRef;
 
   return prerenderFallbackSlide ? (

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -25,6 +25,7 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
   const [emblaRef, embla] = useEmblaCarousel({
     loop: true,
     startIndex: startIndex,
+    speed: 20,
   });
   const [selectedIndex, setSelectedIndex] = useState(startIndex);
 

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -15,13 +15,11 @@ import Box from '../box';
 interface Props {
   startIndex?: number;
   onSlideClick?: (index: number) => void;
-  onSlideChange?: (newIndex: number) => void;
 }
 
 const Carousel: FC<PropsWithChildren<Props>> = ({
   startIndex = 0,
   onSlideClick,
-  onSlideChange,
   children,
 }) => {
   const [emblaRef, embla] = useEmblaCarousel({
@@ -62,8 +60,7 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
     if (!embla) return;
     const newIndex = embla.selectedScrollSnap();
     setSelectedIndex(newIndex);
-    onSlideChange && onSlideChange(newIndex);
-  }, [embla, setSelectedIndex, onSlideChange]);
+  }, [embla, setSelectedIndex]);
 
   useEffect(() => {
     if (!embla) return;

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -101,6 +101,7 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
       position="relative"
       aria-label="Carousel"
       aria-roledescription="Carousel"
+      role="group"
     >
       <Flex>{slides.map((slide, index) => renderSlide(slide, index))}</Flex>
       <NavigationButton onClick={scroll} direction="previous" />

--- a/src/components/icons/ChevronLeftLargeIcon.tsx
+++ b/src/components/icons/ChevronLeftLargeIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createIcon } from '@chakra-ui/react';
+
+export const ChevronLeftLargeIcon = createIcon({
+  displayName: 'ChevronLeftLarge',
+  viewBox: '0 0 24 24',
+  path: (
+    <path
+      d="M15 21L16.41 19.59L8.83 12L16.41 4.42L15 3L6 12L15 21Z"
+      fill="currentColor"
+    />
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/ChevronRightLargeIcon.tsx
+++ b/src/components/icons/ChevronRightLargeIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createIcon } from '@chakra-ui/react';
+
+export const ChevronRightLargeIcon = createIcon({
+  displayName: 'ChevronRightLarge',
+  viewBox: '0 0 24 24',
+  path: (
+    <path
+      d="M8.99996 21L7.57996 19.59L15.17 12L7.58996 4.42L8.99996 3L18 12L8.99996 21Z"
+      fill="currentColor"
+    />
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,6 +1,8 @@
 export { ArrowLeftIcon } from './ArrowLeftIcon';
 export { ChevronDownSmallIcon } from './ChevronDownSmallIcon';
 export { ChevronDownLargeIcon } from './ChevronDownLargeIcon';
+export { ChevronLeftLargeIcon } from './ChevronLeftLargeIcon';
+export { ChevronRightLargeIcon } from './ChevronRightLargeIcon';
 export { ErrorIcon } from './ErrorIcon';
 export { CloseIcon } from './CloseIcon';
 export { CheckmarkIcon } from './CheckmarkIcon';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ export { default as AspectRatio } from './aspectRatio';
 export { default as Alert } from './alert';
 export { default as Button } from './button';
 export { default as Box } from './box';
+export { default as Carousel } from './carousel';
 export { default as Center } from './center';
 export { default as Checkbox } from './checkbox';
 export { default as DatePicker } from './datePicker';


### PR DESCRIPTION
References [DM-739](https://autoricardo.atlassian.net/browse/DM-739)

## Motivation and context

For the swiping gallery on the PDP, we need a carousel. In the [RFC](https://github.com/smg-automotive/au-docs/discussions/32) here we agreed on embla-carousel-react. In refinment we decided to have the component in the pkg to reuse it in the seller part too.

FYI: 
- pagination for the fullscreen gallery was not yet part of the ticket -> can be extended
- rendering multiple slides per slide for "similar cars" was not yet part of the ticket -> can be extended

## Before

No carousel

## After

Carousel

## How to test

https://talamcol-swiping-gallery.listings-web.branch.autoscout24.ch/de/d/8614365
https://talamcol-carousel.components-pkg.branch.autoscout24.ch/?path=/story/components-data-display-carousel--overview
