### PR TITLE
feat: top listing badge component

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -54,6 +54,7 @@ export { default as Text } from './text';
 export { default as Textarea } from './textarea';
 export { default as Tooltip } from './tooltip';
 export { default as Footer } from './footer';
+export { default as TopListingBadge } from './topListingBadge';
 export { default as AppLayout } from './layout/app/AppLayout';
 export { default as AppLayoutHeader } from './layout/app/Header';
 export { default as AppLayoutFooter } from './layout/app/Footer';

--- a/src/components/topListingBadge/index.stories.mdx
+++ b/src/components/topListingBadge/index.stories.mdx
@@ -1,0 +1,31 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Image, Box } from '@chakra-ui/react';
+
+import TopListingBadge from './index.tsx';
+
+<Meta
+  title="Components/Features/TopListingBadge"
+  component={TopListingBadge}
+  args={{
+    aspectRatio: 4 / 3,
+  }}
+  argTypes={{
+    aspectRatio: 'number',
+  }}
+/>
+
+export const Template = (args) => (
+  <Box maxW="400px">
+    <TopListingBadge {...args}>
+      <Image src="https://placekitten.com/g/800/800" objectFit="cover" />
+    </TopListingBadge>
+  </Box>
+);
+
+# Top Listing Badge
+
+<Canvas>
+  <Story name="Overview">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Overview" />

--- a/src/components/topListingBadge/index.stories.mdx
+++ b/src/components/topListingBadge/index.stories.mdx
@@ -1,5 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-import { Image, Box } from '@chakra-ui/react';
+import { Box, Image } from '@chakra-ui/react';
 
 import TopListingBadge from './index.tsx';
 

--- a/src/components/topListingBadge/index.stories.mdx
+++ b/src/components/topListingBadge/index.stories.mdx
@@ -25,7 +25,7 @@ export const Template = (args) => (
 # Top Listing Badge
 
 <Canvas>
-  <Story name="Overview">{Template.bind({})}</Story>
+  <Story name="TopListingBadge">{Template.bind({})}</Story>
 </Canvas>
 
-<ArgsTable story="Overview" />
+<ArgsTable story="TopListingBadge" />

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -30,6 +30,7 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
           transformOrigin="top left"
           width="70px"
           textAlign="center"
+          paddingLeft="sm"
         >
           Top
         </Badge>

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -1,0 +1,47 @@
+import React, { FC, PropsWithChildren } from 'react';
+
+import GridItem from '../grid/GridItem';
+import Grid from '../grid';
+import Box from '../box';
+import AspectRatio from '../aspectRatio';
+
+type Props = {
+  aspectRatio: number;
+};
+
+const TopListingBadge: FC<PropsWithChildren<Props>> = ({
+  children,
+  aspectRatio,
+}) => {
+  return (
+    <Grid>
+      <GridItem gridColumn={1} gridRow={1}>
+        <AspectRatio ratio={aspectRatio}>{children}</AspectRatio>
+      </GridItem>
+      <GridItem
+        gridColumn={1}
+        gridRow={1}
+        zIndex="docked"
+        overflow="hidden"
+        position="relative"
+      >
+        <Box
+          transform="rotate(-45deg) translateX(-50%) translateY(12px)"
+          transformOrigin="top left"
+          bg="brand.100"
+          color="gray.900"
+          fontSize="xs"
+          lineHeight={1.75}
+          width="70px"
+          fontWeight="bold"
+          display="inline-block"
+          textAlign="center"
+        >
+          TOP
+        </Box>
+      </GridItem>
+    </Grid>
+  );
+};
+
+export default TopListingBadge;

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, PropsWithChildren } from 'react';
-import { Badge, Box } from '@chakra-ui/react';
+import { Badge } from '@chakra-ui/react';
 
 import GridItem from '../grid/GridItem';
 import Grid from '../grid';

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -1,8 +1,8 @@
 import React, { FC, PropsWithChildren } from 'react';
+import { Badge, Box } from '@chakra-ui/react';
 
 import GridItem from '../grid/GridItem';
 import Grid from '../grid';
-import Box from '../box';
 import AspectRatio from '../aspectRatio';
 
 type Props = {
@@ -25,20 +25,14 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
         overflow="hidden"
         position="relative"
       >
-        <Box
-          transform="rotate(-45deg) translateX(-50%) translateY(12px)"
+        <Badge
+          transform="rotate(-45deg) translateX(-50%) translateY(9px)"
           transformOrigin="top left"
-          bg="brand.100"
-          color="gray.900"
-          fontSize="xs"
-          lineHeight={1.75}
           width="70px"
-          fontWeight="bold"
-          display="inline-block"
           textAlign="center"
         >
-          TOP
-        </Box>
+          Top
+        </Badge>
       </GridItem>
     </Grid>
   );


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-985

## Motivation and context

As a part of the implementation of product cards, we want to show product previews - in this particular case a top-listing badge.
Since this is a component that will be used on the SRP as well it makes sense to share it from the start

## After

<img width="411" alt="Screenshot 2023-03-03 at 16 25 35" src="https://user-images.githubusercontent.com/144707/222759372-e263eab7-07a9-4f93-a365-6aa711cb5dce.png">
