### PR TITLE
fix: articles alignment on tablets

### DIFF
--- a/src/components/articleTeaser/index.tsx
+++ b/src/components/articleTeaser/index.tsx
@@ -28,7 +28,7 @@ const ArticleTeaser: FC<Props> = ({
         <Stack
           direction={{
             '2xs': 'column',
-            md: 'row',
+            sm: 'row',
           }}
           spacing="lg"
           align="center"


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-1267

## Motivation and context
There was issue with articles alignments on the tablet sizes. After talking with Enrique we decided that tablet should have the same display as on desktop. It was just moving the break point from `md > sm`.

## Before
![image](https://user-images.githubusercontent.com/28811793/217856479-b0c2e979-eb81-4449-af28-1daa8ff1abbf.png)

## After
![image](https://user-images.githubusercontent.com/28811793/217856688-303626d0-f400-48db-bf16-bd4b7d347fb9.png)


## How to test
The articles should have the same preview on tablets as on the desktops.
