### PR TITLE
fix: forward refs for input-like components & links

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC } from 'react';
+import React, { ChangeEvent, forwardRef } from 'react';
 import { Checkbox as ChakraCheckbox } from '@chakra-ui/react';
 
 interface Props {
@@ -11,25 +11,32 @@ interface Props {
   isInvalid?: boolean;
 }
 
-const Checkbox: FC<Props> = ({
-  name,
-  value,
-  isDisabled = false,
-  isChecked = false,
-  onChange,
-  label,
-  isInvalid,
-}) => (
-  <ChakraCheckbox
-    name={name}
-    value={value}
-    isDisabled={isDisabled}
-    isChecked={isChecked}
-    onChange={onChange}
-    isInvalid={isInvalid}
-  >
-    {label}
-  </ChakraCheckbox>
+const Checkbox = forwardRef<HTMLInputElement, Props>(
+  (
+    {
+      name,
+      value,
+      isDisabled = false,
+      isChecked = false,
+      onChange,
+      label,
+      isInvalid,
+    },
+    ref
+  ) => (
+    <ChakraCheckbox
+      ref={ref}
+      name={name}
+      value={value}
+      isDisabled={isDisabled}
+      isChecked={isChecked}
+      onChange={onChange}
+      isInvalid={isInvalid}
+    >
+      {label}
+    </ChakraCheckbox>
+  )
 );
+Checkbox.displayName = 'Checkbox';
 
 export default Checkbox;

--- a/src/components/datePicker/index.tsx
+++ b/src/components/datePicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { forwardRef } from 'react';
 import { Input, InputProps } from '@chakra-ui/react';
 
 type Props = {
@@ -7,15 +7,19 @@ type Props = {
   value?: string;
 } & Pick<InputProps, 'onFocus' | 'onBlur' | 'onChange'>;
 
-const DatePicker: FC<Props> = ({ min, ...props }) => {
-  return (
-    <Input
-      {...props}
-      type="date"
-      min={min ? min.toISOString().split('T')[0] : undefined}
-    />
-  );
-};
+const DatePicker = forwardRef<HTMLInputElement, Props>(
+  ({ min, ...props }, ref) => {
+    return (
+      <Input
+        {...props}
+        type="date"
+        min={min ? min.toISOString().split('T')[0] : undefined}
+        ref={ref}
+      />
+    );
+  }
+);
+DatePicker.displayName = 'DatePicker';
 
 export default DatePicker;
 export { Props as DatePickerProps };

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -1,4 +1,8 @@
-import React, { ChangeEventHandler, FC, FocusEventHandler } from 'react';
+import React, {
+  ChangeEventHandler,
+  FocusEventHandler,
+  forwardRef,
+} from 'react';
 import { Input as ChakraInput } from '@chakra-ui/react';
 
 import { useDebouncedOnChange } from '../hooks';
@@ -17,18 +21,26 @@ type Props = {
   debounce?: number;
 };
 
-const Input: FC<Props> = ({ onChange, onBlur, debounce, ...props }) => {
-  const { onBlur: onBlurHandler, onChange: onChangeHandler } =
-    useDebouncedOnChange({
-      onBlur,
-      onChange,
-      debounce,
-    });
+const Input = forwardRef<HTMLInputElement, Props>(
+  ({ onChange, onBlur, debounce, ...props }, ref) => {
+    const { onBlur: onBlurHandler, onChange: onChangeHandler } =
+      useDebouncedOnChange({
+        onBlur,
+        onChange,
+        debounce,
+      });
 
-  return (
-    <ChakraInput {...props} onChange={onChangeHandler} onBlur={onBlurHandler} />
-  );
-};
+    return (
+      <ChakraInput
+        {...props}
+        onChange={onChangeHandler}
+        onBlur={onBlurHandler}
+        ref={ref}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
 
 export default Input;
 export { Props as InputProps };

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, FC, ReactElement, ReactNode } from 'react';
+import React, { ElementType, forwardRef, ReactElement, ReactNode } from 'react';
 import { chakra, useMultiStyleConfig } from '@chakra-ui/react';
 
 interface Props {
@@ -11,38 +11,45 @@ interface Props {
   [key: string]: unknown;
 }
 
-const Link: FC<Props> = ({
-  as = chakra.a,
-  children,
-  isExternal = false,
-  rel,
-  leftIcon,
-  rightIcon,
-  ...rest
-}) => {
-  const styles = useMultiStyleConfig(`Link`);
+const Link = forwardRef<HTMLAnchorElement, Props>(
+  (
+    {
+      as = chakra.a,
+      children,
+      isExternal = false,
+      rel,
+      leftIcon,
+      rightIcon,
+      ...rest
+    },
+    ref
+  ) => {
+    const styles = useMultiStyleConfig(`Link`);
 
-  const Component = chakra(as, {
-    baseStyle: styles.link,
-  });
+    const Component = chakra(as, {
+      baseStyle: styles.link,
+    });
 
-  const textStyle = {
-    ...(leftIcon ? styles.leftIcon : {}),
-    ...(rightIcon ? styles.rightIcon : {}),
-  };
+    const textStyle = {
+      ...(leftIcon ? styles.leftIcon : {}),
+      ...(rightIcon ? styles.rightIcon : {}),
+    };
 
-  return (
-    <Component
-      target={isExternal ? '_blank' : undefined}
-      rel={rel || isExternal ? 'noopener noreferrer' : undefined}
-      {...rest}
-    >
-      {leftIcon}
-      <chakra.span __css={textStyle}>{children}</chakra.span>
-      {rightIcon}
-    </Component>
-  );
-};
+    return (
+      <Component
+        target={isExternal ? '_blank' : undefined}
+        rel={rel || isExternal ? 'noopener noreferrer' : undefined}
+        ref={ref}
+        {...rest}
+      >
+        {leftIcon}
+        <chakra.span __css={textStyle}>{children}</chakra.span>
+        {rightIcon}
+      </Component>
+    );
+  }
+);
+Link.displayName = 'Link';
 
 export default Link;
 export { Props as LinkProps };

--- a/src/components/radio/RadioListItem.tsx
+++ b/src/components/radio/RadioListItem.tsx
@@ -1,9 +1,12 @@
-import React, { FC, PropsWithChildren } from 'react';
+import React, { forwardRef, PropsWithChildren } from 'react';
 import { useRadio, UseRadioProps } from '@chakra-ui/react';
 
 import Box from '../box';
 
-export const RadioListItem: FC<PropsWithChildren<UseRadioProps>> = (props) => {
+export const RadioListItem = forwardRef<
+  HTMLInputElement,
+  PropsWithChildren<UseRadioProps>
+>((props, ref) => {
   const { getInputProps, getCheckboxProps } = useRadio(props);
 
   const input = getInputProps();
@@ -11,7 +14,7 @@ export const RadioListItem: FC<PropsWithChildren<UseRadioProps>> = (props) => {
 
   return (
     <Box as="label" width="full">
-      <input {...input} />
+      <input {...input} ref={ref} />
       <Box
         {...checkbox}
         cursor="pointer"
@@ -30,4 +33,5 @@ export const RadioListItem: FC<PropsWithChildren<UseRadioProps>> = (props) => {
       </Box>
     </Box>
   );
-};
+});
+RadioListItem.displayName = 'RadioListItem';

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC } from 'react';
+import React, { ChangeEvent, forwardRef } from 'react';
 import { Radio as ChakraRadio } from '@chakra-ui/react';
 
 interface Props {
@@ -12,29 +12,36 @@ interface Props {
   isDisabled?: boolean;
 }
 
-const Radio: FC<Props> = ({
-  name,
-  value,
-  label,
-  size = 'md',
-  onChange,
-  isChecked = false,
-  isInvalid,
-  isDisabled = false,
-}) => {
-  return (
-    <ChakraRadio
-      name={name}
-      value={value}
-      size={size}
-      onChange={onChange}
-      isChecked={isChecked}
-      isInvalid={isInvalid}
-      isDisabled={isDisabled}
-    >
-      {label}
-    </ChakraRadio>
-  );
-};
+const Radio = forwardRef<HTMLInputElement, Props>(
+  (
+    {
+      name,
+      value,
+      label,
+      size = 'md',
+      onChange,
+      isChecked = false,
+      isInvalid,
+      isDisabled = false,
+    },
+    ref
+  ) => {
+    return (
+      <ChakraRadio
+        name={name}
+        value={value}
+        size={size}
+        onChange={onChange}
+        isChecked={isChecked}
+        isInvalid={isInvalid}
+        isDisabled={isDisabled}
+        ref={ref}
+      >
+        {label}
+      </ChakraRadio>
+    );
+  }
+);
+Radio.displayName = 'Radio';
 
 export default Radio;

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { forwardRef } from 'react';
 import {
   Select as ChakraSelect,
   SelectProps as ChakraSelectProps,
@@ -30,16 +30,19 @@ type Props = Pick<
   name: string;
 } & (OptionsAndValue<string> | OptionsAndValue<number>);
 
-const Select: FC<Props> = ({ options, ...props }) => {
-  return (
-    <ChakraSelect {...props} icon={<ChevronDownLargeIcon />}>
-      {options.map((option) => (
-        <option value={option.value} key={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </ChakraSelect>
-  );
-};
+const Select = forwardRef<HTMLSelectElement, Props>(
+  ({ options, ...props }, ref) => {
+    return (
+      <ChakraSelect {...props} icon={<ChevronDownLargeIcon />} ref={ref}>
+        {options.map((option) => (
+          <option value={option.value} key={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </ChakraSelect>
+    );
+  }
+);
+Select.displayName = 'Select';
 
 export default Select;

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -1,4 +1,8 @@
-import React, { ChangeEventHandler, FC, FocusEventHandler } from 'react';
+import React, {
+  ChangeEventHandler,
+  FocusEventHandler,
+  forwardRef,
+} from 'react';
 
 import { Textarea as ChakraTextarea } from '@chakra-ui/react';
 
@@ -16,8 +20,9 @@ interface Props {
   cols?: number;
 }
 
-const Textarea: FC<Props> = ({ ...props }) => {
-  return <ChakraTextarea {...props} />;
-};
+const Textarea = forwardRef<HTMLTextAreaElement, Props>(({ ...props }, ref) => {
+  return <ChakraTextarea {...props} ref={ref} />;
+});
+Textarea.displayName = 'Textarea';
 
 export default Textarea;


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-826

## Motivation and context

`react-hook-form` relies on ref forwarding and uncontrolled inputs. To enable that we add `forwardRef` for input-like components that can be used in forms.

