### PR TITLE
fix: collor of required indicator

### DIFF
--- a/src/themes/components/form.ts
+++ b/src/themes/components/form.ts
@@ -10,8 +10,13 @@ const baseStyleHelperText: SystemStyleObject = {
   color: 'gray.400',
 };
 
+const requiredIndicator: SystemStyleObject = {
+  color: 'red.500',
+};
+
 const baseStyle: PartsStyleObject<typeof parts> = {
   helperText: baseStyleHelperText,
+  requiredIndicator,
 };
 
 export default {


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/VSST-759

## Motivation and context

Change color for required indicator to red.

## Before

Required indicator is grey

## After

Required indicator is red

![Screenshot 2022-12-08 at 15 47 00](https://user-images.githubusercontent.com/2486360/206476726-6815cbb7-3ea0-42ba-a985-f4d4ea18c533.png)

## How to test

[Add a deep link and instructions how to verify the new behavior]
