### PR TITLE
fix: adjusted target and rel in link

### DIFF
--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -59,7 +59,13 @@ import Link from './index.tsx';
 
 <Canvas>
   <Story name="Link with rel and target">
-    <Link rel="nofollow noopener noreferrer" target="_blank" href="https://autoscout24.ch">AutoScout24 Homepage</Link>
+    <Link
+      rel="nofollow noopener noreferrer"
+      target="_blank"
+      href="https://autoscout24.ch"
+    >
+      AutoScout24 Homepage
+    </Link>
   </Story>
 </Canvas>
 
@@ -67,6 +73,8 @@ import Link from './index.tsx';
 
 <Canvas>
   <Story name="Link with external rel">
-    <Link isExternal={true} href="https://autoscout24.ch">AutoScout24 Homepage</Link>
+    <Link isExternal={true} href="https://autoscout24.ch">
+      AutoScout24 Homepage
+    </Link>
   </Story>
 </Canvas>

--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -54,3 +54,19 @@ import Link from './index.tsx';
     </p>
   </Story>
 </Canvas>
+
+## Link with rel and target
+
+<Canvas>
+  <Story name="Link with rel and target">
+    <Link rel="nofollow noopener noreferrer" target="_blank" href="https://autoscout24.ch">AutoScout24 Homepage</Link>
+  </Story>
+</Canvas>
+
+## Link with external rel
+
+<Canvas>
+  <Story name="Link with external rel">
+    <Link isExternal={true} href="https://autoscout24.ch">AutoScout24 Homepage</Link>
+  </Story>
+</Canvas>

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -14,6 +14,7 @@ interface Props {
   rightIcon?: ReactElement;
   isExternal?: boolean;
   rel?: string;
+  target?: string;
   variant?: 'baseLink' | 'navigationLink' | 'subNavigationLink';
   [key: string]: unknown;
   fontWeight?: 'regular' | 'bold';
@@ -27,6 +28,7 @@ const Link = forwardRef<HTMLAnchorElement, Props>(
       children,
       isExternal = false,
       rel,
+      target,
       leftIcon,
       rightIcon,
       variant = 'baseLink',
@@ -50,8 +52,8 @@ const Link = forwardRef<HTMLAnchorElement, Props>(
 
     return (
       <Component
-        target={isExternal ? '_blank' : undefined}
-        rel={rel || isExternal ? 'noopener noreferrer' : undefined}
+        target={target || (isExternal ? '_blank' : undefined)}
+        rel={rel || (isExternal ? 'noopener noreferrer' : undefined)}
         ref={ref}
         {...rest}
         fontWeight={fontWeight}


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-968

## Motivation and context

To be able to pass the next `rel` and `target` as the image showed we need to make target and rel approachable.

<img width="912" alt="Screenshot 2023-04-11 at 14 24 18" src="https://user-images.githubusercontent.com/37380787/231162593-a0085557-ff32-4c9e-bf8f-4e691554c16b.png">

## How to test

Please check the las 2 variations from the Link component

## Thank you 🪺
