### PR TITLE
fix: remove sticky from ad container

### DIFF
--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -44,9 +44,7 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
             marginRight="2xl"
             position="relative"
           >
-            <Box position="sticky" top="2xl">
-              {skyScraperAd}
-            </Box>
+            {skyScraperAd}
           </chakra.aside>
         ) : null}
       </Flex>

--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -3,7 +3,6 @@ import React, { FC, PropsWithChildren, ReactNode } from 'react';
 import { chakra, Container, Flex } from '@chakra-ui/react';
 
 import Divider from '../divider';
-import Box from '../box';
 import { sizes } from '../../themes/shared/sizes';
 
 interface Props {


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Turns out, the ad container is not always sticky. For instance, on the detail page it is not, on the search page it is. Let the usage define the sticky behavior and not the component.
