### PR TITLE
feat: adding indeterminate checkbox state

### DIFF
--- a/src/components/checkbox/index.stories.mdx
+++ b/src/components/checkbox/index.stories.mdx
@@ -85,3 +85,22 @@ export const Template = ({ isChecked, ...args }) => {
     </Stack>
   </Story>
 </Canvas>
+
+## Indeterminate
+
+<Canvas>
+  <Story
+    name="Indeterminate"
+    args={{
+      name: 'Control',
+      value: 1,
+      isChecked: false,
+      isDisabled: false,
+      isInvalid: false,
+      isIndeterminate: true,
+      label: 'Indeterminate',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/checkbox/index.stories.mdx
+++ b/src/components/checkbox/index.stories.mdx
@@ -18,6 +18,34 @@ export const Template = ({ isChecked, ...args }) => {
   );
 };
 
+export const IndeterminateTemplate = () => {
+  const [checkedItems, setCheckedItems] = useState([false, false]);
+  const allChecked = checkedItems.every(Boolean);
+  const isIndeterminate = checkedItems.some(Boolean) && !allChecked;
+  return (
+    <>
+      <Checkbox
+        label="Parent Checkbox"
+        isChecked={allChecked}
+        isIndeterminate={isIndeterminate}
+        onChange={(e) => setCheckedItems([e.target.checked, e.target.checked])}
+      />
+      <Stack pl="lg" mt="s" spacing="s">
+        <Checkbox
+          label="Child Checkbox 1"
+          isChecked={checkedItems[0]}
+          onChange={(e) => setCheckedItems([e.target.checked, checkedItems[1]])}
+        />
+        <Checkbox
+          label="Child Checkbox 2"
+          isChecked={checkedItems[1]}
+          onChange={(e) => setCheckedItems([checkedItems[0], e.target.checked])}
+        />
+      </Stack>
+    </>
+  );
+};
+
 # Checkbox
 
 ## Overview
@@ -89,18 +117,5 @@ export const Template = ({ isChecked, ...args }) => {
 ## Indeterminate
 
 <Canvas>
-  <Story
-    name="Indeterminate"
-    args={{
-      name: 'Control',
-      value: 1,
-      isChecked: false,
-      isDisabled: false,
-      isInvalid: false,
-      isIndeterminate: true,
-      label: 'Indeterminate',
-    }}
-  >
-    {Template.bind({})}
-  </Story>
+  <Story name="Indeterminate">{IndeterminateTemplate.bind({})}</Story>
 </Canvas>

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -9,6 +9,7 @@ interface Props {
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   label?: string;
   isInvalid?: boolean;
+  isIndeterminate?: boolean;
 }
 
 const Checkbox = forwardRef<HTMLInputElement, Props>(
@@ -21,6 +22,7 @@ const Checkbox = forwardRef<HTMLInputElement, Props>(
       onChange,
       label,
       isInvalid,
+      isIndeterminate = false,
     },
     ref
   ) => (
@@ -32,6 +34,7 @@ const Checkbox = forwardRef<HTMLInputElement, Props>(
       isChecked={isChecked}
       onChange={onChange}
       isInvalid={isInvalid}
+      isIndeterminate={isIndeterminate}
     >
       {label}
     </ChakraCheckbox>


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-418

## Motivation and context

We are missing indeterminate state for checkbox currently so we are adding support for it by adding new prop on checkbox component.

## Before

N/A

## After

We can now toggle indeterminate state by passing `isIndeterminate` prop to our checkbox component.

<img width="557" alt="Screenshot 2022-11-17 at 15 27 15" src="https://user-images.githubusercontent.com/12614035/202473174-fee7d89c-3d91-4d4a-bf65-607990ca9b0b.png">

<img width="149" alt="Screenshot 2022-11-17 at 15 26 00" src="https://user-images.githubusercontent.com/12614035/202473106-48b94191-f9bd-406c-8436-782a56140ecb.png">

## How to test

https://checkbox-indeterminate-state.components-pkg.branch.autoscout24.ch/?path=/story/components-forms-checkbox--indeterminate
