### PR TITLE
chore: group ui related dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,17 @@
 {
-  "extends": ["github>smg-automotive/renovate-config"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>smg-automotive/renovate-config"],
+  "packageRules": [
+    {
+      "groupName": "UI dependencies",
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchPackagePatterns": [
+        "@chakra-ui/*",
+        "@emotion/*",
+        "framer-motion",
+        "embla-carousel-react",
+        "use-debounce"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/FE-88

## Motivation and context

Releases of multiple UI-related dependencies cause multiple releases of components package since all of them are merged separately.

This PR groups the patch and minor releases of those dependencies to reduce the version noise on the components package

