### PR TITLE
Lint hidden folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 !/.storybook
 !/.jest
+!.prettierrc.js

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require("@smg-automotive/eslint-config/prettier"),
-}
+  ...require('@smg-automotive/eslint-config/prettier'),
+};


### PR DESCRIPTION
FE-61

## Motivation and context

By default, hidden folders are not linted by eslint, we need to add them to the eslint ignore file with a !. 
I tried to come up with something global that could be done at the eslint pkg level but could not find anything. 

## Before

.jest folder was not linted

## After

.jest folder is linter
