### PR TITLE
fix: font family in body

### DIFF
--- a/src/components/layout/app/AppLayout.tsx
+++ b/src/components/layout/app/AppLayout.tsx
@@ -16,6 +16,7 @@ const AppLayout = forwardRef<GridProps, 'div'>((props, ref) => {
       templateAreas={pageGirdArea}
       minHeight="100vh"
       ref={ref}
+      textStyle="body"
       {...props}
     />
   );


### PR DESCRIPTION
References [VSST-754](https://autoricardo.atlassian.net/browse/VSST-754?atlOrigin=eyJpIjoiODBlMzg2Zjg3NDQ2NDY2ZDlmYmQzNGQ5MWY3MWM2YzAiLCJwIjoiaiJ9)

## Motivation and context

Font family should be `Make it Sans` everywhere and it is not always the case (at least in seller-web).

## Before

Some components don't return the right font. 
From what I understood it is especially linked to the `Text` component: if we don't pass a `textStyle` props, the font is not applied. 

## After

I applied the base style to the AppLayout to make sure we always have the right font everywhere

## How to test

You can have a look at [this PR](https://github.com/smg-automotive/seller-web/pull/209)
