### PR TITLE
fix: accepted all style props

### DIFF
--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,19 +1,7 @@
 import React, { FC } from 'react';
 import { Text as ChakraText, TextProps } from '@chakra-ui/react';
 
-type Props = Pick<
-  TextProps,
-  | 'as'
-  | 'children'
-  | 'color'
-  | 'textStyle'
-  | 'textAlign'
-  | 'isTruncated'
-  | 'noOfLines'
-  | 'marginBottom'
->;
-
-const Text: FC<Props> = ({ children, ...chakraProps }) => (
+const Text: FC<TextProps> = ({ children, ...chakraProps }) => (
   <ChakraText {...chakraProps}>{children}</ChakraText>
 );
 

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,8 +1,3 @@
-import React, { FC } from 'react';
-import { Text as ChakraText, TextProps } from '@chakra-ui/react';
-
-const Text: FC<TextProps> = ({ children, ...chakraProps }) => (
-  <ChakraText {...chakraProps}>{children}</ChakraText>
-);
+import { Text } from '@chakra-ui/react';
 
 export default Text;

--- a/src/themes/stories/BorderRadiusShowcase.tsx
+++ b/src/themes/stories/BorderRadiusShowcase.tsx
@@ -16,7 +16,7 @@ const BorderRadiusShowcase: FC = () => {
             >
               {name}
             </Button>
-            <Text mt={2}>{radii as string}</Text>
+            <Text mt="xs">{radii as string}</Text>
           </Flex>
         );
       })}

--- a/src/themes/stories/TypographyShowcase.tsx
+++ b/src/themes/stories/TypographyShowcase.tsx
@@ -8,7 +8,7 @@ const TypographyShowcase: FC = () => {
     <>
       {Object.entries(theme.textStyles).map(([name, typography]) => {
         return (
-          <Text key={name} mb={5} style={typography as CSSProperties}>
+          <Text key={name} mb="lg" style={typography as CSSProperties}>
             {name}
           </Text>
         );


### PR DESCRIPTION
References
> Slack discussion:  https://automotivesmg.slack.com/archives/C034EGP8GG0/p1680175774281809

## Motivation and context

I will go through all the components we have so far and give the flexibility to taking all the style props that the component offers BUT taking into consideration the DS, in some components we must restrict some props styles. 

## Take into consideration
After I merge this change I will make a clean up in all the projects, removing the extra wrappers we added, making the DOM cleaner. Wait for the PRs...

Note: this is not a breaking change.

## Before

The text component picked some style props

## After

The text component takes all the style props without any restriction.

## Thank you 🧘🏼‍♀️


