### PR TITLE
fix(pagination): fix total pages

### DIFF
--- a/src/components/pagination/__tests__/Pagination.Test.tsx
+++ b/src/components/pagination/__tests__/Pagination.Test.tsx
@@ -114,7 +114,7 @@ describe('<Pagination />', () => {
         render(
           <Pagination
             totalPages={10}
-            currentPage={10}
+            currentPage={9}
             onChange={mockOnChange}
           />
         );

--- a/src/components/pagination/__tests__/Pagination.Test.tsx
+++ b/src/components/pagination/__tests__/Pagination.Test.tsx
@@ -112,11 +112,7 @@ describe('<Pagination />', () => {
     describe('last page is active', () => {
       it('should not be able to change the page by click on Next button', () => {
         render(
-          <Pagination
-            totalPages={10}
-            currentPage={9}
-            onChange={mockOnChange}
-          />
+          <Pagination totalPages={10} currentPage={9} onChange={mockOnChange} />
         );
 
         expect(screen.getByLabelText('next page')).toBeDisabled();

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -22,47 +22,36 @@ const Pagination: FC<PropsWithChildren<Props>> = (props) => {
   const { onChange, totalPages, currentPage, marginTop, marginBottom } = props;
   const { paginationContainer, dots } = useMultiStyleConfig('Pagination');
 
-  // workaround for pagination API as it starts from 0
-  const totalPagesPlusOne = totalPages + 1;
-  const currentPagePlusOne = currentPage + 1;
-  const pageNumberMinusOne = (pageNumber: number) => pageNumber - 1;
-
   const paginationRange = useMemo(() => {
     // Default number of page buttons: firstPage + lastPage + currentPage + left side dots + right side dots
     const pageButtonsCount = 5;
     const totalPageButtonsCount = siblingCount + pageButtonsCount;
 
-    if (totalPageButtonsCount >= totalPagesPlusOne) {
-      return range(1, totalPagesPlusOne);
+    if (totalPageButtonsCount >= totalPages) {
+      return range(1, totalPages);
     }
 
     const leftSiblingIndex = Math.max(currentPage - siblingCount, 1);
-    const rightSiblingIndex = Math.min(
-      currentPage + siblingCount,
-      totalPagesPlusOne
-    );
+    const rightSiblingIndex = Math.min(currentPage + siblingCount, totalPages);
 
     const shouldShowLeftDots = leftSiblingIndex > 2;
-    const shouldShowRightDots = rightSiblingIndex < totalPagesPlusOne - 2;
+    const shouldShowRightDots = rightSiblingIndex < totalPages - 2;
 
     const firstPageNumber = 1;
-    const lastPageNumber = totalPagesPlusOne;
+    const lastPageNumber = totalPages;
 
     // Show dots on right side
     if (!shouldShowLeftDots && shouldShowRightDots) {
       const leftItemCount = 3 + 2 * siblingCount;
       const leftRange = range(1, leftItemCount);
 
-      return [...leftRange, Dots, totalPagesPlusOne];
+      return [...leftRange, Dots, totalPages];
     }
 
     // Show dots on left side
     if (shouldShowLeftDots && !shouldShowRightDots) {
       const rightItemCount = 3 + 2 * siblingCount;
-      const rightRange = range(
-        totalPagesPlusOne - rightItemCount + 1,
-        totalPagesPlusOne
-      );
+      const rightRange = range(totalPages - rightItemCount + 1, totalPages);
       return [firstPageNumber, Dots, ...rightRange];
     }
 
@@ -73,7 +62,7 @@ const Pagination: FC<PropsWithChildren<Props>> = (props) => {
     }
 
     return [];
-  }, [totalPagesPlusOne, currentPage]);
+  }, [totalPages, currentPage]);
 
   if (paginationRange.length < 2) {
     return null;
@@ -81,6 +70,10 @@ const Pagination: FC<PropsWithChildren<Props>> = (props) => {
 
   const onNext = () => onChange(currentPage + 1);
   const onPrevious = () => onChange(currentPage - 1);
+
+  // workaround for pagination API as it starts from 0
+  const currentPagePlusOne = currentPage + 1;
+  const pageNumberMinusOne = (pageNumber: number) => pageNumber - 1;
 
   const isFirstPage = currentPage === 0;
   const isLastPage =
@@ -118,7 +111,7 @@ const Pagination: FC<PropsWithChildren<Props>> = (props) => {
           <PaginationButton
             key={`paginationButton-${index}`}
             isActive={pageNumber === currentPagePlusOne}
-            ariaLabel={`go to page ${pageNumber} of ${totalPagesPlusOne}`}
+            ariaLabel={`go to page ${pageNumber} of ${totalPages}`}
             onClick={() => onChange(pageNumberMinusOne(pageNumber as number))}
           >
             {pageNumber}


### PR DESCRIPTION

## Motivation and context

Total pages shouldn't be increased by one, because of pagination API.
Pagination API starts from 0, but number of pages (length) doesn't change.

Pages: [0, 1, 2]
Total Pages: 3

## Before

Wrong total pages

## After

Correct total pages

## How to test

https://boyarskiy-pagination-fix.components-pkg.branch.autoscout24.ch/?path=/story/patterns-navigation-pagination--pagination
