### PR TITLE
fix: enable tooltiop close/open on touch screens

### DIFF
--- a/src/components/tooltip/__tests__/Tooltip.Test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.Test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
-import { fireEvent } from '@storybook/testing-library';
 
 import Tooltip from '..';
 
@@ -19,17 +19,20 @@ describe('<Tooltip />', () => {
     expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument();
   });
 
-  it('shows tooltip label on focus in', async () => {
+  it('shows tooltip label on hover', async () => {
     renderWrapper();
-    fireEvent.focusIn(screen.getByTestId('test-tooltip'));
-    expect(await screen.findByText(tooltipLabel)).toBeInTheDocument();
+    userEvent.hover(screen.getByTestId('test-tooltip'));
+    const tooltipLabelElement = await screen.findByText(tooltipLabel);
+    expect(tooltipLabelElement).toBeInTheDocument();
   });
 
-  it('does not show tooltip label on focus out', async () => {
+  it('does not show tooltip label on unhover', async () => {
+    const user = userEvent.setup();
     renderWrapper();
-    fireEvent.focusOut(screen.getByTestId('test-tooltip'));
-    await waitFor(() => {
-      expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument();
-    });
+    user.hover(screen.getByTestId('test-tooltip'));
+    user.unhover(screen.getByTestId('test-tooltip'));
+    return waitFor(() =>
+      expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument()
+    );
   });
 });

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { cloneElement, FC, useState } from 'react';
 
 import { Tooltip as ChakraTooltip, TooltipProps } from '@chakra-ui/react';
 
@@ -7,9 +7,24 @@ type Props = {
 } & Pick<TooltipProps, 'label' | 'placement' | 'maxWidth'>;
 
 const Tooltip: FC<Props> = ({ children, ...props }) => {
+  const [isLabelOpen, setIsLabelOpen] = useState<boolean>(false);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const childrenWithProps = cloneElement(children as React.ReactElement<any>, {
+    onMouseEnter: () => setIsLabelOpen(true),
+    onMouseLeave: () => setIsLabelOpen(false),
+    onClick: () => setIsLabelOpen(true),
+  });
+
   return (
-    <ChakraTooltip hasArrow placement="auto" maxWidth="6xl" {...props}>
-      {children}
+    <ChakraTooltip
+      hasArrow
+      placement="auto"
+      maxWidth="6xl"
+      isOpen={isLabelOpen}
+      {...props}
+    >
+      {childrenWithProps}
     </ChakraTooltip>
   );
 };


### PR DESCRIPTION
References [FE-142](https://autoricardo.atlassian.net/browse/FE-142)

## Motivation and context

Chakra-ui Tooltip is not created for touch screens. It was created for hover state. We are wrapping their comp and just omit some props.

## Before

No support for touch screens.

## After

Support touch screens.

## How to test
- Open branch dev storybook. 
- Find Tooltip.
- Switch to mobile mode in browser dev.
- Try to open and close tooltip label via press.


[FE-142]: https://autoricardo.atlassian.net/browse/FE-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ