### PR TITLE
fix: gray color & missing image size

### DIFF
--- a/src/components/missingImage/index.tsx
+++ b/src/components/missingImage/index.tsx
@@ -12,8 +12,8 @@ const MissingImage: FC = () => {
         data-testid="missing-image"
         src={missingImage}
         alt="image missing"
-        width="lg"
-        height="lg"
+        width="xl"
+        height="xl"
         objectFit="cover"
       />
     </Box>

--- a/src/themes/shared/colors.ts
+++ b/src/themes/shared/colors.ts
@@ -14,7 +14,7 @@ export const colors = {
     900: '#13364E',
   },
   gray: {
-    50: '#FAFAFA',
+    50: '#F5F5F5',
     100: '#EAEAEA',
     200: '#CFCFCF',
     300: '#B5B5B5',


### PR DESCRIPTION
References
Notion - gray color: https://www.notion.so/smgnet/Review-light-grey-colors-828e4dab90ce4b1ba12a85f0f436af45
Notion - missing image size icon: https://www.notion.so/smgnet/Missing-image-icon-9396c3d7eb0948d686b495855581fb36

## Thank you 🌖