### PR TITLE
fix(Link): infinite loop when wrapped with NextLink

### DIFF
--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -1,4 +1,10 @@
-import React, { ElementType, forwardRef, ReactElement, ReactNode } from 'react';
+import React, {
+  ElementType,
+  forwardRef,
+  ReactElement,
+  ReactNode,
+  useMemo,
+} from 'react';
 import { chakra, useMultiStyleConfig } from '@chakra-ui/react';
 
 interface Props {
@@ -26,9 +32,11 @@ const Link = forwardRef<HTMLAnchorElement, Props>(
   ) => {
     const styles = useMultiStyleConfig(`Link`);
 
-    const Component = chakra(as, {
-      baseStyle: styles.link,
-    });
+    const Component = useMemo(() => {
+      return chakra(as, {
+        baseStyle: styles.link,
+      });
+    }, [as, styles.link]);
 
     const textStyle = {
       ...(leftIcon ? styles.leftIcon : {}),


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/VSST-722

## Motivation and context

Using Link component in combination with NextLink caused infinite re-rendering and return an error:

```
<NextLink href="/" passHref={true}>
  <Link>some link</Link>
</NextLink>
```

```
Uncaught [Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.]
```

After research, it looks like it is related to forwardRef, somehow the component re-creates itself in a loop.
I wrapped component creation with `useMemo` to prevent re-creation when `as` is the same.

PS: didn't find solution for other issue that props autocomplete does not work in IDE.

## Before

Link component wrapped with NextLink didn't work.

## After

It is possible to use Link component wrapped with NextLink:

```
<NextLink href="/" passHref={true} legacyBehavior={true}>
  <Link>some link</Link>
</NextLink>
```

Note: starting with Next.js 13, `<NextLink>` renders as `<a>`, so attempting to use `<a>` as a child is invalid. Therefore, we can use `legacyBehavior` prop.

https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor

## How to test

[Add a deep link and instructions how to verify the new behavior]
