### PR TITLE
fix: add more resources for release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
 
   release:
     <<: *DOCKER_NODE
-    resource_class: small
+    resource_class: medium
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
## Motivation and context

Add more resources for `release` job to prevent failing with an error:
```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

<img width="1464" alt="Screenshot 2022-11-15 at 09 58 36" src="https://user-images.githubusercontent.com/2486360/201875902-51347955-22ba-40b3-8a31-8831b913c379.png">

https://app.circleci.com/pipelines/github/smg-automotive/components-pkg/2369/workflows/dd51c921-f9e1-41fa-8776-c6688f0d0ba0/jobs/10967

## Before

small resources

## After

medium resources

## How to test

[Add a deep link and instructions how to verify the new behavior]
