### PR TITLE
feat: add new component for energy label

### DIFF
--- a/src/components/energyLabel/index.stories.mdx
+++ b/src/components/energyLabel/index.stories.mdx
@@ -1,0 +1,28 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+import EnergyLabel from './index.tsx';
+
+<Meta title="Components/Data display/Energy label" component={EnergyLabel} />
+
+export const Template = (args) => <EnergyLabel {...args} />;
+
+# EnergyLabel
+
+## Overview
+
+<Canvas>
+  <Story
+    name="Energy label"
+    args={{
+      efficiency: 'A',
+    }}
+    argTypes={{
+      efficiency: {
+        options: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+        control: 'select',
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/energyLabel/index.tsx
+++ b/src/components/energyLabel/index.tsx
@@ -22,7 +22,7 @@ const colors: Record<Efficiency, string> = {
 
 const EnergyLabel: FC<Props> = ({ efficiency }) => {
   return (
-    <Flex height="20px" width="40px">
+    <Flex height="20px" width="md">
       <Box
         borderTopWidth="10px"
         borderTopColor="transparent"

--- a/src/components/energyLabel/index.tsx
+++ b/src/components/energyLabel/index.tsx
@@ -24,8 +24,6 @@ const EnergyLabel: FC<Props> = ({ efficiency }) => {
   return (
     <Flex height="20px" width="40px">
       <Box
-        width="0"
-        height="0"
         borderTopWidth="10px"
         borderTopColor="transparent"
         borderRightWidth="10px"

--- a/src/components/energyLabel/index.tsx
+++ b/src/components/energyLabel/index.tsx
@@ -1,0 +1,52 @@
+import React, { FC } from 'react';
+
+import Text from '../text';
+import Flex from '../flex';
+import Box from '../box';
+
+type Efficiency = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G';
+
+interface Props {
+  efficiency: Efficiency;
+}
+
+const EnergyLabel: FC<Props> = ({ efficiency }) => {
+  const colors: Record<Efficiency, `#${string}`> = {
+    A: '#4CA651',
+    B: '#54B646',
+    C: '#CAD143',
+    D: '#FEF050',
+    E: '#F1AE3D',
+    F: '#EE6E2D',
+    G: '#D02F26',
+  };
+
+  return (
+    <Flex height="20px" width="40px">
+      <Box
+        width="0"
+        height="0"
+        borderTopWidth="10px"
+        borderTopColor="transparent"
+        borderRightWidth="10px"
+        borderRightColor={colors[efficiency]}
+        borderBottomWidth="10px"
+        borderBottomColor="transparent"
+      />
+      <Flex
+        backgroundColor={colors[efficiency]}
+        width="full"
+        height="full"
+        justifyContent="end"
+        alignItems="center"
+        paddingRight="xxs"
+      >
+        <Text color="white" textStyle="heading4">
+          {efficiency}
+        </Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default EnergyLabel;

--- a/src/components/energyLabel/index.tsx
+++ b/src/components/energyLabel/index.tsx
@@ -10,17 +10,17 @@ interface Props {
   efficiency: Efficiency;
 }
 
-const EnergyLabel: FC<Props> = ({ efficiency }) => {
-  const colors: Record<Efficiency, `#${string}`> = {
-    A: '#4CA651',
-    B: '#54B646',
-    C: '#CAD143',
-    D: '#FEF050',
-    E: '#F1AE3D',
-    F: '#EE6E2D',
-    G: '#D02F26',
-  };
+const colors: Record<Efficiency, string> = {
+  A: '#4CA651',
+  B: '#54B646',
+  C: '#CAD143',
+  D: '#FEF050',
+  E: '#F1AE3D',
+  F: '#EE6E2D',
+  G: '#D02F26',
+};
 
+const EnergyLabel: FC<Props> = ({ efficiency }) => {
   return (
     <Flex height="20px" width="40px">
       <Box

--- a/src/components/energyLabel/index.tsx
+++ b/src/components/energyLabel/index.tsx
@@ -37,7 +37,7 @@ const EnergyLabel: FC<Props> = ({ efficiency }) => {
         height="full"
         justifyContent="end"
         alignItems="center"
-        paddingRight="xxs"
+        paddingRight="xs"
       >
         <Text color="white" textStyle="heading4">
           {efficiency}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export { default as Checkbox } from './checkbox';
 export { default as DatePicker } from './datePicker';
 export { default as DevOverlay } from './devOverlay';
 export { default as Divider } from './divider';
+export { default as EnergyLabel } from './energyLabel';
 export { default as Flex } from './flex';
 export { default as FormControl } from './formControl';
 export { default as FormLabel } from './formLabel';


### PR DESCRIPTION
References [DM-726](https://autoricardo.atlassian.net/browse/DM-726)

## Motivation and context

To display the efficiency of a car on the new PDP, we need an energy label component. Colors and sizing are not using the tokens, but those are given by the European commission, so we use those.

## Before

No energy label component

## After

Energy label component

## How to test

https://talamcol-energy-label.components-pkg.branch.autoscout24.ch/?path=/story/components-data-display-energy-label--energy-label