### PR TITLE
BREAKING CHANGE: ignored some flex properties

### DIFF
--- a/src/components/flex/index.tsx
+++ b/src/components/flex/index.tsx
@@ -1,2 +1,10 @@
-import { Flex } from '@chakra-ui/react';
+import React, { FC } from 'react';
+
+import { Flex as ChakraFlex, FlexProps } from '@chakra-ui/react';
+
+const Flex: FC<Omit<FlexProps, 'gap' | 'columnGap' | 'rowGap'>> = ({
+  children,
+  ...rest
+}) => <ChakraFlex {...rest}>{children}</ChakraFlex>;
+
 export default Flex;

--- a/src/components/footer/Companies.tsx
+++ b/src/components/footer/Companies.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import Flex from '../flex';
+import Stack from '../stack';
 import Box from '../box';
 import FooterLink from './Link';
 import { FooterConfigInstance } from './config/factory';
@@ -11,20 +11,25 @@ interface FooterCompaniesProps {
 
 const FooterCompanies: FC<FooterCompaniesProps> = ({ config }) => {
   return (
-    <Flex
+    <Box
+      gap={{ base: 'md', md: '2xl' }}
       marginBottom="md"
       marginTop="2xl"
-      flexWrap="wrap"
-      justifyContent="center"
+      as={Stack}
+      direction="row"
+      justify="center"
+      wrap="wrap"
     >
       {config.companies.map((companyLink, index) => {
         return (
-          <Box key={`company-${index}`} marginRight={{ base: 'md', md: '2xl' }}>
-            <FooterLink linkInstance={companyLink} bold={true} />
-          </Box>
+          <FooterLink
+            key={`company-${index}`}
+            linkInstance={companyLink}
+            bold={true}
+          />
         );
       })}
-    </Flex>
+    </Box>
   );
 };
 

--- a/src/components/footer/Companies.tsx
+++ b/src/components/footer/Companies.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import Flex from '../flex';
+import Box from '../box';
 import FooterLink from './Link';
 import { FooterConfigInstance } from './config/factory';
 
@@ -13,17 +14,14 @@ const FooterCompanies: FC<FooterCompaniesProps> = ({ config }) => {
     <Flex
       marginBottom="md"
       marginTop="2xl"
-      gap={{ base: 'md', md: '2xl' }}
       flexWrap="wrap"
       justifyContent="center"
     >
       {config.companies.map((companyLink, index) => {
         return (
-          <FooterLink
-            key={`company-${index}`}
-            linkInstance={companyLink}
-            bold={true}
-          />
+          <Box key={`company-${index}`} marginRight={{ base: 'md', md: '2xl' }}>
+            <FooterLink linkInstance={companyLink} bold={true} />
+          </Box>
         );
       })}
     </Flex>


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-1208

## How to test
Please check the next points:

* We must not be able to pass the properties `gap`, `columnGap` and `rowGap`
https://github.com/smg-automotive/listings-web/pull/639/files

* The footer looks as before in the companies section (check all breakpoints)
![Screenshot 2023-03-08 at 13 28 43](https://user-images.githubusercontent.com/37380787/223713492-e7606ab6-cfe9-46c3-917b-3412b8f6cd97.png)

## Take into consideration:
* In seller project I just find one place were we are using gap. I will open a PR for it.

## Thank you 🌕
