### PR TITLE
fix: DevOverlay activeTheme type

### DIFF
--- a/src/components/devOverlay/__tests__/DevOverlay.Test.tsx
+++ b/src/components/devOverlay/__tests__/DevOverlay.Test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import DevOverlay from '../index';
-import { Brand } from '../../../types/brand';
 
 describe('The DevOverlay Component', () => {
   it('renders the dev overlay', () => {
@@ -11,7 +10,7 @@ describe('The DevOverlay Component', () => {
         variables={[]}
         hideDevOverlay={jest.fn()}
         toggleTheme={jest.fn()}
-        activeTheme={Brand.as24}
+        activeTheme="as24"
       />
     );
 
@@ -29,7 +28,7 @@ describe('The DevOverlay Component', () => {
         ]}
         hideDevOverlay={jest.fn()}
         toggleTheme={jest.fn()}
-        activeTheme={Brand.as24}
+        activeTheme="as24"
       />
     );
 

--- a/src/components/devOverlay/index.stories.mdx
+++ b/src/components/devOverlay/index.stories.mdx
@@ -17,10 +17,10 @@ import { Brand } from '../../types/brand';
 export const Template = ({ ...args }) => {
   const [{ activeTheme }, updateArgs] = useArgs();
   const toggleTheme = () => {
-    if (activeTheme === Brand.as24) {
-      return updateArgs({ activeTheme: Brand.ms24 });
+    if (activeTheme === 'as24') {
+      return updateArgs({ activeTheme: 'ms24' });
     }
-    return updateArgs({ activeTheme: Brand.as24 });
+    return updateArgs({ activeTheme: 'as24' });
   };
   return (
     <ThemeProvider theme={activeTheme}>
@@ -49,11 +49,11 @@ export const Template = ({ ...args }) => {
           value: 'storybook',
         },
       ],
-      activeTheme: Brand.as24,
+      activeTheme: 'as24',
     }}
     argTypes={{
       activeTheme: {
-        options: [Brand.as24, Brand.ms24],
+        options: ['as24', 'ms24'],
         control: 'select',
       },
     }}

--- a/src/components/devOverlay/index.tsx
+++ b/src/components/devOverlay/index.tsx
@@ -34,7 +34,7 @@ const DevOverlay: FC<DevOverlayProps> = ({
   toggleTheme,
   activeTheme,
 }) => {
-  const isThemeSwitcherChecked = Brand.as24 !== activeTheme;
+  const isThemeSwitcherChecked = 'as24' !== activeTheme;
 
   return (
     <Box

--- a/src/components/footer/config/__tests__/index.Test.ts
+++ b/src/components/footer/config/__tests__/index.Test.ts
@@ -1,13 +1,12 @@
 /* eslint-disable unicorn/filename-case */
 import { FooterConfig } from '../factory';
-import { Brand } from '../../../../types/brand';
 import { footerConfig } from '..';
 
 describe('The footer configuration', () => {
   it('returns a mapped instance', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,
-      brand: Brand.ms24,
+      brand: 'ms24',
       environment: 'production',
       useAbsoluteUrls: true,
     });
@@ -23,7 +22,7 @@ describe('The footer configuration', () => {
   it('returns six sections', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,
-      brand: Brand.ms24,
+      brand: 'ms24',
       environment: 'production',
       useAbsoluteUrls: true,
     });
@@ -34,7 +33,7 @@ describe('The footer configuration', () => {
   it('returns only one visible title per section', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,
-      brand: Brand.ms24,
+      brand: 'ms24',
       environment: 'production',
       useAbsoluteUrls: true,
     });
@@ -48,7 +47,7 @@ describe('The footer configuration', () => {
   it('returns only one link item per app type', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,
-      brand: Brand.ms24,
+      brand: 'ms24',
       environment: 'production',
       useAbsoluteUrls: true,
     });
@@ -61,7 +60,7 @@ describe('The footer configuration', () => {
   it('returns only one link item per social media type', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,
-      brand: Brand.ms24,
+      brand: 'ms24',
       environment: 'production',
       useAbsoluteUrls: true,
     });
@@ -76,7 +75,7 @@ describe('The footer configuration', () => {
   it('returns five company links', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,
-      brand: Brand.ms24,
+      brand: 'ms24',
       environment: 'production',
       useAbsoluteUrls: true,
     });

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -1,4 +1,1 @@
-export const enum Brand {
-  as24 = 'as24',
-  ms24 = 'ms24',
-}
+export type Brand = 'as24' | 'ms24';


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Current activeTheme type doesn't work outside of package

## Before

We couldn't set `as24` or `ms24` as value for `activeTheme` prop 

## After

We can set `as24` or `ms24` as `activeTheme` prop of `DevOverlay` component

## How to test

[Add a deep link and instructions how to verify the new behavior]
