### PR TITLE
feat: add sizes to textarea

### DIFF
--- a/src/components/textarea/index.stories.mdx
+++ b/src/components/textarea/index.stories.mdx
@@ -63,6 +63,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       rows: 10,
       cols: 50,
     }}
+    argTypes={{
+      size: {
+        options: ['sm', 'md'],
+        control: 'select',
+      },
+    }}
   >
     {Template.bind({})}
   </Story>
@@ -83,6 +89,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       rows: 10,
       cols: 50,
     }}
+    argTypes={{
+      size: {
+        options: ['sm', 'md'],
+        control: 'select',
+      },
+    }}
   >
     {Template.bind({})}
   </Story>
@@ -101,6 +113,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       rows: 10,
       cols: 50,
     }}
+    argTypes={{
+      size: {
+        options: ['sm', 'md'],
+        control: 'select',
+      },
+    }}
   >
     {Template.bind({})}
   </Story>
@@ -118,6 +136,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       autoFocus: false,
       rows: 10,
       cols: 50,
+    }}
+    argTypes={{
+      size: {
+        options: ['sm', 'md'],
+        control: 'select',
+      },
     }}
   >
     {Template.bind({})}

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -18,6 +18,7 @@ interface Props {
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
   rows?: number;
   cols?: number;
+  size?: 'sm' | 'md';
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, Props>(({ ...props }, ref) => {

--- a/src/themes/components/textarea.ts
+++ b/src/themes/components/textarea.ts
@@ -20,6 +20,11 @@ const variants: Record<string, SystemStyleInterpolation> = {
   outline: Input.variants.outline.field ?? {},
 };
 
+const sizes: Record<string, SystemStyleObject> = {
+  sm: { fontSize: 'sm' },
+  md: { fontSize: 'base' },
+};
+
 const defaultProps = {
   variant: 'outline',
 };
@@ -27,5 +32,6 @@ const defaultProps = {
 export default {
   baseStyle,
   variants,
+  sizes,
   defaultProps,
 };


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

We need to have the ability to change the sizes of textarea.

## Before

N/A

## After

Size prop is available

## How to test


