### PR TITLE
fix(Spinner): Export component

### DIFF
--- a/src/components/center/index.tsx
+++ b/src/components/center/index.tsx
@@ -1,9 +1,14 @@
-import React, { FC, PropsWithChildren } from 'react';
-import { Center as ChakraCenter } from '@chakra-ui/react';
+import React, { FC } from 'react';
+import {
+  Center as ChakraCenter,
+  CenterProps as ChakraCenterProps,
+} from '@chakra-ui/react';
 
-const Center: FC<PropsWithChildren> = ({ children }) => (
+type CenterProps = Pick<ChakraCenterProps, 'children' | 'padding'>;
+
+const Center: FC<CenterProps> = ({ children }) => (
   <ChakraCenter>{children}</ChakraCenter>
 );
 
 export default Center;
-export { PropsWithChildren as CenterProps };
+export { CenterProps };

--- a/src/components/center/index.tsx
+++ b/src/components/center/index.tsx
@@ -6,8 +6,8 @@ import {
 
 type CenterProps = Pick<ChakraCenterProps, 'children' | 'padding'>;
 
-const Center: FC<CenterProps> = ({ children }) => (
-  <ChakraCenter>{children}</ChakraCenter>
+const Center: FC<CenterProps> = ({ children, padding }) => (
+  <ChakraCenter padding={padding}>{children}</ChakraCenter>
 );
 
 export default Center;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -37,6 +37,7 @@ export { default as Show } from './show';
 export { default as SimpleGrid } from './simpleGrid';
 export { default as SimpleHeader } from './simpleHeader';
 export { default as Stack } from './stack';
+export { default as Spinner } from './spinner';
 export { default as Text } from './text';
 export { default as Textarea } from './textarea';
 export { default as Tooltip } from './tooltip';

--- a/src/components/spinner/index.tsx
+++ b/src/components/spinner/index.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { Spinner as ChakraSpinner } from '@chakra-ui/react';
 
 type Props = {
-  size: 'xs' | 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 };
 
 const Spinner: FC<Props> = ({ size }) => (


### PR DESCRIPTION
References N/A

## Motivation and context

Forgot to export the Spinner component.
Since I'm on it allowing padding on the Center component so I don't need to wrap a div for the spacing