### PR TITLE
fix: add truncated and noOfLines prop to Text comp

### DIFF
--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -3,7 +3,13 @@ import { Text as ChakraText, TextProps } from '@chakra-ui/react';
 
 type Props = Pick<
   TextProps,
-  'as' | 'children' | 'color' | 'textStyle' | 'textAlign'
+  | 'as'
+  | 'children'
+  | 'color'
+  | 'textStyle'
+  | 'textAlign'
+  | 'isTruncated'
+  | 'noOfLines'
 >;
 
 const Text: FC<Props> = ({ children, ...chakraProps }) => (


### PR DESCRIPTION
References

## Motivation and context
Instead of using Box as={Text} for truncation, we should pick `isTruncated` prop. Similar prop is noOfLines. 

## Before
No truncation.

## After
With truncation prop.
With noOfLines prop

## How to test

[Add a deep link and instructions how to verify the new behavior]
