### PR TITLE
feat: extending LayoutWithVehicleReference component

### DIFF
--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -7,7 +7,7 @@ import { sizes } from 'src/themes/shared/sizes';
 import Divider from '../divider';
 
 interface Props {
-  header: ReactNode;
+  header?: ReactNode;
   footer?: ReactNode;
   skyScraperAd?: ReactNode;
   maxContentWidth: keyof typeof sizes.container;
@@ -22,8 +22,12 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
 }) => {
   return (
     <>
-      {header}
-      <Divider />
+      {header ? (
+        <>
+          {header}
+          <Divider />
+        </>
+      ) : null}
       <Flex justifyContent="center">
         <Container
           as="main"

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -10,7 +10,7 @@ import BaseGridLayout, { repeatArea } from './BaseGrid';
 type ColumSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
 interface Props {
-  header: ReactNode;
+  header?: ReactNode;
   title?: string | ReactNode;
   backLink?: {
     text: string;

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -2,6 +2,8 @@ import React, { FC, ReactNode } from 'react';
 
 import { GridItem, Heading } from '@chakra-ui/react';
 
+import { sizes } from 'src/themes/shared/sizes';
+
 import Link from '../link';
 import { ArrowLeftIcon } from '../icons';
 import BaseLayout from './BaseLayout';
@@ -24,6 +26,7 @@ interface Props {
     content: ReactNode;
     columns?: ColumnSize;
   };
+  maxContentWidth?: keyof typeof sizes.container;
 }
 
 const TwoColumnsLayout: FC<Props> = ({
@@ -32,9 +35,10 @@ const TwoColumnsLayout: FC<Props> = ({
   backLink,
   left: { content: leftContent, columns: leftColumns = 6 },
   right: { content: rightContent, columns: rightColumns = 6 },
+  maxContentWidth = 'lg',
 }) => {
   return (
-    <BaseLayout header={header} maxContentWidth="lg">
+    <BaseLayout header={header} maxContentWidth={maxContentWidth}>
       <BaseGridLayout
         templateAreas={{
           '2xs': `"backlink" ${

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -7,7 +7,7 @@ import { ArrowLeftIcon } from '../icons';
 import BaseLayout from './BaseLayout';
 import BaseGridLayout, { repeatArea } from './BaseGrid';
 
-export type ColumSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+export type ColumnSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
 interface Props {
   header?: ReactNode;
@@ -18,11 +18,11 @@ interface Props {
   };
   left: {
     content: ReactNode;
-    columns?: ColumSize;
+    columns?: ColumnSize;
   };
   right: {
     content: ReactNode;
-    columns?: ColumSize;
+    columns?: ColumnSize;
   };
 }
 

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -7,7 +7,7 @@ import { ArrowLeftIcon } from '../icons';
 import BaseLayout from './BaseLayout';
 import BaseGridLayout, { repeatArea } from './BaseGrid';
 
-type ColumSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+export type ColumSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
 interface Props {
   header?: ReactNode;

--- a/src/components/layout/WithVehicleReference.stories.mdx
+++ b/src/components/layout/WithVehicleReference.stories.mdx
@@ -1,10 +1,10 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { Box } from '@chakra-ui/react';
 
-import Button from '../button';
 import SimpleHeader from '../simpleHeader';
 import Input from '../input';
 import FormControl from '../formControl';
+import Button from '../button';
 import LayoutWithVehicleReference from './WithVehicleReference.tsx';
 
 <Meta

--- a/src/components/layout/WithVehicleReference.stories.mdx
+++ b/src/components/layout/WithVehicleReference.stories.mdx
@@ -1,5 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Box } from '@chakra-ui/react';
 
+import Button from '../button';
 import SimpleHeader from '../simpleHeader';
 import Input from '../input';
 import FormControl from '../formControl';
@@ -9,12 +11,6 @@ import LayoutWithVehicleReference from './WithVehicleReference.tsx';
   title="Layout/Pages/Layout with vehicle reference"
   component={LayoutWithVehicleReference}
   args={{
-    header: (
-      <SimpleHeader
-        title="I am a simple header!"
-        url="https://www.autoscout24.ch/de"
-      />
-    ),
     vehicle: {
       vehicleTitle: 'AUDI A5 Sportback 3.0 TDI quattro S-tronic (Limousine)',
       price: `CHF 23'900.–`,
@@ -47,6 +43,11 @@ import LayoutWithVehicleReference from './WithVehicleReference.tsx';
         disable: true,
       },
     },
+    callToAction: {
+      table: {
+        disable: true,
+      },
+    },
   }}
   parameters={{
     layout: 'fullscreen',
@@ -64,6 +65,12 @@ export const Template = (args) => <LayoutWithVehicleReference {...args} />;
     name="With title"
     args={{
       title: 'Nachricht an den Verkäufer',
+      header: (
+        <SimpleHeader
+          title="I am a simple header!"
+          url="https://www.autoscout24.ch/de"
+        />
+      ),
     }}
   >
     {Template.bind({})}
@@ -82,6 +89,12 @@ export const Template = (args) => <LayoutWithVehicleReference {...args} />;
         text: 'Back',
         url: 'https://www.autoscout24.ch/de',
       },
+      header: (
+        <SimpleHeader
+          title="I am a simple header!"
+          url="https://www.autoscout24.ch/de"
+        />
+      ),
     }}
   >
     {Template.bind({})}
@@ -93,7 +106,37 @@ export const Template = (args) => <LayoutWithVehicleReference {...args} />;
 ## Without back link and title
 
 <Canvas>
-  <Story name="Without back link and title">{Template.bind({})}</Story>
+  <Story
+    name="Without back link and title"
+    args={{
+      header: (
+        <SimpleHeader
+          title="I am a simple header!"
+          url="https://www.autoscout24.ch/de"
+        />
+      ),
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Without header & with CTA"
+    args={{
+      title: 'Nachricht an den Verkäufer',
+      callToAction: (
+        <Box marginBottom="xl">
+          <Button variant="secondary" onClick={() => ({})} width="full">
+            View vehicle
+          </Button>
+        </Box>
+      ),
+    }}
+  >
+    {Template.bind({})}
+  </Story>
 </Canvas>
 
 <ArgsTable story="Without back link and title" />

--- a/src/components/layout/WithVehicleReference.stories.mdx
+++ b/src/components/layout/WithVehicleReference.stories.mdx
@@ -17,6 +17,13 @@ import LayoutWithVehicleReference from './WithVehicleReference.tsx';
       sellerName: `Auto-Center Grenchen AG 2540 Grenchen (SO)`,
       sellerAddress: `2540 Grenchen (SO)`,
       image: <img src="/dummyImage.jpeg" alt="vehicle reference image" />,
+      callToAction: (
+        <Box marginBottom="xl">
+          <Button variant="secondary" onClick={() => ({})} width="full">
+            View vehicle
+          </Button>
+        </Box>
+      ),
     },
     children: (
       <>
@@ -39,11 +46,6 @@ import LayoutWithVehicleReference from './WithVehicleReference.tsx';
       },
     },
     header: {
-      table: {
-        disable: true,
-      },
-    },
-    callToAction: {
       table: {
         disable: true,
       },
@@ -123,16 +125,9 @@ export const Template = (args) => <LayoutWithVehicleReference {...args} />;
 
 <Canvas>
   <Story
-    name="Without header & with CTA"
+    name="Without header"
     args={{
       title: 'Nachricht an den Verkäufer',
-      callToAction: (
-        <Box marginBottom="xl">
-          <Button variant="secondary" onClick={() => ({})} width="full">
-            View vehicle
-          </Button>
-        </Box>
-      ),
     }}
   >
     {Template.bind({})}

--- a/src/components/layout/WithVehicleReference.stories.mdx
+++ b/src/components/layout/WithVehicleReference.stories.mdx
@@ -128,6 +128,7 @@ export const Template = (args) => <LayoutWithVehicleReference {...args} />;
     name="Without header"
     args={{
       title: 'Nachricht an den Verkäufer',
+      maxContentWidth: 'xl',
     }}
   >
     {Template.bind({})}

--- a/src/components/layout/WithVehicleReference.stories.mdx
+++ b/src/components/layout/WithVehicleReference.stories.mdx
@@ -18,11 +18,9 @@ import LayoutWithVehicleReference from './WithVehicleReference.tsx';
       sellerAddress: `2540 Grenchen (SO)`,
       image: <img src="/dummyImage.jpeg" alt="vehicle reference image" />,
       callToAction: (
-        <Box marginBottom="xl">
           <Button variant="secondary" onClick={() => ({})} width="full">
             View vehicle
           </Button>
-        </Box>
       ),
     },
     children: (
@@ -38,8 +36,9 @@ import LayoutWithVehicleReference from './WithVehicleReference.tsx';
         </FormControl>
       </>
     ),
-  }}
-  argTypes={{
+
+}}
+argTypes={{
     children: {
       table: {
         disable: true,
@@ -51,7 +50,7 @@ import LayoutWithVehicleReference from './WithVehicleReference.tsx';
       },
     },
   }}
-  parameters={{
+parameters={{
     layout: 'fullscreen',
   }}
 />

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -11,7 +11,8 @@ interface Props {
     url: string;
   };
   vehicle: VehicleReferenceProps;
-  header: ReactNode;
+  header?: ReactNode;
+  callToAction?: ReactNode;
 }
 
 const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
@@ -20,6 +21,7 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
   vehicle,
   header,
   children,
+  callToAction,
 }) => {
   const contentMargin = { md: '2xl' };
 
@@ -33,7 +35,7 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
         columns: 8,
       }}
       right={{
-        content: <VehicleReference {...vehicle} />,
+        content: <VehicleReference {...vehicle} callToAction={callToAction} />,
         columns: 4,
       }}
     />

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -2,7 +2,7 @@ import React, { FC, PropsWithChildren, ReactNode } from 'react';
 
 import VehicleReference, { VehicleReferenceProps } from '../vehicleReference';
 import Box from '../box';
-import TwoColumnsLayout from './TwoColumnsLayout';
+import TwoColumnsLayout, { ColumSize } from './TwoColumnsLayout';
 
 interface Props {
   title?: string | ReactNode;
@@ -12,7 +12,8 @@ interface Props {
   };
   vehicle: VehicleReferenceProps;
   header?: ReactNode;
-  callToAction?: ReactNode;
+  leftColumnSize?: ColumSize;
+  rightColumnSize?: ColumSize;
 }
 
 const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
@@ -21,7 +22,8 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
   vehicle,
   header,
   children,
-  callToAction,
+  leftColumnSize = 8,
+  rightColumnSize = 4,
 }) => {
   const contentMargin = { md: '2xl' };
 
@@ -32,11 +34,11 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
       title={title ? <Box marginRight={contentMargin}>{title}</Box> : null}
       left={{
         content: <Box marginRight={contentMargin}>{children}</Box>,
-        columns: 8,
+        columns: leftColumnSize,
       }}
       right={{
-        content: <VehicleReference {...vehicle} callToAction={callToAction} />,
-        columns: 4,
+        content: <VehicleReference {...vehicle} />,
+        columns: rightColumnSize,
       }}
     />
   );

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -1,9 +1,10 @@
 import React, { FC, PropsWithChildren, ReactNode } from 'react';
 
+import { sizes } from 'src/themes/shared/sizes';
+
 import VehicleReference, { VehicleReferenceProps } from '../vehicleReference';
 import Box from '../box';
 import TwoColumnsLayout, { ColumnSize } from './TwoColumnsLayout';
-
 interface Props {
   title?: string | ReactNode;
   backLink?: {
@@ -14,6 +15,7 @@ interface Props {
   header?: ReactNode;
   leftColumnSize?: ColumnSize;
   rightColumnSize?: ColumnSize;
+  maxContentWidth?: keyof typeof sizes.container;
 }
 
 const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
@@ -24,6 +26,7 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
   children,
   leftColumnSize = 8,
   rightColumnSize = 4,
+  maxContentWidth = 'lg',
 }) => {
   const contentMargin = { md: '2xl' };
 
@@ -40,6 +43,7 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
         content: <VehicleReference {...vehicle} />,
         columns: rightColumnSize,
       }}
+      maxContentWidth={maxContentWidth}
     />
   );
 };

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -2,7 +2,7 @@ import React, { FC, PropsWithChildren, ReactNode } from 'react';
 
 import VehicleReference, { VehicleReferenceProps } from '../vehicleReference';
 import Box from '../box';
-import TwoColumnsLayout, { ColumSize } from './TwoColumnsLayout';
+import TwoColumnsLayout, { ColumnSize } from './TwoColumnsLayout';
 
 interface Props {
   title?: string | ReactNode;
@@ -12,8 +12,8 @@ interface Props {
   };
   vehicle: VehicleReferenceProps;
   header?: ReactNode;
-  leftColumnSize?: ColumSize;
-  rightColumnSize?: ColumSize;
+  leftColumnSize?: ColumnSize;
+  rightColumnSize?: ColumnSize;
 }
 
 const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -13,6 +13,7 @@ interface Props {
   price?: string | null;
   sellerName?: string | null;
   sellerAddress?: string | null;
+  callToAction?: ReactNode;
 }
 
 const VehicleReference: FC<Props> = ({
@@ -21,6 +22,7 @@ const VehicleReference: FC<Props> = ({
   price,
   sellerName,
   sellerAddress,
+  callToAction,
 }) => {
   const styles = useMultiStyleConfig(`VehicleReference`);
 
@@ -44,6 +46,9 @@ const VehicleReference: FC<Props> = ({
           </Box>
         </Stack>
       </Stack>
+      {callToAction ? (
+        <Box marginTop={{ base: 'lg', md: 'sm' }}>{callToAction}</Box>
+      ) : null}
     </article>
   );
 };


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-1193

## Motivation and context

In order to reuse `LayoutWithVehicleReference` on `SuccessPage` we have to extend component with additional props.

## Before

- no call to action button
- header required

## After

![Screenshot 2023-05-11 at 17 04 04](https://github.com/smg-automotive/components-pkg/assets/12614035/daaf53f9-3cb2-40a4-9a0b-0e92ef7205b9)

## How to test

https://zbiljic-vsst-1193-components-pkg.branch.autoscout24.dev/?path=/story/layout-pages-layout-with-vehicle-reference--without-header
