### PR TITLE
feat: adding size prop to FormControll & Checkbox

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   label?: string;
   isInvalid?: boolean;
   isIndeterminate?: boolean;
+  size?: 'sm' | 'lg';
 }
 
 const Checkbox = forwardRef<HTMLInputElement, Props>(
@@ -23,6 +24,7 @@ const Checkbox = forwardRef<HTMLInputElement, Props>(
       label,
       isInvalid,
       isIndeterminate = false,
+      size = 'lg',
     },
     ref
   ) => (
@@ -35,6 +37,7 @@ const Checkbox = forwardRef<HTMLInputElement, Props>(
       onChange={onChange}
       isInvalid={isInvalid}
       isIndeterminate={isIndeterminate}
+      size={size}
     >
       {label}
     </ChakraCheckbox>

--- a/src/components/formControl/index.stories.mdx
+++ b/src/components/formControl/index.stories.mdx
@@ -6,7 +6,7 @@ import { Input } from '../../index.ts';
 
 <Meta
   title="Components/Forms/Form Control"
-  component={Input}
+  component={FormControl}
   args={{
     label: 'Label',
     hint: 'I am a hint text',
@@ -14,6 +14,13 @@ import { Input } from '../../index.ts';
     isDisabled: false,
     isRequired: false,
     errorMessage: '',
+    size: 'lg',
+  }}
+  argTypes={{
+    size: {
+      options: ['sm', 'lg'],
+      control: 'select',
+    },
   }}
   parameters={{
     controls: {

--- a/src/components/formControl/index.tsx
+++ b/src/components/formControl/index.tsx
@@ -3,12 +3,12 @@ import {
   FormControl as ChakraFormControl,
   FormErrorMessage,
   FormHelperText,
-  FormLabel,
 } from '@chakra-ui/react';
 
 import Tooltip from '../tooltip';
 import Stack from '../stack';
 import { TooltipIcon } from '../icons';
+import FormLabel from '../formLabel';
 
 type Props = {
   isDisabled?: boolean;
@@ -18,6 +18,7 @@ type Props = {
   label?: string;
   hint?: string;
   tooltip?: string;
+  size?: 'sm' | 'lg';
 };
 
 const FormControl: FC<PropsWithChildren<Props>> = ({
@@ -29,18 +30,19 @@ const FormControl: FC<PropsWithChildren<Props>> = ({
   label,
   hint,
   tooltip,
+  size = 'lg',
 }) => {
   const isInvalid = !!errorMessage;
 
   const formLabel = (
-    <FormLabel htmlFor={id}>
+    <FormLabel htmlFor={id} size={size}>
       {label}
       {isRequired ? <>&nbsp;</> : null}
     </FormLabel>
   );
 
   const formLabelWithTooltip = (
-    <Stack direction="row" spacing="sm">
+    <Stack direction="row" spacing="sm" align="center">
       {formLabel}
       <Tooltip label={tooltip}>
         <TooltipIcon pos="relative" bottom="xxs" />

--- a/src/components/formLabel/index.stories.mdx
+++ b/src/components/formLabel/index.stories.mdx
@@ -8,6 +8,13 @@ import FormLabel from './index.tsx';
   component={FormLabel}
   args={{
     children: 'I am label',
+    size: 'lg',
+  }}
+  argTypes={{
+    size: {
+      options: ['sm', 'lg'],
+      control: 'select',
+    },
   }}
 />
 

--- a/src/components/formLabel/index.tsx
+++ b/src/components/formLabel/index.tsx
@@ -1,8 +1,22 @@
 import React, { FC, PropsWithChildren } from 'react';
-import { FormLabel as ChakraFormLabel } from '@chakra-ui/react';
+import {
+  FormLabel as ChakraFormLabel,
+  FormLabelProps as ChakraFormLabelProps,
+} from '@chakra-ui/react';
 
-const FormLabel: FC<PropsWithChildren> = ({ children }) => (
-  <ChakraFormLabel>{children}</ChakraFormLabel>
+type FormLabelProps = { size?: 'sm' | 'lg' } & Pick<
+  ChakraFormLabelProps,
+  'htmlFor'
+>;
+
+const FormLabel: FC<PropsWithChildren<FormLabelProps>> = ({
+  size = 'lg',
+  htmlFor,
+  children,
+}) => (
+  <ChakraFormLabel size={size} htmlFor={htmlFor}>
+    {children}
+  </ChakraFormLabel>
 );
 
 export default FormLabel;

--- a/src/themes/components/checkbox.ts
+++ b/src/themes/components/checkbox.ts
@@ -1,6 +1,15 @@
 import { PartsStyleObject, SystemStyleObject } from '@chakra-ui/styled-system';
 import { checkboxAnatomy as parts } from '@chakra-ui/anatomy';
 
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
+  sm: {
+    label: { fontSize: 'sm' },
+  },
+  lg: {
+    label: { fontSize: 'base' },
+  },
+};
+
 const baseStyleControl: SystemStyleObject = {
   width: 'xs',
   height: 'xs',
@@ -49,4 +58,5 @@ const baseStyle: PartsStyleObject<typeof parts> = {
 
 export default {
   baseStyle,
+  sizes,
 };

--- a/src/themes/components/formLabel.ts
+++ b/src/themes/components/formLabel.ts
@@ -1,5 +1,10 @@
 import type { SystemStyleObject } from '@chakra-ui/styled-system';
 
+const sizes: Record<string, SystemStyleObject> = {
+  sm: { fontSize: 'sm' },
+  lg: { fontSize: 'base' },
+};
+
 const baseStyle: SystemStyleObject = {
   textStyle: 'label',
   mb: 4,
@@ -13,4 +18,5 @@ const baseStyle: SystemStyleObject = {
 
 export default {
   baseStyle,
+  sizes,
 };


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-873

## Motivation and context

We should be able to choose between `small` and `large` sizes for `FormControl` and `Checkbox` components. With this MR we are adding `size` prop for those components.

https://www.figma.com/file/CHU4fpMfXpiAW4qNFzi9y1/11.-AS24---Web---Components?node-id=55%3A3221&t=T3ICxm84xQl7q1DD-0

## Before

Without possibility to choose size.

## After

We can pass value for size prop -  `sm` | `lg`

## How to test

https://zbiljic-vsst-873-components-pkg.branch.autoscout24.dev/?path=/story/components-forms-form-label--form-label