### PR TITLE
feat: whitelist textStyle for heading components

### DIFF
--- a/src/components/heading/index.tsx
+++ b/src/components/heading/index.tsx
@@ -1,56 +1,62 @@
 import React, { FC } from 'react';
 import { Heading as ChakraHeading, HeadingProps } from '@chakra-ui/react';
 
-export const H1: FC<Omit<HeadingProps, 'as' | 'textStyle'>> = ({
+export const H1: FC<Omit<HeadingProps, 'as'>> = ({
+  textStyle = 'heading1',
   children,
   ...rest
 }) => (
-  <ChakraHeading as="h1" textStyle="heading1" {...rest}>
+  <ChakraHeading as="h1" textStyle={textStyle} {...rest}>
     {children}
   </ChakraHeading>
 );
 
-export const H2: FC<Omit<HeadingProps, 'as' | 'textStyle'>> = ({
+export const H2: FC<Omit<HeadingProps, 'as'>> = ({
+  textStyle = 'heading2',
   children,
   ...rest
 }) => (
-  <ChakraHeading as="h2" textStyle="heading2" {...rest}>
+  <ChakraHeading as="h2" textStyle={textStyle} {...rest}>
     {children}
   </ChakraHeading>
 );
 
-export const H3: FC<Omit<HeadingProps, 'as' | 'textStyle'>> = ({
+export const H3: FC<Omit<HeadingProps, 'as'>> = ({
+  textStyle = 'heading3',
   children,
   ...rest
 }) => (
-  <ChakraHeading as="h3" textStyle="heading3" {...rest}>
+  <ChakraHeading as="h3" textStyle={textStyle} {...rest}>
     {children}
   </ChakraHeading>
 );
 
-export const H4: FC<Omit<HeadingProps, 'as' | 'textStyle'>> = ({
+export const H4: FC<Omit<HeadingProps, 'as'>> = ({
+  textStyle = 'heading4',
   children,
   ...rest
 }) => (
-  <ChakraHeading as="h4" textStyle="heading4" {...rest}>
+  <ChakraHeading as="h4" textStyle={textStyle} {...rest}>
     {children}
   </ChakraHeading>
 );
 
-export const H5: FC<Omit<HeadingProps, 'as' | 'textStyle'>> = ({
+export const H5: FC<Omit<HeadingProps, 'as'>> = ({
+  textStyle = 'heading5',
   children,
   ...rest
 }) => (
-  <ChakraHeading as="h5" textStyle="heading5" {...rest}>
+  <ChakraHeading as="h5" textStyle={textStyle} {...rest}>
     {children}
   </ChakraHeading>
 );
 
-export const H6: FC<Omit<HeadingProps, 'as' | 'textStyle'>> = ({
+export const H6: FC<Omit<HeadingProps, 'as'>> = ({
+  textStyle = 'heading6',
   children,
   ...rest
 }) => (
-  <ChakraHeading as="h6" textStyle="heading6" {...rest}>
+  <ChakraHeading as="h6" textStyle={textStyle} {...rest}>
     {children}
   </ChakraHeading>
 );


### PR DESCRIPTION
References [DM-1427](https://autoricardo.atlassian.net/browse/DM-1427)

## Motivation and context

as per [WCAG 2.0](https://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G141), it's important to follow proper nesting on the page (h2 after h1 etc.). To meet our design requirements, it happens that a heading that is for example a h3 as per nesting, should look like an h4.

## Before

textStyle is not allowed

## After

textStyle is allowed

## How to test

-

[DM-1427]: https://autoricardo.atlassian.net/browse/DM-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ