### PR TITLE
fix(checkbox): add variants to align elements by top and center

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -12,6 +12,7 @@ export interface CheckboxProps {
   isIndeterminate?: boolean;
   size?: 'sm' | 'lg';
   fontWeight?: 'regular' | 'bold';
+  alignItems?: 'center' | 'flex-start';
 }
 
 const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
@@ -27,6 +28,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       isIndeterminate = false,
       size = 'lg',
       fontWeight = 'regular',
+      alignItems = 'center',
       ...props
     },
     ref
@@ -43,6 +45,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       isIndeterminate={isIndeterminate}
       size={size}
       fontWeight={fontWeight}
+      alignItems={alignItems}
     >
       {label}
     </ChakraCheckbox>

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -12,7 +12,7 @@ export interface CheckboxProps {
   isIndeterminate?: boolean;
   size?: 'sm' | 'lg';
   fontWeight?: 'regular' | 'bold';
-  alignItems?: 'center' | 'flex-start';
+  variant?: 'allignCenter' | 'allignTop';
 }
 
 const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
@@ -28,7 +28,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       isIndeterminate = false,
       size = 'lg',
       fontWeight = 'regular',
-      alignItems = 'center',
+      variant = 'allignCenter',
       ...props
     },
     ref
@@ -45,7 +45,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       isIndeterminate={isIndeterminate}
       size={size}
       fontWeight={fontWeight}
-      alignItems={alignItems}
+      variant={variant}
     >
       {label}
     </ChakraCheckbox>

--- a/src/themes/components/checkbox.ts
+++ b/src/themes/components/checkbox.ts
@@ -56,6 +56,22 @@ const baseStyleLabel: SystemStyleObject = {
   },
 };
 
+const allignCenter = {
+  container: {
+    alignItems: 'center',
+  },
+};
+
+const allignTop = {
+  container: {
+    alignItems: 'flex-start',
+  },
+  label: {
+    position: 'relative',
+    top: '-5',
+  },
+};
+
 const baseStyle: PartsStyleObject<typeof parts> = {
   control: baseStyleControl,
   container: baseStyleContainer,
@@ -63,7 +79,16 @@ const baseStyle: PartsStyleObject<typeof parts> = {
   label: baseStyleLabel,
 };
 
+const variants = {
+  allignTop: allignTop,
+  allignCenter: allignCenter,
+};
+
 export default {
   baseStyle,
   sizes,
+  variants,
+  defaultProps: {
+    variant: 'allignCenter',
+  },
 };

--- a/src/themes/components/checkbox.ts
+++ b/src/themes/components/checkbox.ts
@@ -66,9 +66,8 @@ const allignTop = {
   container: {
     alignItems: 'flex-start',
   },
-  label: {
-    position: 'relative',
-    top: '-5',
+  control: {
+    marginTop: 'xs',
   },
 };
 


### PR DESCRIPTION
## Motivation and context

Add variants to the checkbox to align elements by top and center. They are centered by default.

**Center:**

<img width="321" alt="Screenshot 2023-06-09 at 10 46 31" src="https://github.com/smg-automotive/components-pkg/assets/2486360/701d0e62-f782-4256-b18f-f9d8c9510494">


**Top:**

<img width="318" alt="Screenshot 2023-06-09 at 10 46 39" src="https://github.com/smg-automotive/components-pkg/assets/2486360/5454f74a-5cac-49ed-946c-32b0af8351f5">


