### PR TITLE
fix: change chevron icon

### DIFF
--- a/src/components/icons/ChevronUpLargeIcon.tsx
+++ b/src/components/icons/ChevronUpLargeIcon.tsx
@@ -8,7 +8,7 @@ export const ChevronUpLargeIcon = createIcon({
     <>
       <title>Chevron up large icon</title>
       <path
-        d="M19.59 16.41L12 8.83L4.42 16.41L3 15L12 6L21 15L19.59 16.41Z"
+        d="M5 15L6.415 16.415L12.0002 10.8298L17.5888 16.4111L18.9999 14.9999L12 8L5 15Z"
         fill="currentColor"
       />
     </>


### PR DESCRIPTION
References [VSST-1200](https://autoricardo.atlassian.net/browse/VSST-1200)

## Motivation and context
Current icon is too big in the accordion. It needs to be replaced with a smaller one

## Before / After
![Cursor_and_83f810b4-bd06-4b29-afa9-42a6ef55817b__440×375_](https://github.com/smg-automotive/components-pkg/assets/14924034/f0b30d0f-7d0c-4d50-b3bf-adeecc11fde2)



## How to test
Check if the icon is smaller on a accordion


[VSST-1200]: https://autoricardo.atlassian.net/browse/VSST-1200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ