### PR TITLE
fix: referenced opacity as an object

### DIFF
--- a/src/themes/components/carousel.ts
+++ b/src/themes/components/carousel.ts
@@ -1,5 +1,6 @@
 import { ComponentStyleConfig } from '@chakra-ui/react';
 
+import { opacity } from '../shared/opacity';
 import { colors } from '../shared/colors';
 import { hexToRgb } from '../../lib/hexToRgb';
 
@@ -72,7 +73,7 @@ const fullScreen = {
     height: 'full',
   },
   button: {
-    opacity: '100%',
+    opacity: opacity[100],
     backgroundColor: 'black',
   },
   icon: {

--- a/src/themes/components/menu.ts
+++ b/src/themes/components/menu.ts
@@ -4,6 +4,8 @@ import {
 } from '@chakra-ui/styled-system';
 import { menuAnatomy as parts } from '@chakra-ui/anatomy';
 
+import { opacity } from '../shared/opacity';
+
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(parts.keys);
 
@@ -35,7 +37,7 @@ const baseStyleItem = defineStyle({
     bg: 'gray.100',
   },
   _disabled: {
-    opacity: 0.4,
+    opacity: opacity[40],
     cursor: 'not-allowed',
   },
 });

--- a/src/themes/components/switch.ts
+++ b/src/themes/components/switch.ts
@@ -7,6 +7,7 @@ import type {
 } from '@chakra-ui/styled-system';
 import { switchAnatomy as parts } from '@chakra-ui/anatomy';
 
+import { opacity } from '../shared/opacity';
 import { colors as ms24Colors } from '../ms24/colors';
 import { colors as as24Colors } from '../as24/colors';
 
@@ -34,7 +35,7 @@ const baseStyleTrack: SystemStyleFunction = ({ bg, checkedBg }) => {
       boxShadow: 'outline',
     },
     _disabled: {
-      opacity: 0.4,
+      opacity: opacity[40],
       cursor: 'not-allowed',
     },
     _checked: {


### PR DESCRIPTION
## Motivation and context

We were hardcoding the opacity values instead using our tokens.

## Take into consideration

We were not able to used the `opacity` tokens as we are doing for the rest of the tokens like in colors -> `color: 'green50'`because chakra doesn't have any theme key for opacity. Besides we were using different units for opacity and it was not synced with our Design System.

![Screenshot 2022-11-30 at 14 29 27](https://user-images.githubusercontent.com/37380787/205273356-4548bcd6-2c36-491c-9808-10a733a3f55e.png)

I checked in the projects and we are using `opacity` only in the listings-web so far. I will adjusted it as well.

There is also another way to do it by `layerStyle` -> https://chakra-ui.com/docs/styled-system/text-and-layer-styles
but we could face an issue when we want to use it for something else than opacity and we end up with the element that has multiple

## Before

Opacity tokens didn't work and were not passed

## After

We reference opacity as an object.

## How to test

The opacity tokens are triggered in the carousel story and opacity showedCase. 

## Thank you 🦔
