### PR TITLE
Fix range filter

### DIFF
--- a/src/components/rangeFilterInput/InputGroup.tsx
+++ b/src/components/rangeFilterInput/InputGroup.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, FocusEvent } from 'react';
 import {
   InputGroup as ChakraInputGroup,
   NumberInput,
@@ -16,6 +16,7 @@ import {
 type InputGroupProps = {
   handleChange: (event: ChangeCallback) => void;
   inputProps: RangeFilterInputField;
+  onBlur?: (event: ChangeCallback) => void;
   unit?: string;
   variant: 'inputLeft' | 'inputRight';
 } & PickedNumberInputProps;
@@ -23,10 +24,12 @@ type InputGroupProps = {
 const InputGroup: FC<InputGroupProps> = ({
   handleChange,
   inputProps,
+  onBlur,
   unit,
   variant,
   ...rest
 }) => {
+  const inputVariantName = variant === 'inputLeft' ? 'from' : 'to';
   return (
     <ChakraInputGroup>
       <NumberInput
@@ -34,8 +37,16 @@ const InputGroup: FC<InputGroupProps> = ({
         variant={variant}
         defaultValue={inputProps.value ? inputProps.value : ''}
         name={inputProps.name}
-        onChange={(_, value) =>
-          handleChange({ value, name: variant === 'inputLeft' ? 'from' : 'to' })
+        onChange={(_, value) => handleChange({ value, name: inputVariantName })}
+        onBlur={
+          onBlur
+            ? (event: FocusEvent<HTMLInputElement>) => {
+                onBlur({
+                  value: Number(event.target.value),
+                  name: inputVariantName,
+                });
+              }
+            : undefined
         }
         {...rest}
       >

--- a/src/components/rangeFilterInput/InputGroup.tsx
+++ b/src/components/rangeFilterInput/InputGroup.tsx
@@ -43,6 +43,7 @@ const InputGroup: FC<InputGroupProps> = ({
         <NumberInputField
           value={inputProps.value ? inputProps.value : ''}
           placeholder={inputProps.placeholder ? inputProps.placeholder : ''}
+          fontSize="body"
         />
       </NumberInput>
     </ChakraInputGroup>

--- a/src/components/rangeFilterInput/__tests__/Index.Test.tsx
+++ b/src/components/rangeFilterInput/__tests__/Index.Test.tsx
@@ -21,6 +21,7 @@ describe('<RangeFilterInput/>', () => {
           placeholder: 'To',
         }}
         unit="CHF"
+        debounce={false}
       />
     );
   };

--- a/src/components/rangeFilterInput/index.stories.mdx
+++ b/src/components/rangeFilterInput/index.stories.mdx
@@ -10,10 +10,6 @@ import RangeFilterInput from './index';
   title="Components/Filter/Range Input"
   component={RangeFilterInput}
   argTypes={{
-    size: {
-      options: ['md', 'lg'],
-      control: 'select',
-    },
     isDisabled: {
       control: 'boolean',
     },

--- a/src/components/rangeFilterInput/index.stories.mdx
+++ b/src/components/rangeFilterInput/index.stories.mdx
@@ -15,7 +15,7 @@ import RangeFilterInput from './index';
     },
   }}
   parameters={{
-    actions: ['change'],
+    actions: ['change', 'onBlur'],
   }}
 />
 ;
@@ -36,6 +36,9 @@ export const Template = ({ from, to, unit, ...rest }) => {
         handleChange={(event) => {
           action('change')(event);
           onChange(event.value, event.name);
+        }}
+        onBlur={(event) => {
+          action('onBlur')(event);
         }}
         unit={unit}
         {...rest}

--- a/src/components/rangeFilterInput/index.tsx
+++ b/src/components/rangeFilterInput/index.tsx
@@ -38,7 +38,7 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
   ...rest
 }) => {
   const debounceThreshold = debounce ? 1000 : 0;
-  const setValueDebounced = useDebouncedCallback(
+  const handleChangeDebounced = useDebouncedCallback(
     handleChange,
     debounceThreshold
   );
@@ -48,7 +48,7 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
       <InputGroup
         inputProps={from}
         variant="inputLeft"
-        handleChange={setValueDebounced}
+        handleChange={handleChangeDebounced}
         unit={unit}
         {...rest}
       />
@@ -56,7 +56,7 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
       <InputGroup
         inputProps={to}
         variant="inputRight"
-        handleChange={setValueDebounced}
+        handleChange={handleChangeDebounced}
         unit={unit}
         {...rest}
       />

--- a/src/components/rangeFilterInput/index.tsx
+++ b/src/components/rangeFilterInput/index.tsx
@@ -1,3 +1,4 @@
+import { useDebouncedCallback } from 'use-debounce';
 import React, { FC } from 'react';
 import { NumberInputProps } from '@chakra-ui/react';
 
@@ -17,7 +18,7 @@ export type ChangeCallback = {
 
 export type PickedNumberInputProps = Pick<
   NumberInputProps,
-  'min' | 'max' | 'isDisabled' | 'onFocus'
+  'min' | 'max' | 'isDisabled' | 'onFocus' | 'onBlur'
 >;
 
 type RangeFilterInputProps = {
@@ -25,7 +26,6 @@ type RangeFilterInputProps = {
   to: RangeFilterInputField;
   handleChange: (event: ChangeCallback) => void;
   unit?: string;
-  size?: 'md' | 'lg';
 } & PickedNumberInputProps;
 
 const RangeFilterInput: FC<RangeFilterInputProps> = ({
@@ -33,15 +33,20 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
   to,
   handleChange,
   unit,
-  size,
   ...rest
 }) => {
+  const debounceThreshold = 1000;
+  const setValueDebounced = useDebouncedCallback(
+    handleChange,
+    debounceThreshold
+  );
+
   return (
     <Stack direction="row" spacing={0}>
       <InputGroup
         inputProps={from}
         variant="inputLeft"
-        handleChange={handleChange}
+        handleChange={setValueDebounced}
         unit={unit}
         {...rest}
       />
@@ -49,7 +54,7 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
       <InputGroup
         inputProps={to}
         variant="inputRight"
-        handleChange={handleChange}
+        handleChange={setValueDebounced}
         unit={unit}
         {...rest}
       />

--- a/src/components/rangeFilterInput/index.tsx
+++ b/src/components/rangeFilterInput/index.tsx
@@ -26,6 +26,7 @@ type RangeFilterInputProps = {
   to: RangeFilterInputField;
   handleChange: (event: ChangeCallback) => void;
   unit?: string;
+  debounce?: boolean;
 } & PickedNumberInputProps;
 
 const RangeFilterInput: FC<RangeFilterInputProps> = ({
@@ -33,9 +34,10 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
   to,
   handleChange,
   unit,
+  debounce = true,
   ...rest
 }) => {
-  const debounceThreshold = 1000;
+  const debounceThreshold = debounce ? 1000 : 0;
   const setValueDebounced = useDebouncedCallback(
     handleChange,
     debounceThreshold

--- a/src/components/rangeFilterInput/index.tsx
+++ b/src/components/rangeFilterInput/index.tsx
@@ -1,5 +1,5 @@
 import { useDebouncedCallback } from 'use-debounce';
-import React, { FC } from 'react';
+import React, { FC, FocusEventHandler } from 'react';
 import { NumberInputProps } from '@chakra-ui/react';
 
 import Stack from '../stack';
@@ -18,15 +18,16 @@ export type ChangeCallback = {
 
 export type PickedNumberInputProps = Pick<
   NumberInputProps,
-  'min' | 'max' | 'isDisabled' | 'onFocus' | 'onBlur'
+  'min' | 'max' | 'isDisabled' | 'onFocus'
 >;
 
 type RangeFilterInputProps = {
-  from: RangeFilterInputField;
-  to: RangeFilterInputField;
-  handleChange: (event: ChangeCallback) => void;
-  unit?: string;
   debounce?: boolean;
+  from: RangeFilterInputField;
+  handleChange: (event: ChangeCallback) => void;
+  onBlur?: (event: ChangeCallback) => void;
+  to: RangeFilterInputField;
+  unit?: string;
 } & PickedNumberInputProps;
 
 const RangeFilterInput: FC<RangeFilterInputProps> = ({
@@ -35,6 +36,7 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
   handleChange,
   unit,
   debounce = true,
+  onBlur,
   ...rest
 }) => {
   const debounceThreshold = debounce ? 1000 : 0;
@@ -49,6 +51,7 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
         inputProps={from}
         variant="inputLeft"
         handleChange={handleChangeDebounced}
+        onBlur={onBlur}
         unit={unit}
         {...rest}
       />
@@ -57,6 +60,7 @@ const RangeFilterInput: FC<RangeFilterInputProps> = ({
         inputProps={to}
         variant="inputRight"
         handleChange={handleChangeDebounced}
+        onBlur={onBlur ? onBlur : undefined}
         unit={unit}
         {...rest}
       />

--- a/src/components/rangeFilterInput/index.tsx
+++ b/src/components/rangeFilterInput/index.tsx
@@ -1,5 +1,5 @@
 import { useDebouncedCallback } from 'use-debounce';
-import React, { FC, FocusEventHandler } from 'react';
+import React, { FC } from 'react';
 import { NumberInputProps } from '@chakra-ui/react';
 
 import Stack from '../stack';

--- a/src/themes/components/numberInput.ts
+++ b/src/themes/components/numberInput.ts
@@ -17,20 +17,13 @@ const baseStyle: PartsStyleObject<typeof parts> = {
 };
 
 const size: Record<string, SystemStyleObject> = {
-  md: {
-    textStyle: 'body-small',
-    h: 'md',
-  },
   lg: {
-    textStyle: 'body',
+    textStyle: 'body-small',
     h: 'lg',
   },
 };
 
 const sizes: Record<string, PartsStyleObject<typeof parts>> = {
-  md: {
-    field: size.md,
-  },
   lg: {
     field: size.lg,
   },
@@ -69,6 +62,7 @@ const variantInputLeft: PartsStyleObject<typeof parts> = {
     ...variantOutline.field,
     borderTopEndRadius: 0,
     borderBottomEndRadius: 0,
+    borderRight: 0,
   },
 };
 
@@ -86,7 +80,7 @@ const variants = {
 };
 
 const defaultProps = {
-  size: 'md',
+  size: 'lg',
 };
 
 export default {


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-1178

## Motivation and context
Adds debounce of 1 second (debatable) for range input filter because it would be too heavy on BE side on each keystroke. Also added onBlur param.

Also some style fixes based on latest design updates.

## Before
No debounce on range input filter. No onBlur param option.

## After
1 second debounce option on filter input. onBlur option.

![image](https://user-images.githubusercontent.com/28811793/220915114-6c322a5a-8f35-40d8-b663-c3bd5dc06161.png)

## How to test
After entering input should be 1 second delay in action tab on storybook.
