### PR TITLE
feat: add 'width' to SimpleGrid component

### DIFF
--- a/src/components/simpleGrid/index.tsx
+++ b/src/components/simpleGrid/index.tsx
@@ -13,6 +13,7 @@ type Props = Pick<
   | 'spacingY'
   | 'children'
   | 'alignItems'
+  | 'width'
 >;
 
 const SimpleGrid: FC<Props> = (props) => <ChakraSimpleGrid {...props} />;


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

If we need to set width to SimpleGrid we need to do sth like `<Box as={SimpleGrid} w="full" />`

## Before

SimpleGrid does not have width prop

## After

Use <SimpleGrid w="full />

## How to test

[Add a deep link and instructions how to verify the new behavior]
