### PR TITLE
fix: make vehicle reference props optional

### DIFF
--- a/src/components/vehicleReference/index.stories.mdx
+++ b/src/components/vehicleReference/index.stories.mdx
@@ -7,6 +7,13 @@ import VehicleReference from './index.tsx';
 <Meta
   title="Patterns/Data display/Vehicle reference"
   component={VehicleReference}
+  argTypes={{
+    image: {
+      table: {
+        disable: true,
+      },
+    },
+  }}
 />
 
 export const Template = (args) => (
@@ -53,3 +60,18 @@ export const Template = (args) => (
 </Canvas>
 
 <ArgsTable story="Vehicle reference missing image" />
+
+## Vehicle reference with minimal props
+
+<Canvas>
+  <Story
+    name="Vehicle reference with minimal props"
+    args={{
+      vehicleTitle: 'AUDI',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Vehicle reference with minimal props" />

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -10,9 +10,9 @@ import AspectRatio from '../aspectRatio';
 interface Props {
   image?: ReactNode;
   vehicleTitle: string;
-  price: string;
-  sellerName: string;
-  sellerAddress: string;
+  price?: string;
+  sellerName?: string;
+  sellerAddress?: string;
 }
 
 const VehicleReference: FC<Props> = ({

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -10,9 +10,9 @@ import AspectRatio from '../aspectRatio';
 interface Props {
   image?: ReactNode;
   vehicleTitle: string;
-  price?: string;
-  sellerName?: string;
-  sellerAddress?: string;
+  price?: string | null;
+  sellerName?: string | null;
+  sellerAddress?: string | null;
 }
 
 const VehicleReference: FC<Props> = ({


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

According to backend, only id, make, sellerId and vehicleCategory are mandatory on listing.

## Before

Props are mandatory

## After

Props are optional

## How to test

[Add a deep link and instructions how to verify the new behavior]
