### PR TITLE
fix: remove focus outline in carousel's buttons

### DIFF
--- a/src/themes/components/carousel.ts
+++ b/src/themes/components/carousel.ts
@@ -128,6 +128,9 @@ const Carousel: ComponentStyleConfig = {
       color: 'white',
       visibility: 'hidden',
       _groupHover: { md: { visibility: 'visible' } },
+      _focus: {
+        outline: 'none',
+      },
     },
     button: {
       display: 'flex',


### PR DESCRIPTION
Improvements for [IN-681](https://autoricardo.atlassian.net/browse/IN-681?atlOrigin=eyJpIjoiZmExMWQxNjgxN2ZmNDg2ODkxZTk1OGZkZWEzMzU2NGEiLCJwIjoiaiJ9) following QA's review, [here](https://github.com/smg-automotive/seller-web/pull/530#issuecomment-1552616082)

## Motivation and context

On focus on the gallery button, a white border is displayed

## Before

White border on focus
<img width="234" alt="outline" src="https://github.com/smg-automotive/components-pkg/assets/52455155/756df5d3-e6be-4582-b6ea-c46ae94b57f1">

## After

No white border
<img width="201" alt="no-outline" src="https://github.com/smg-automotive/components-pkg/assets/52455155/96f1c449-8ba5-455a-a16b-c2c35899bbcd">

## How to test

[Add a deep link and instructions how to verify the new behavior]


[IN-681]: https://autoricardo.atlassian.net/browse/IN-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ