### PR TITLE
feat: add small chevron icons

### DIFF
--- a/src/components/icons/ChevronLeftSmallIcon.tsx
+++ b/src/components/icons/ChevronLeftSmallIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { createIcon } from '@chakra-ui/react';
+
+export const ChevronLeftSmallIcon = createIcon({
+  displayName: 'ChevronLeftLarge',
+  viewBox: '0 0 24 24',
+  path: (
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M14 5L7.00006 11.9999L14 18.9999L15.415 17.5849L9.83006 11.9999L15.415 6.415L14 5Z"
+      fill="currentColor"
+    />
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/ChevronRightSmallIcon.tsx
+++ b/src/components/icons/ChevronRightSmallIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { createIcon } from '@chakra-ui/react';
+
+export const ChevronRightSmallIcon = createIcon({
+  displayName: 'ChevronRightLarge',
+  viewBox: '0 0 24 24',
+  path: (
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M10 5L16.9999 11.9999L9.99996 18.9999L8.58496 17.5849L14.1699 11.9999L8.58503 6.415L10 5Z"
+      fill="currentColor"
+    />
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -6,6 +6,8 @@ export { ChevronDownSmallIcon } from './ChevronDownSmallIcon';
 export { ChevronDownLargeIcon } from './ChevronDownLargeIcon';
 export { ChevronLeftLargeIcon } from './ChevronLeftLargeIcon';
 export { ChevronRightLargeIcon } from './ChevronRightLargeIcon';
+export { ChevronLeftSmallIcon } from './ChevronLeftSmallIcon';
+export { ChevronRightSmallIcon } from './ChevronRightSmallIcon';
 export { ErrorIcon } from './ErrorIcon';
 export { CloseIcon } from './CloseIcon';
 export { CheckmarkIcon } from './CheckmarkIcon';


### PR DESCRIPTION
## Motivation and context

Left and right small chevron icons

## Before

N/A

## After

![Screenshot 2022-11-08 at 22 17 24](https://user-images.githubusercontent.com/2486360/200677371-82ee1ae1-fb7b-4e2d-99d1-362e784a8666.png)

## How to test

https://boyarskiy-icons.components-pkg.branch.autoscout24.ch/?path=/story/foundations-icons--overview
