### PR TITLE
feat: add text style to textarea

### DIFF
--- a/src/components/textarea/index.stories.mdx
+++ b/src/components/textarea/index.stories.mdx
@@ -6,6 +6,7 @@ import { action } from '@storybook/addon-actions';
 import { Box } from '@chakra-ui/react';
 
 import Textarea from './index.tsx';
+import { shared } from '../../themes';
 
 <Meta title="Components/Forms/Textarea" component={Textarea} />
 
@@ -63,6 +64,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       rows: 10,
       cols: 50,
     }}
+    argTypes={{
+      textStyle: {
+        options: Object.keys(shared.textStyles),
+        control: { type: 'select' },
+      },
+    }}
   >
     {Template.bind({})}
   </Story>
@@ -83,6 +90,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       rows: 10,
       cols: 50,
     }}
+    argTypes={{
+      textStyle: {
+        options: Object.keys(shared.textStyles),
+        control: { type: 'select' },
+      },
+    }}
   >
     {Template.bind({})}
   </Story>
@@ -101,6 +114,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       rows: 10,
       cols: 50,
     }}
+    argTypes={{
+      textStyle: {
+        options: Object.keys(shared.textStyles),
+        control: { type: 'select' },
+      },
+    }}
   >
     {Template.bind({})}
   </Story>
@@ -118,6 +137,12 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
       autoFocus: false,
       rows: 10,
       cols: 50,
+    }}
+    argTypes={{
+      textStyle: {
+        options: Object.keys(shared.textStyles),
+        control: { type: 'select' },
+      },
     }}
   >
     {Template.bind({})}

--- a/src/components/textarea/index.stories.mdx
+++ b/src/components/textarea/index.stories.mdx
@@ -66,7 +66,7 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
     }}
     argTypes={{
       textStyle: {
-        options: Object.keys(shared.textStyles),
+        options: ['body', 'body-small'],
         control: { type: 'select' },
       },
     }}
@@ -92,7 +92,7 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
     }}
     argTypes={{
       textStyle: {
-        options: Object.keys(shared.textStyles),
+        options: ['body', 'body-small'],
         control: { type: 'select' },
       },
     }}
@@ -116,7 +116,7 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
     }}
     argTypes={{
       textStyle: {
-        options: Object.keys(shared.textStyles),
+        options: ['body', 'body-small'],
         control: { type: 'select' },
       },
     }}
@@ -140,7 +140,7 @@ export const Template = ({ value, onChange, onBlur, onFocus, ...args }) => {
     }}
     argTypes={{
       textStyle: {
-        options: Object.keys(shared.textStyles),
+        options: ['body', 'body-small'],
         control: { type: 'select' },
       },
     }}

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -18,6 +18,7 @@ interface Props {
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
   rows?: number;
   cols?: number;
+  textStyle?: string;
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, Props>(({ ...props }, ref) => {

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -18,7 +18,7 @@ interface Props {
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
   rows?: number;
   cols?: number;
-  textStyle?: string;
+  textStyle?: 'body' | 'body-small';
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, Props>(({ ...props }, ref) => {


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

In order to change text style for textarea component, we have to add textStyle props.

## Before

N/A

## After

textStyle prop is available

## How to test

[Add a deep link and instructions how to verify the new behavior]
