### PR TITLE
feat: add translation switcher

### DIFF
--- a/src/components/devOverlay/__tests__/DevOverlay.Test.tsx
+++ b/src/components/devOverlay/__tests__/DevOverlay.Test.tsx
@@ -10,7 +10,9 @@ describe('The DevOverlay Component', () => {
         variables={[]}
         hideDevOverlay={jest.fn()}
         toggleTheme={jest.fn()}
+        toggleTranslation={jest.fn()}
         activeTheme="as24"
+        displayTranslationKeys={false}
       />
     );
 
@@ -29,6 +31,8 @@ describe('The DevOverlay Component', () => {
         hideDevOverlay={jest.fn()}
         toggleTheme={jest.fn()}
         activeTheme="as24"
+        toggleTranslation={jest.fn()}
+        displayTranslationKeys={false}
       />
     );
 

--- a/src/components/devOverlay/index.tsx
+++ b/src/components/devOverlay/index.tsx
@@ -27,7 +27,7 @@ export type DevOverlayProps = Omit<ButtonProps, 'onClick' | 'children'> &
     toggleTranslation: Exclude<SwitchProps['onChange'], undefined>;
     variables: DevOverlayVariables;
     activeTheme: Brand;
-    displayTranslationKeys?: boolean;
+    displayTranslationKeys: boolean;
   };
 
 const DevOverlay: FC<DevOverlayProps> = ({
@@ -36,7 +36,7 @@ const DevOverlay: FC<DevOverlayProps> = ({
   toggleTheme,
   toggleTranslation,
   activeTheme,
-  displayTranslationKeys,
+  displayTranslationKeys = false,
 }) => {
   const isThemeSwitcherChecked = 'as24' !== activeTheme;
 

--- a/src/components/devOverlay/index.tsx
+++ b/src/components/devOverlay/index.tsx
@@ -24,15 +24,19 @@ export type DevOverlayProps = Omit<ButtonProps, 'onClick' | 'children'> &
   Omit<SwitchProps, 'onChange'> & {
     hideDevOverlay: Exclude<ButtonProps['onClick'], undefined>;
     toggleTheme: Exclude<SwitchProps['onChange'], undefined>;
+    toggleTranslation: Exclude<SwitchProps['onChange'], undefined>;
     variables: DevOverlayVariables;
     activeTheme: Brand;
+    displayTranslationKeys?: boolean;
   };
 
 const DevOverlay: FC<DevOverlayProps> = ({
   variables,
   hideDevOverlay,
   toggleTheme,
+  toggleTranslation,
   activeTheme,
+  displayTranslationKeys,
 }) => {
   const isThemeSwitcherChecked = 'as24' !== activeTheme;
 
@@ -93,6 +97,19 @@ const DevOverlay: FC<DevOverlayProps> = ({
         <Switch onChange={toggleTheme} isChecked={isThemeSwitcherChecked} />
         &nbsp;
         <span>🏍️</span>
+      </div>
+      <Heading as="h4" textStyle="heading4">
+        Switch Translation
+      </Heading>
+      <div>
+        <span>🌐</span>
+        &nbsp;
+        <Switch
+          onChange={toggleTranslation}
+          isChecked={displayTranslationKeys}
+        />
+        &nbsp;
+        <span>🔑</span>
       </div>
     </Box>
   );


### PR DESCRIPTION
References [VSST-857](https://autoricardo.atlassian.net/browse/VSST-857?atlOrigin=eyJpIjoiZWQ4YzI2Mjc1MDY5NDBmNDlhNjQ2OWEzYmY0NzU1YTYiLCJwIjoiaiJ9)

## Motivation and context

This PR combined with [this one](https://github.com/smg-automotive/i18n-pkg/pull/79) and [this one](https://github.com/smg-automotive/seller-web/pull/217) allows a better and easier cooperation with translation by returning the keys instead of translations. We can now have a switcher for this in the DevOverlay component.

## Before

No possibility to check upon the keys easily

## After

<img width="243" alt="devOverlay" src="https://user-images.githubusercontent.com/52455155/208465746-8a193b77-8ae5-487f-bee7-18b7da2cc5ac.png">

Possible to check the translation keys in local and int env

## How to test

You can check with [this link](https://marine-test-key-translation-seller-web.branch.autoscout24.dev/en/insertion/identify) that the switcher for translation is visible in `devOverlay` and that it works as intended.