### PR TITLE
fix: extending Input with type prop

### DIFF
--- a/src/components/input/index.stories.mdx
+++ b/src/components/input/index.stories.mdx
@@ -70,7 +70,7 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       onBlur: false,
       autoFocus: false,
       value: '',
-      type: 'text'
+      type: 'text',
     }}
     argTypes={{
       value: {
@@ -83,7 +83,7 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       type: {
         options: ['text', 'number'],
         control: 'select',
-      }
+      },
     }}
   >
     {Template.bind({})}

--- a/src/components/input/index.stories.mdx
+++ b/src/components/input/index.stories.mdx
@@ -70,6 +70,7 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       onBlur: false,
       autoFocus: false,
       value: '',
+      type: 'text'
     }}
     argTypes={{
       value: {
@@ -79,6 +80,10 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
         options: ['md', 'lg'],
         control: 'select',
       },
+      type: {
+        options: ['text', 'number'],
+        control: 'select',
+      }
     }}
   >
     {Template.bind({})}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -17,6 +17,7 @@ type SharedProps = {
   onFocus?: FocusEventHandler<HTMLInputElement>;
   autoFocus?: boolean;
   name: string;
+  type?: 'text' | 'number';
 };
 
 type ControlledInputProps = {
@@ -43,7 +44,17 @@ type DebouncedInputPros = {
 type Props = ControlledInputProps | InputPros | DebouncedInputPros;
 
 const Input = forwardRef<HTMLInputElement, Props>(
-  ({ onChange, value, debounce = false, setInputValue, ...props }, ref) => {
+  (
+    {
+      onChange,
+      value,
+      debounce = false,
+      setInputValue,
+      type = 'text',
+      ...props
+    },
+    ref
+  ) => {
     const [internalUIValue, setInternalUIValue] = useState(value);
     // https://lawsofux.com/doherty-threshold/
     const debounceThreshold = debounce ? 400 : 0;
@@ -72,6 +83,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
     return (
       <ChakraInput
         {...props}
+        type={type}
         value={inputValue}
         onChange={onChangeHandler}
         ref={ref}


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-898

## Motivation and context

We need to use Input component with type `number` for some of the fields inside seller-web repo (mileage, price etc.). In order to achieve that we have to extend Input component with `type` prop.

## Before

No `type` prop on Input component

## After

We can set type prop.

## How to test

https://zbiljic-vsst-989-extend-input-props-components-pkg.branch.autoscout24.dev/?path=/story/components-forms-input--overview&args=type:number
