### PR TITLE
fix: header&footer container width & lighthouse improvements

### DIFF
--- a/src/components/navigation/footer/index.tsx
+++ b/src/components/navigation/footer/index.tsx
@@ -56,7 +56,7 @@ const Footer: FC<FooterProps> = ({
           <Center>
             <Container
               width="full"
-              maxWidth="container.xl"
+              maxWidth="container.2xl"
               paddingX={{ base: 0, md: 'lg' }}
             >
               <FooterSectionGrid config={config} />

--- a/src/components/navigation/header/NavigationAvatar.tsx
+++ b/src/components/navigation/header/NavigationAvatar.tsx
@@ -60,7 +60,6 @@ export const NavigationAvatar: FC<NavigationAvatarProps> = ({
       onClick={onLogin}
       __css={linkStyles.link}
       fontWeight="bold"
-      color="gray.900"
       position="relative"
       top="1px"
     >

--- a/src/components/navigation/header/NavigationAvatar.tsx
+++ b/src/components/navigation/header/NavigationAvatar.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from 'react';
-import { HStack } from '@chakra-ui/react';
+import { useI18n } from '@smg-automotive/i18n-pkg';
+import { HStack, useMultiStyleConfig } from '@chakra-ui/react';
 
 import Hide from 'src/components/hide';
 import Box from 'src/components/box';
 import Avatar from 'src/components/avatar';
 
-import NavigationLink from './links/NavigationLink';
 import { Drawer } from './hooks/useNavigationDrawer';
 import { DrawerIndicator } from './drawer/DrawerIndicator';
 import { DrawerNode } from './config/drawerNodeItems';
@@ -30,6 +30,9 @@ export const NavigationAvatar: FC<NavigationAvatarProps> = ({
   onLogin,
 }) => {
   const isDrawerOpened = isOpen && drawer?.current === DrawerNode.User;
+  const linkStyles = useMultiStyleConfig('Link', { variant: 'navigationLink' });
+  const { t } = useI18n();
+
   if (user) {
     return (
       <HStack
@@ -54,19 +57,17 @@ export const NavigationAvatar: FC<NavigationAvatarProps> = ({
 
   return (
     <HStack
-      spacing="xs"
-      cursor="pointer"
-      _hover={{ color: 'blue.700' }}
-      color="gray.900"
+      onClick={onLogin}
+      __css={linkStyles.link}
       fontWeight="bold"
+      color="gray.900"
+      position="relative"
+      top="1px"
     >
-      <NavigationLink
-        translationKey="header.login"
-        fontWeight="bold"
-        leftIcon={<Avatar />}
-        hideTextBelow="sm"
-        onClick={onLogin}
-      />
+      <Hide below="sm" marginRight="xs">
+        {t('header.login')}
+      </Hide>
+      <Box as={Avatar} marginLeft="2px" />
     </HStack>
   );
 };

--- a/src/components/navigation/header/NavigationItems.tsx
+++ b/src/components/navigation/header/NavigationItems.tsx
@@ -47,6 +47,7 @@ export const NavigationItems: FC<NavigationItemsProps> = ({
           width={{ sm: '124px', base: '101px' }}
           height={{ sm: '30px', base: 'sm' }}
           src={logo}
+          alt="Platform logo"
         />
       </Link>
       <NavigationItem

--- a/src/components/navigation/header/drawer/index.tsx
+++ b/src/components/navigation/header/drawer/index.tsx
@@ -32,6 +32,7 @@ export const NavigationDrawer: FC<NavigationDrawerProps> = ({
           data-testid="drawer-body"
           py={{ md: '2xl' }}
           px={{ md: 'xs' }}
+          maxWidth="container.2xl"
           width="full"
           margin={{ xl: 'auto' }}
         >

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -96,6 +96,7 @@ const Navigation: FC<NavigationProps> = ({
         backgroundColor="white"
       >
         <Box
+          maxWidth="container.2xl"
           height={config.menuHeight}
           alignItems="center"
           margin="auto"

--- a/src/themes/shared/sizes.ts
+++ b/src/themes/shared/sizes.ts
@@ -16,6 +16,7 @@ export const sizes = {
     md: '768px',
     lg: '1024px',
     xl: '1280px',
+    '2xl': '1604px',
   },
 };
 


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Adding max-width for navigation containers (header & footer). Minor lighthouse improvements.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
