### PR TITLE
fix: adding key prop to checkbox group fragment

### DIFF
--- a/src/components/checkboxGroup/index.stories.mdx
+++ b/src/components/checkboxGroup/index.stories.mdx
@@ -73,7 +73,7 @@ export const Template = ({ ...args }) => {
   );
 };
 
-# Checkbox
+# CheckboxGroup
 
 ## Overview
 

--- a/src/components/checkboxGroup/index.tsx
+++ b/src/components/checkboxGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, Fragment } from 'react';
 
 import { Box } from '@chakra-ui/react';
 
@@ -41,17 +41,16 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
       />
 
       {checkboxes?.map((item, index) => (
-        <>
+        <Fragment key={item.name}>
           <Box
             as={Checkbox}
             {...item}
             size={size}
             pl="md"
             isDisabled={isDisabled}
-            key={item.name}
           />
           {addDividerAfterIndex?.includes(index) ? <Divider /> : null}
-        </>
+        </Fragment>
       ))}
     </Stack>
   );


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Missing key prop on `CheckboxGroup` component

## Before

N/A

## After

We have `key` prop on `CheckboxGroup` fragment

## How to test

[Add a deep link and instructions how to verify the new behavior]
