### PR TITLE
feat: arrow events on fullscreen carousel

### DIFF
--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -83,6 +83,24 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
     embla.on('select', onSelect);
   }, [embla, onSelect]);
 
+  useEffect(() => {
+    const keydownListener = (e: KeyboardEvent) => {
+      if (fullScreen) {
+        switch (e.code) {
+          case 'ArrowRight':
+            scrollNext();
+            break;
+          case 'ArrowLeft':
+            scrollPrev();
+            break;
+        }
+      }
+    };
+
+    document.addEventListener('keydown', keydownListener);
+    return () => document.removeEventListener('keydown', keydownListener);
+  }, [fullScreen, scrollNext, scrollPrev]);
+
   const prerenderFallbackSlide = startIndex !== 0 && !emblaRef;
 
   return prerenderFallbackSlide ? (


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-799

## Motivation and context

Adds previous/next navigation events on the left and right arrow keys respectively

## How to test

- Interact with the fullscreen gallery in storybook
- For best results use the  link to open canvas in new tab:
<img width="162" alt="Screenshot 2022-11-10 at 16 16 57" src="https://user-images.githubusercontent.com/144707/201133685-2e30ac34-926c-421c-bd3e-7eea35b2e429.png">
