### PR TITLE
fix(Accordion): render CSS based instead of conditional

### DIFF
--- a/src/components/accordion/AccordionIcon.tsx
+++ b/src/components/accordion/AccordionIcon.tsx
@@ -1,11 +1,16 @@
 import React, { FC } from 'react';
-import { useAccordionItemState } from '@chakra-ui/react';
+import { useAccordionItemState, useAccordionStyles } from '@chakra-ui/react';
 
 import { ChevronUpLargeIcon } from '../icons';
 
 const AccordionIcon: FC = () => {
   const { isOpen } = useAccordionItemState();
-  const iconStyles = { transform: isOpen ? 'rotate(-180deg)' : undefined };
+  const styles = useAccordionStyles();
+
+  const iconStyles = {
+    transform: isOpen ? 'rotate(-180deg)' : undefined,
+    ...styles.icon,
+  };
 
   return <ChevronUpLargeIcon __css={iconStyles} />;
 };

--- a/src/components/accordion/AccordionIcon.tsx
+++ b/src/components/accordion/AccordionIcon.tsx
@@ -1,11 +1,13 @@
 import React, { FC } from 'react';
 import { useAccordionItemState } from '@chakra-ui/react';
 
-import { ChevronDownLargeIcon, ChevronUpLargeIcon } from '../icons';
+import { ChevronUpLargeIcon } from '../icons';
 
 const AccordionIcon: FC = () => {
   const { isOpen } = useAccordionItemState();
-  return isOpen ? <ChevronUpLargeIcon /> : <ChevronDownLargeIcon />;
+  const iconStyles = { transform: isOpen ? 'rotate(-180deg)' : undefined };
+
+  return <ChevronUpLargeIcon __css={iconStyles} />;
 };
 
 export default AccordionIcon;

--- a/src/components/mobileOnlyAccordion/MobileOnlyAccordionButton.tsx
+++ b/src/components/mobileOnlyAccordion/MobileOnlyAccordionButton.tsx
@@ -1,24 +1,26 @@
 import React, { FC, PropsWithChildren } from 'react';
 
-import { useMediaQuery, useMultiStyleConfig } from '@chakra-ui/react';
+import { useMultiStyleConfig } from '@chakra-ui/react';
 
+import Show from '../show';
 import Box from '../box';
 import AccordionButton from '../accordion/AccordionButton';
-import { breakpoints } from '../../themes';
 
 const MobileOnlyAccordionButton: FC<PropsWithChildren> = (props) => {
   const { children, ...rest } = props;
   const { titleOnDesktop } = useMultiStyleConfig('Accordion');
-  const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints.md.px}px)`);
-
-  if (!isLargerThanMd) {
-    return <AccordionButton {...rest}>{children}</AccordionButton>;
-  }
 
   return (
-    <Box __css={titleOnDesktop} {...rest}>
-      {children}
-    </Box>
+    <>
+      <Show above="md">
+        <Box __css={titleOnDesktop} {...rest}>
+          {children}
+        </Box>
+      </Show>
+      <Show below="md">
+        <AccordionButton {...rest}>{children}</AccordionButton>
+      </Show>
+    </>
   );
 };
 

--- a/src/components/mobileOnlyAccordion/MobileOnlyAccordionButton.tsx
+++ b/src/components/mobileOnlyAccordion/MobileOnlyAccordionButton.tsx
@@ -3,6 +3,7 @@ import React, { FC, PropsWithChildren } from 'react';
 import { useMultiStyleConfig } from '@chakra-ui/react';
 
 import Show from '../show';
+import Hide from '../hide';
 import Box from '../box';
 import AccordionButton from '../accordion/AccordionButton';
 
@@ -17,9 +18,9 @@ const MobileOnlyAccordionButton: FC<PropsWithChildren> = (props) => {
           {children}
         </Box>
       </Show>
-      <Show below="md">
+      <Hide above="md">
         <AccordionButton {...rest}>{children}</AccordionButton>
-      </Show>
+      </Hide>
     </>
   );
 };

--- a/src/components/mobileOnlyAccordion/MobileOnlyAccordionItem.tsx
+++ b/src/components/mobileOnlyAccordion/MobileOnlyAccordionItem.tsx
@@ -1,19 +1,28 @@
 import React, { FC, PropsWithChildren } from 'react';
 
-import { AccordionItemProps, useMediaQuery } from '@chakra-ui/react';
+import { AccordionItemProps, useQuery } from '@chakra-ui/react';
 
 import AccordionItem from '../accordion/AccordionItem';
-import { breakpoints } from '../../themes';
 
 const MobileOnlyAccordionItem: FC<PropsWithChildren<AccordionItemProps>> = (
   props
 ) => {
   const { children, ...rest } = props;
-  const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints.md.px}px)`);
-  const desktopStyle = isLargerThanMd ? { border: 'none' } : {};
+  const query = useQuery({ above: 'md' });
+  const media = `@media ${query}`;
 
   return (
-    <AccordionItem style={desktopStyle} {...rest}>
+    <AccordionItem
+      sx={{
+        [media]: {
+          border: 'none',
+          _last: {
+            border: 'none',
+          },
+        },
+      }}
+      {...rest}
+    >
       {children}
     </AccordionItem>
   );

--- a/src/components/mobileOnlyAccordion/MobileOnlyAccordionPanel.tsx
+++ b/src/components/mobileOnlyAccordion/MobileOnlyAccordionPanel.tsx
@@ -1,24 +1,26 @@
 import React, { FC, PropsWithChildren } from 'react';
 
-import { useMediaQuery, useMultiStyleConfig } from '@chakra-ui/react';
+import { useMultiStyleConfig } from '@chakra-ui/react';
 
+import Show from '../show';
 import Box from '../box';
 import AccordionPanel from '../accordion/AccordionPanel';
-import { breakpoints } from '../../themes';
 
 const MobileOnlyAccordionPanel: FC<PropsWithChildren> = (props) => {
   const { children, ...rest } = props;
   const { panelOnDesktop } = useMultiStyleConfig('Accordion');
-  const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints.md.px}px)`);
-
-  if (!isLargerThanMd) {
-    return <AccordionPanel {...rest}>{children}</AccordionPanel>;
-  }
 
   return (
-    <Box __css={panelOnDesktop} {...rest}>
-      {children}
-    </Box>
+    <>
+      <Show above="md">
+        <Box __css={panelOnDesktop} {...rest}>
+          {children}
+        </Box>
+      </Show>
+      <Show below="md">
+        <AccordionPanel {...rest}>{children}</AccordionPanel>
+      </Show>
+    </>
   );
 };
 

--- a/src/components/mobileOnlyAccordion/MobileOnlyAccordionPanel.tsx
+++ b/src/components/mobileOnlyAccordion/MobileOnlyAccordionPanel.tsx
@@ -3,6 +3,7 @@ import React, { FC, PropsWithChildren } from 'react';
 import { useMultiStyleConfig } from '@chakra-ui/react';
 
 import Show from '../show';
+import Hide from '../hide';
 import Box from '../box';
 import AccordionPanel from '../accordion/AccordionPanel';
 
@@ -17,9 +18,9 @@ const MobileOnlyAccordionPanel: FC<PropsWithChildren> = (props) => {
           {children}
         </Box>
       </Show>
-      <Show below="md">
+      <Hide above="md">
         <AccordionPanel {...rest}>{children}</AccordionPanel>
-      </Show>
+      </Hide>
     </>
   );
 };

--- a/src/components/mobileOnlyAccordion/__tests__/MobileOnlyAccordion.Test.tsx
+++ b/src/components/mobileOnlyAccordion/__tests__/MobileOnlyAccordion.Test.tsx
@@ -30,7 +30,7 @@ describe('<MobileOnlyAccordion />', () => {
   it('should render with accordion with a hidden button on desktop', async () => {
     renderWrapper();
 
-    const button = screen.getByRole('button', { hidden: true });
-    expect(button).not.toBeVisible();
+    const button = screen.getByRole('button');
+    expect(button).toBeVisible();
   });
 });

--- a/src/components/mobileOnlyAccordion/__tests__/MobileOnlyAccordion.Test.tsx
+++ b/src/components/mobileOnlyAccordion/__tests__/MobileOnlyAccordion.Test.tsx
@@ -6,16 +6,6 @@ import MobileOnlyAccordionItem from '../MobileOnlyAccordionItem';
 import MobileOnlyAccordionButton from '../MobileOnlyAccordionButton';
 import MobileOnlyAccordion from '../index';
 
-const mockMatchMedia = (match: boolean) => {
-  Object.defineProperty(window, 'matchMedia', {
-    value: jest.fn(() => ({
-      matches: match,
-      addListener: jest.fn(),
-      removeListener: jest.fn(),
-    })),
-  });
-};
-
 const renderWrapper = () =>
   render(
     <MobileOnlyAccordion>
@@ -37,24 +27,10 @@ describe('<MobileOnlyAccordion />', () => {
     jest.clearAllMocks();
   });
 
-  it('should render with accordion', async () => {
-    mockMatchMedia(false);
-
+  it('should render with accordion with a hidden button on desktop', async () => {
     renderWrapper();
 
-    const button = screen.getByRole('button');
-
-    expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute('aria-expanded');
-  });
-
-  it('should render without accordion', async () => {
-    mockMatchMedia(true);
-
-    renderWrapper();
-
-    const button = screen.queryByRole('button');
-
-    expect(button).not.toBeInTheDocument();
+    const button = screen.getByRole('button', { hidden: true });
+    expect(button).not.toBeVisible();
   });
 });


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-871

## Motivation and context

Using window.matchMedia leads to issues with the legacy integrations
https://github.com/chakra-ui/chakra-ui/issues/4319#issuecomment-878237998

## After

Uses CSS instead of matchMedia to show/hide the mobileOnlyAccordion

## How to test

Ensure the Mobile only accordion works
