### PR TITLE
fix: list style for unordered and ordered list

### DIFF
--- a/src/components/list/OrderedList.stories.mdx
+++ b/src/components/list/OrderedList.stories.mdx
@@ -35,14 +35,13 @@ import ListItem from './ListItem.tsx';
 />
 
 export const Template = ({ showContainer, ...args }) => (
-  <Box
-    maxW="200px"
-    border={showContainer ? '1px solid black' : '1px solid transparent'}
-  >
-    <OrderedList {...args} bg={showContainer ? 'gray.100' : 'inherit'}>
-      <ListItem>
-        Item 1 is a very long item that will wrap to the next line
-      </ListItem>
+  <Box maxW="100px">
+    <OrderedList
+      {...args}
+      border={showContainer ? '1px solid black' : '1px solid transparent'}
+      bg={showContainer ? 'gray.100' : 'inherit'}
+    >
+      <ListItem>Item 1 is very long</ListItem>
       <ListItem>Item 2</ListItem>
       <ListItem>Item 3</ListItem>
     </OrderedList>

--- a/src/components/list/OrderedList.stories.mdx
+++ b/src/components/list/OrderedList.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 import Box from 'src/components/box';
 
-import OrderedList from './OrderedList';
+import OrderedList, { styleTypes } from './OrderedList';
 import ListItem from './ListItem.tsx';
 
 <Meta
@@ -21,12 +21,15 @@ import ListItem from './ListItem.tsx';
   argTypes={{
     size: {
       control: 'select',
+      options: ['sm', 'md'],
     },
     variant: {
       control: 'select',
+      options: ['icon-inside', 'icon-outside'],
     },
     styleType: {
       control: 'select',
+      options: styleTypes,
     },
   }}
 />

--- a/src/components/list/UnorderedList.stories.mdx
+++ b/src/components/list/UnorderedList.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 import Box from 'src/components/box';
 
-import UnorderedList from './UnorderedList';
+import UnorderedList, { styleTypes } from './UnorderedList';
 import ListItem from './ListItem.tsx';
 
 <Meta
@@ -14,19 +14,21 @@ import ListItem from './ListItem.tsx';
   args={{
     size: 'md',
     variant: 'icon-inside',
-    start: 1,
     styleType: 'initial',
     showContainer: false,
   }}
   argTypes={{
     size: {
       control: 'select',
+      options: ['sm', 'md'],
     },
     variant: {
       control: 'select',
+      options: ['icon-inside', 'icon-outside'],
     },
     styleType: {
       control: 'select',
+      options: styleTypes,
     },
     showContainer: {
       control: 'boolean',

--- a/src/components/list/UnorderedList.stories.mdx
+++ b/src/components/list/UnorderedList.stories.mdx
@@ -37,14 +37,13 @@ import ListItem from './ListItem.tsx';
 />
 
 export const Template = ({ showContainer, ...args }) => (
-  <Box
-    maxW="200px"
-    border={showContainer ? '1px solid black' : '1px solid transparent'}
-  >
-    <UnorderedList {...args} bg={showContainer ? 'gray.100' : 'inherit'}>
-      <ListItem>
-        Item 1 is a very long item that will wrap to the next line
-      </ListItem>
+  <Box maxW="100px">
+    <UnorderedList
+      {...args}
+      border={showContainer ? '1px solid black' : '1px solid transparent'}
+      bg={showContainer ? 'gray.100' : 'inherit'}
+    >
+      <ListItem>Item 1 is very long</ListItem>
       <ListItem>Item 2</ListItem>
       <ListItem>Item 3</ListItem>
     </UnorderedList>

--- a/src/themes/components/list.ts
+++ b/src/themes/components/list.ts
@@ -36,11 +36,6 @@ const variants = {
     container: defineStyle({
       listStylePos: 'inside',
     }),
-    item: defineStyle({
-      _before: {
-        content: '""',
-      },
-    }),
   }),
   'icon-outside': definePartsStyle({
     container: defineStyle({

--- a/src/themes/components/list.ts
+++ b/src/themes/components/list.ts
@@ -51,6 +51,6 @@ export default defineMultiStyleConfig({
   variants,
   defaultProps: {
     size: 'md',
-    variant: 'icon-outside',
+    variant: 'icon-inside',
   },
 }) as ComponentStyleConfig;

--- a/src/themes/components/list.ts
+++ b/src/themes/components/list.ts
@@ -51,6 +51,6 @@ export default defineMultiStyleConfig({
   variants,
   defaultProps: {
     size: 'md',
-    variant: 'icon-inside',
+    variant: 'icon-outside',
   },
 }) as ComponentStyleConfig;

--- a/src/themes/components/list.ts
+++ b/src/themes/components/list.ts
@@ -5,10 +5,6 @@ import {
 } from '@chakra-ui/react';
 import { listAnatomy as parts } from '@chakra-ui/anatomy';
 
-import { styleTypes as unorderedStyleTypes } from 'src/components/list/UnorderedList';
-
-import { fontSizes } from '../shared/fontSizes';
-
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(parts.keys);
 
@@ -36,25 +32,22 @@ const sizes = {
 };
 
 const variants = {
-  'icon-inside': definePartsStyle(({ size, styleType }) => ({
+  'icon-inside': definePartsStyle({
     container: defineStyle({
       listStylePos: 'inside',
     }),
     item: defineStyle({
       _before: {
         content: '""',
-        marginStart: unorderedStyleTypes.includes(styleType)
-          ? `calc(-${fontSizes[size as keyof typeof fontSizes]} / 2)`
-          : '',
       },
     }),
-  })),
-  'icon-outside': definePartsStyle(({ size }) => ({
+  }),
+  'icon-outside': definePartsStyle({
     container: defineStyle({
       listStylePos: 'outside',
-      marginStart: fontSizes[size as keyof typeof fontSizes],
+      marginStart: '1em',
     }),
-  })),
+  }),
 };
 
 export default defineMultiStyleConfig({


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

If you open https://main-components-pkg.branch.autoscout24.dev/?path=/story/components-data-display-list-unordered-list--unordered-list in Firefox, you can see that there is no space between the bullet point and the list item text. This is caused by the margin we overwrite in the styles. This PR addresses the following issues:

1. removing the margin for the inside variant. This was not needed and caused the bullet points and text being too close to each other
2. setting the margin for the outside variant to 1em (same as chakra has by default: https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/layout/src/list.tsx#L107, but it's only needed for outside)

FYI: there is a bug in chromium browsers, nothing we can do there:
<img width="1025" alt="Bildschirm­foto 2023-04-05 um 16 16 27" src="https://user-images.githubusercontent.com/71456764/230108754-01130f7f-712c-463e-a878-48f9772ab468.png">

## How to test
- https://talamcol-fix-list-style-components-pkg.branch.autoscout24.dev/?path=/story/components-data-display-list-unordered-list--unordered-list
- https://talamcol-fix-list-style-components-pkg.branch.autoscout24.dev/?path=/story/components-data-display-list-ordered-list--ordered-list
- https://github.com/smg-automotive/listings-web/pull/743
- the features page in seller-web is not affected by this. I checked