### PR TITLE
fix: fullScreen modal zindex

### DIFF
--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -1,4 +1,5 @@
 import { mode } from '@chakra-ui/theme-tools';
+
 import {
   ComponentStyleConfig,
   createMultiStyleConfigHelpers,
@@ -6,6 +7,7 @@ import {
 } from '@chakra-ui/react';
 import { modalAnatomy as parts } from '@chakra-ui/anatomy';
 
+import { zIndices } from '../shared/zIndices';
 import { opacity } from '../shared/opacity';
 
 const { defineMultiStyleConfig, definePartsStyle } =
@@ -83,7 +85,7 @@ const variants = {
     dialogContainer: {
       width: '100vw',
       color: 'white',
-      zIndex: 'modal',
+      zIndex: zIndices.fullScreenModal,
     },
     header: baseStyleHeader,
     closeButton: baseStyleCloseButton,

--- a/src/themes/shared/zIndices.ts
+++ b/src/themes/shared/zIndices.ts
@@ -13,4 +13,5 @@ export const zIndices = {
   toast: 1700,
   tooltip: 1800,
   header: 1900,
+  fullScreenModal: 2000,
 };


### PR DESCRIPTION
[IN-681](https://autoricardo.atlassian.net/browse/IN-681?atlOrigin=eyJpIjoiYjE4YWRkMWFjNTIyNGU1M2JiNjU5MzNmOWYxYjk5Y2QiLCJwIjoiaiJ9)

## Motivation and context

zIndex of Header was > than zIndex of fullScreenModal

## Before

![image (13)](https://github.com/smg-automotive/components-pkg/assets/52455155/9342b917-9d5f-44c4-ae62-703120215197)

## After

Header is hidden
<img width="956" alt="ok" src="https://github.com/smg-automotive/components-pkg/assets/52455155/ccd4880b-6e8a-45d1-a87e-c89acb5b6c1d">

## How to test

This bug was visible on Firefox (and maybe others), not Chrome.
You can check with this link: https://fix-modal-seller-web.branch.autoscout24.dev/de/insertion/car/100000243/images


[IN-681]: https://autoricardo.atlassian.net/browse/IN-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ