### PR TITLE
fix: make onClick optional for popover action button

### DIFF
--- a/src/components/popoverFilter/ActionButton.tsx
+++ b/src/components/popoverFilter/ActionButton.tsx
@@ -20,7 +20,7 @@ const FilterActionButton: FC<Props> = ({
       onClick={
         isApplied
           ? () => {
-              actionButton.onClick();
+              actionButton.onClick?.();
               onClose();
             }
           : onClose

--- a/src/components/popoverFilter/props.ts
+++ b/src/components/popoverFilter/props.ts
@@ -8,7 +8,7 @@ export type PopoverFilterProps = {
    */
   actionButton: {
     label: string;
-    onClick: () => void;
+    onClick?: () => void;
   };
   /**
    * Shows the value of the filter in default and open state.


### PR DESCRIPTION
References [DM-1442](https://autoricardo.atlassian.net/browse/DM-1442)

## Motivation and context

Since we apply search realtime when a filter is changed, the onClick handler of the action button is usually not needed. 

## Before

Passing onClick={()=> null}

## After

onClick is now optional and does not have to be passed

[DM-1442]: https://autoricardo.atlassian.net/browse/DM-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ