### PR TITLE
fix: removing newsletter link from footer

### DIFF
--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -232,7 +232,7 @@ export const footerConfig: FooterConfigInterface = {
         {
           translationKey: 'footer.sections.aboutUs.newsletter',
           visibilitySettings: {
-            brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: true },
+            brand: { [Brand.AutoScout24]: false, [Brand.MotoScout24]: false },
           },
           link: {
             de: '/de/newsletter/?ac=rg',


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-1256

## Motivation and context

Our newsletter signup form is not protected by a captcha. It looks like currently, it’s generating a lot of fake registrations. The temporary measure is to take the current registration form down and replace it with the new version developed by marketing later (when ready)

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

No `Newsletter` link in footer

## How to test

https://zbiljic-vsst-1256-remove-newsletter-link-components-pkg.branch.autoscout24.dev/?path=/docs/patterns-navigation-footer--docs
