### PR TITLE
fix: invalid html attributes for button

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -71,19 +71,21 @@ const Button: FC<Props> = (props) => {
     isDisabled = false,
     as = 'button',
     isExternal,
+    ariaLabel,
+    icon,
     ...rest
   } = props;
 
   return (
     <ChakraButton
-      leftIcon={props.children ? props.leftIcon : props.icon}
+      leftIcon={props.children ? props.leftIcon : icon}
       rightIcon={props.children ? props.rightIcon : undefined}
       iconSpacing={props.children ? 'xs' : 0}
       as={as}
       variant={variant}
       size={size}
       isDisabled={isDisabled}
-      aria-label={props.children ? undefined : props.ariaLabel}
+      aria-label={props.children ? undefined : ariaLabel}
       {...rest}
       {...(props.as === 'a'
         ? {


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

ariaLabel and icon were spread in the `rest` object on the component. Because they are no chakra props, they are not filtered out. This results in invalid HTML:

![image](https://user-images.githubusercontent.com/71456764/206384395-7cc8904a-60a7-44f4-a215-99a85f10cb2a.png)
![image](https://user-images.githubusercontent.com/71456764/206384447-9c1b0a05-d6db-4173-9088-c92a9c39605f.png)
