### PR TITLE
feat: add warning icon

### DIFF
--- a/src/components/icons/WarningIcon.tsx
+++ b/src/components/icons/WarningIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createIcon } from '@chakra-ui/react';
+
+export const WarningIcon = createIcon({
+  displayName: 'Warning',
+  viewBox: '0 0 24 24',
+  path: (
+    <>
+      <title>Warning icon</title>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M1 22L12 2L23 22H1ZM4.37 20H19.62L12 6.16L4.37 20ZM13 14L11 15V10H13V14ZM11 19L13 18V16H11V19Z"
+        fill="currentColor"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -45,6 +45,7 @@ export { TwitterIcon } from './TwitterIcon';
 export { UtilityVehicleIcon } from './UtilityVehicleIcon';
 export { VehiclePowerIcon } from './VehiclePowerIcon';
 export { VideoIcon } from './VideoIcon';
+export { WarningIcon } from './WarningIcon';
 export { WhatsAppIcon } from './WhatsAppIcon';
 export { YoutubeIcon } from './YoutubeIcon';
 export { HeartIcon } from './HeartIcon';


### PR DESCRIPTION
Adds a `WarningIcon` needed to implement error messages on product cards:

![Screenshot 2023-03-15 at 16 59 38](https://user-images.githubusercontent.com/144707/225368186-ee436ab5-2404-47f0-ac77-a0fca3d5250a.png)
