### PR TITLE
fix(pagination): prevent default on click event

### DIFF
--- a/src/components/pagination/PaginationButton.tsx
+++ b/src/components/pagination/PaginationButton.tsx
@@ -1,11 +1,11 @@
-import React, { FC, PropsWithChildren } from 'react';
+import React, { FC, MouseEvent, PropsWithChildren } from 'react';
 import { chakra, useMultiStyleConfig } from '@chakra-ui/react';
 
 interface Props {
   isDisabled?: boolean;
   isActive?: boolean;
   ariaLabel: string;
-  onClick: () => void;
+  onClick: (e: MouseEvent) => void;
 }
 
 const PaginationButton: FC<PropsWithChildren<Props>> = (props) => {

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useMemo } from 'react';
+import React, { FC, MouseEvent, PropsWithChildren, useMemo } from 'react';
 import { BoxProps, Show, useMultiStyleConfig } from '@chakra-ui/react';
 
 import PaginationButton from './PaginationButton';
@@ -68,8 +68,14 @@ const Pagination: FC<PropsWithChildren<Props>> = (props) => {
     return null;
   }
 
-  const onNext = () => onChange(currentPage + 1);
-  const onPrevious = () => onChange(currentPage - 1);
+  const onNext = (e: MouseEvent) => {
+    e.preventDefault();
+    onChange(currentPage + 1);
+  };
+  const onPrevious = (e: MouseEvent) => {
+    e.preventDefault();
+    onChange(currentPage - 1);
+  };
 
   // workaround for pagination API as it starts from 0
   const currentPagePlusOne = currentPage + 1;
@@ -112,7 +118,10 @@ const Pagination: FC<PropsWithChildren<Props>> = (props) => {
             key={`paginationButton-${index}`}
             isActive={pageNumber === currentPagePlusOne}
             ariaLabel={`go to page ${pageNumber} of ${totalPages}`}
-            onClick={() => onChange(pageNumberMinusOne(pageNumber as number))}
+            onClick={(e) => {
+              e.preventDefault();
+              onChange(pageNumberMinusOne(pageNumber as number));
+            }}
           >
             {pageNumber}
           </PaginationButton>


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Prevent default event on click

## Before

Without preventing default onClick event caused refreshing the page

## After

Prevents unexpected page refresh and works correctly

## How to test

[Add a deep link and instructions how to verify the new behavior]
