### PR TITLE
fix(footer): missing link for IT lang

### DIFF
--- a/src/components/footer/config/index.ts
+++ b/src/components/footer/config/index.ts
@@ -177,7 +177,7 @@ export const footerConfig: FooterConfigInterface = {
             de: '/de/auto-verkaufen',
             en: '/de/auto-verkaufen',
             fr: '/fr/vendre-voiture',
-            it: '',
+            it: '/it/vendere-auto',
           },
         },
         {


### PR DESCRIPTION
## Motivation and context

We found a missing link for IT lang during the integration footer into legacy.

