### PR TITLE
fix(Icon): make the chevron up icon point to the right direction

### DIFF
--- a/src/components/icons/ChevronUpSmallIcon.tsx
+++ b/src/components/icons/ChevronUpSmallIcon.tsx
@@ -10,8 +10,8 @@ export const ChevronUpSmallIcon = createIcon({
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-        fill="currentColor"
+        d="m5 15 1.415 1.415L12 10.83l5.589 5.581L18.999 15 12 8l-7 7Z"
+        fill="#currentColor"
       />
     </>
   ),

--- a/src/components/icons/ChevronUpSmallIcon.tsx
+++ b/src/components/icons/ChevronUpSmallIcon.tsx
@@ -11,7 +11,7 @@ export const ChevronUpSmallIcon = createIcon({
         fillRule="evenodd"
         clipRule="evenodd"
         d="m5 15 1.415 1.415L12 10.83l5.589 5.581L18.999 15 12 8l-7 7Z"
-        fill="#currentColor"
+        fill="currentColor"
       />
     </>
   ),


### PR DESCRIPTION
References N/a

## Motivation and context

![image](https://user-images.githubusercontent.com/3371760/231466628-3be779e5-30a4-420b-80a7-377b3af64a1b.png)
The icon points the wrong way
