### PR TITLE
feat: support slide enter and leave events

### DIFF
--- a/src/components/carousel/StoryTemplate.tsx
+++ b/src/components/carousel/StoryTemplate.tsx
@@ -34,6 +34,8 @@ interface Props {
     numberOfSlides: number;
     onSlideClick: boolean;
     fullScreen: boolean;
+    onSlideEnter: boolean;
+    onSlideLeave: boolean;
   };
   action: (message: string) => (...args: unknown[]) => void;
 }
@@ -90,6 +92,12 @@ const FullScreenVariant: FC<Props> = ({ args, action }) => {
           slide: (
             <Slide index={i + 1} key={`slide-${i + 1}`} fullScreen={true} />
           ),
+          onSlideEnter: args.onSlideEnter
+            ? () => action('onSlideEnter')(i)
+            : undefined,
+          onSlideLeave: args.onSlideLeave
+            ? () => action('onSlideLeave')(i)
+            : undefined,
           thumbnail: (
             <Slide index={i + 1} key={`slide-${i + 1}`} fullScreen={true} />
           ),

--- a/src/components/carousel/StoryTemplate.tsx
+++ b/src/components/carousel/StoryTemplate.tsx
@@ -35,7 +35,7 @@ interface Props {
     onSlideClick: boolean;
     fullScreen: boolean;
   };
-  action: (message: string) => void;
+  action: (message: string) => (...args: unknown[]) => void;
 }
 
 interface SlideProps {
@@ -69,9 +69,7 @@ const DefaultVariant: FC<Props> = ({ args, action }) => {
   return (
     <FullHeight>
       <Carousel
-        onSlideClick={
-          args.onSlideClick ? () => action('onSlideClick') : undefined
-        }
+        onSlideClick={args.onSlideClick ? action('onSlideClick') : undefined}
       >
         {Array.from({ length: args.numberOfSlides || 6 }).map((_, i) => (
           <Slide index={i + 1} key={`slide-${i + 1}`} fullScreen={false} />
@@ -86,9 +84,7 @@ const FullScreenVariant: FC<Props> = ({ args, action }) => {
     <FullHeight>
       <Carousel
         fullScreen={true}
-        onSlideClick={
-          args.onSlideClick ? () => action('onSlideClick') : undefined
-        }
+        onSlideClick={args.onSlideClick ? action('onSlideClick') : undefined}
       >
         {Array.from({ length: args.numberOfSlides || 6 }).map((_, i) => ({
           slide: (

--- a/src/components/carousel/__tests__/Index.Test.tsx
+++ b/src/components/carousel/__tests__/Index.Test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 import Carousel from '../index';
 
@@ -28,6 +28,74 @@ describe('<Carousel />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('triggers the onSlideEnter event on the first slide', () => {
+    const mockOnEnter = jest.fn();
+
+    render(
+      <Carousel fullScreen={true}>
+        {[
+          {
+            slide: <div>slide 1</div>,
+            onSlideEnter: mockOnEnter,
+            thumbnail: <div>thumbnail 1</div>,
+          },
+          { slide: <div>slide 2</div>, thumbnail: <div>thumbnail 2</div> },
+          { slide: <div>slide 3</div>, thumbnail: <div>thumbnail 3</div> },
+        ]}
+      </Carousel>
+    );
+
+    return waitFor(() => expect(mockOnEnter).toHaveBeenCalled());
+  });
+
+  it('triggers the onSlideEnter event on the navigation', () => {
+    const mockOnEnter = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <Carousel fullScreen={true}>
+        {[
+          { slide: <div>slide 1</div>, thumbnail: <div>thumbnail 1</div> },
+          {
+            slide: <div>slide 2</div>,
+            onSlideEnter: mockOnEnter,
+            thumbnail: <div>thumbnail 2</div>,
+          },
+          { slide: <div>slide 3</div>, thumbnail: <div>thumbnail 3</div> },
+        ]}
+      </Carousel>
+    );
+
+    act(() => {
+      user.click(screen.getByText('thumbnail 2'));
+    });
+    return waitFor(() => expect(mockOnEnter).toHaveBeenCalled());
+  });
+
+  it('triggers the onSlideLEave event on the navigation', () => {
+    const mockOnLeave = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <Carousel fullScreen={true}>
+        {[
+          {
+            slide: <div>slide 1</div>,
+            onSlideLeave: mockOnLeave,
+            thumbnail: <div>thumbnail 1</div>,
+          },
+          { slide: <div>slide 2</div>, thumbnail: <div>thumbnail 2</div> },
+          { slide: <div>slide 3</div>, thumbnail: <div>thumbnail 3</div> },
+        ]}
+      </Carousel>
+    );
+
+    act(() => {
+      user.click(screen.getByText('thumbnail 2'));
+    });
+    return waitFor(() => expect(mockOnLeave).toHaveBeenCalled());
   });
 
   it('should create the carousel in infinite mode', async () => {

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -55,6 +55,8 @@ export const Template = (args) => {
       onSlideClick: true,
       fullScreen: true,
       numberOfSlides: 6,
+      onSlideEnter: true,
+      onSlideLeave: true,
     }}
   >
     {Template.bind({})}

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -20,7 +20,12 @@ type DefaultProps = {
   children: ReactNode[];
 } & SharedProps;
 
-type FullScreenSlide = { slide: ReactNode; thumbnail: ReactNode };
+type FullScreenSlide = {
+  slide: ReactNode;
+  thumbnail: ReactNode;
+  onSlideEnter?: () => void;
+  onSlideLeave?: () => void;
+};
 type FullScreenProps = {
   fullScreen: true;
   children: Array<FullScreenSlide>;
@@ -115,6 +120,29 @@ const Carousel: FC<Props> = (props) => {
     document.addEventListener('keydown', keydownListener);
     return () => document.removeEventListener('keydown', keydownListener);
   }, [fullScreen, scrollNext, scrollPrev]);
+
+  const current = mainCarousel?.selectedScrollSnap();
+  const previous = mainCarousel?.previousScrollSnap();
+
+  useEffect(() => {
+    if (!props.fullScreen) {
+      return;
+    }
+
+    if (current !== undefined) {
+      const currentSlide = props.children[current];
+      if (currentSlide.onSlideEnter) {
+        currentSlide.onSlideEnter();
+      }
+    }
+
+    if (previous !== undefined && previous !== current) {
+      const previousSlide = props.children[previous];
+      if (previousSlide.onSlideLeave) {
+        previousSlide.onSlideLeave();
+      }
+    }
+  }, [current, previous, props.fullScreen, props.children]);
 
   const prerenderFallbackSlide = startIndex !== 0 && !mainCarouselRef;
 


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-877

## Motivation and context

When fixing the video sliding bug we noticed that video is still playing when the slide was swiped away.
This PR adds optional `onSlideEnter` and `onSlideLeave` events that can be used to take actions when the slide enters and leaves the carousel respectively.

## How to test

Interact with fullscreen carousel in storybook and notice that respective events are fired
