### PR TITLE
fix: set base as the default variant for modal

### DIFF
--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -126,5 +126,5 @@ const sizes = {
 export default defineMultiStyleConfig({
   variants,
   sizes,
-  defaultProps: { size: 'md' },
+  defaultProps: { size: 'md', variant: 'base' },
 }) as ComponentStyleConfig;


### PR DESCRIPTION
Latest changes in the modal theme broke the ModalFilter.
Having `base` as the default props for variant should fix it.
