### PR TITLE
feat: expose chakra props for Grid components

### DIFF
--- a/src/components/grid/GridItem.tsx
+++ b/src/components/grid/GridItem.tsx
@@ -5,13 +5,11 @@ import {
   GridItemProps,
 } from '@chakra-ui/react';
 
-type Props = Pick<GridItemProps, 'children' | 'area'>;
-
-const GridItem = forwardRef<Props, 'div'>((props, ref) => {
+const GridItem = forwardRef<GridItemProps, 'div'>((props, ref) => {
   return <ChakraGridItem {...props} ref={ref} />;
 });
 
 GridItem.displayName = 'GridItem';
 
 export default GridItem;
-export { Props as GridProps };
+export { GridItemProps };

--- a/src/components/grid/index.tsx
+++ b/src/components/grid/index.tsx
@@ -1,22 +1,11 @@
 import React from 'react';
 import { Grid as ChakraGrid, forwardRef, GridProps } from '@chakra-ui/react';
 
-type Props = Pick<
-  GridProps,
-  | 'children'
-  | 'templateAreas'
-  | 'gap'
-  | 'templateColumns'
-  | 'templateRows'
-  | 'padding'
-  | 'minHeight'
->;
-
-const Grid = forwardRef<Props, 'div'>((props, ref) => {
+const Grid = forwardRef<GridProps, 'div'>((props, ref) => {
   return <ChakraGrid {...props} ref={ref} />;
 });
 
 Grid.displayName = 'Grid';
 
 export default Grid;
-export { Props as GridProps };
+export { GridProps };

--- a/src/components/layout/app/Content.tsx
+++ b/src/components/layout/app/Content.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { forwardRef } from '@chakra-ui/react';
 
-import GridItem, { GridProps } from '../../grid/GridItem';
+import GridItem, { GridItemProps } from '../../grid/GridItem';
 
-const AppLayoutContent = forwardRef<GridProps, 'div'>((props, ref) => {
+const AppLayoutContent = forwardRef<GridItemProps, 'div'>((props, ref) => {
   return <GridItem area="content" ref={ref} {...props} />;
 });
 

--- a/src/components/layout/app/Footer.tsx
+++ b/src/components/layout/app/Footer.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { forwardRef } from '@chakra-ui/react';
 
-import GridItem, { GridProps } from '../../grid/GridItem';
+import GridItem, { GridItemProps } from '../../grid/GridItem';
 
-const AppLayoutFooter = forwardRef<GridProps, 'div'>((props, ref) => {
+const AppLayoutFooter = forwardRef<GridItemProps, 'div'>((props, ref) => {
   return <GridItem area="footer" ref={ref} {...props} />;
 });
 

--- a/src/components/layout/app/Header.tsx
+++ b/src/components/layout/app/Header.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { forwardRef } from '@chakra-ui/react';
 
-import GridItem, { GridProps } from '../../grid/GridItem';
+import GridItem, { GridItemProps } from '../../grid/GridItem';
 
-const AppLayoutHeader = forwardRef<GridProps, 'div'>((props, ref) => {
+const AppLayoutHeader = forwardRef<GridItemProps, 'div'>((props, ref) => {
   return <GridItem area="header" ref={ref} {...props} />;
 });
 


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

For the new PDP, we need to whitelist even more props for the Grid components (sticky section on the right, full height, start position, different gaps for column and row etc.). Since this is a layout component similar to `Flex` or `Box` I don't see a reason to restrict it.

## Before

Subset of the chakra grid props

## After

allow all chakra props

