### PR TITLE
feat: success button variant

### DIFF
--- a/src/components/button/index.stories.mdx
+++ b/src/components/button/index.stories.mdx
@@ -9,6 +9,8 @@ import Button from './index.tsx';
 
 export const Template = (args) => <Button {...args}>{args.label}</Button>;
 
+export const variants = ['primary', 'secondary', 'success'];
+
 # Button
 
 ## Primary
@@ -24,7 +26,7 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
     }}
     argTypes={{
       variant: {
-        options: ['primary', 'secondary'],
+        options: variants,
         control: 'select',
       },
       size: {
@@ -52,7 +54,7 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
     }}
     argTypes={{
       variant: {
-        options: ['primary', 'secondary'],
+        options: variants,
         control: 'select',
       },
       size: {
@@ -66,6 +68,34 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
 </Canvas>
 
 <ArgsTable story="Secondary" />
+
+## Success
+
+<Canvas>
+  <Story
+    name="Success"
+    args={{
+      isDisabled: false,
+      label: 'Success Button',
+      variant: 'success',
+      size: 'lg',
+    }}
+    argTypes={{
+      variant: {
+        options: variants,
+        control: 'select',
+      },
+      size: {
+        options: ['md', 'lg'],
+        control: 'select',
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Success" />
 
 ## Sizes
 
@@ -87,6 +117,9 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
       <Button variant="secondary" isDisabled={true}>
         Secondary Button
       </Button>
+      <Button variant="success" isDisabled={true}>
+        Success Button
+      </Button>
     </Stack>
   </Story>
 </Canvas>
@@ -106,7 +139,7 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
     }}
     argTypes={{
       variant: {
-        options: ['primary', 'secondary'],
+        options: variants,
         control: 'select',
       },
       size: {
@@ -134,7 +167,7 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
     }}
     argTypes={{
       variant: {
-        options: ['primary', 'secondary'],
+        options: variants,
         control: 'select',
       },
       size: {
@@ -167,7 +200,7 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
     }}
     argTypes={{
       variant: {
-        options: ['primary', 'secondary'],
+        options: variants,
         control: 'select',
       },
       size: {
@@ -200,7 +233,7 @@ export const Template = (args) => <Button {...args}>{args.label}</Button>;
     }}
     argTypes={{
       variant: {
-        options: ['primary', 'secondary'],
+        options: variants,
         control: 'select',
       },
       size: {

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -20,7 +20,7 @@ type IconButton = {
 
 type SharedProps = {
   as?: 'button';
-  variant?: 'primary' | 'secondary';
+  variant?: 'primary' | 'secondary' | 'success';
   size?: 'md' | 'lg';
   children: ReactNode;
   leftIcon?: ReactElement;

--- a/src/themes/components/button.ts
+++ b/src/themes/components/button.ts
@@ -54,6 +54,23 @@ const variants = {
       pointerEvents: 'none',
     },
   },
+  success: {
+    bg: 'green.500',
+    color: 'white',
+    _hover: {
+      filter: 'brightness(1.1)',
+    },
+    _active: {
+      filter: 'none',
+      bg: 'green.500',
+    },
+    _disabled: {
+      bg: 'gray.100',
+      boxShadow: 'none',
+      color: 'gray.400',
+      pointerEvents: 'none',
+    },
+  },
 };
 
 const Button: ComponentStyleConfig = {


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-985

## Motivation and context

To implement a [selected state of the feature card component](https://www.figma.com/file/dMPSVZaUu1WZOmfVtHnqhO/Insertion-PART-2?node-id=142%3A43459&t=Q5JLFOEsjK6NzLNf-0) we need a new button variant. This PR adds a `success` button.

## After

<img width="151" alt="Screenshot 2023-03-08 at 13 36 10" src="https://user-images.githubusercontent.com/144707/223714965-d160fb56-a168-4220-bf8f-beb60e7e3dae.png">

