### PR TITLE
feat: allow react node for backlink

### DIFF
--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -11,13 +11,15 @@ import BaseGridLayout, { repeatArea } from './BaseGrid';
 
 export type ColumnSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
-interface Props {
+export interface TwoColumnsLayoutProps {
   header?: ReactNode;
   title?: string | ReactNode;
-  backLink?: {
-    text: string;
-    url: string;
-  };
+  backLink?:
+    | {
+        text: string;
+        url: string;
+      }
+    | ReactNode;
   left: {
     content: ReactNode;
     columns?: ColumnSize;
@@ -29,14 +31,15 @@ interface Props {
   maxContentWidth?: keyof typeof sizes.container;
 }
 
-const TwoColumnsLayout: FC<Props> = ({
-  header,
-  title,
-  backLink,
-  left: { content: leftContent, columns: leftColumns = 6 },
-  right: { content: rightContent, columns: rightColumns = 6 },
-  maxContentWidth = 'lg',
-}) => {
+const TwoColumnsLayout: FC<TwoColumnsLayoutProps> = (props) => {
+  const {
+    header,
+    title,
+    left: { content: leftContent, columns: leftColumns = 6 },
+    right: { content: rightContent, columns: rightColumns = 6 },
+    maxContentWidth = 'lg',
+  } = props;
+
   return (
     <BaseLayout header={header} maxContentWidth={maxContentWidth}>
       <BaseGridLayout
@@ -61,11 +64,15 @@ const TwoColumnsLayout: FC<Props> = ({
         }}
         templateRows="minmax(min-content, max-content) minmax(min-content, max-content) 1fr"
       >
-        {backLink ? (
+        {props.backLink ? (
           <GridItem area="backlink">
-            <Link href={backLink.url} leftIcon={<ArrowLeftIcon />}>
-              {backLink.text}
-            </Link>
+            {typeof props.backLink === 'object' && 'url' in props.backLink ? (
+              <Link href={props.backLink.url} leftIcon={<ArrowLeftIcon />}>
+                {props.backLink.text}
+              </Link>
+            ) : (
+              props.backLink
+            )}
           </GridItem>
         ) : null}
         {title ? (

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -1,21 +1,15 @@
-import React, { FC, PropsWithChildren, ReactNode } from 'react';
-
-import { sizes } from 'src/themes/shared/sizes';
+import React, { FC, PropsWithChildren } from 'react';
 
 import VehicleReference, { VehicleReferenceProps } from '../vehicleReference';
 import Box from '../box';
-import TwoColumnsLayout, { ColumnSize } from './TwoColumnsLayout';
-interface Props {
-  title?: string | ReactNode;
-  backLink?: {
-    text: string;
-    url: string;
-  };
+import TwoColumnsLayout, {
+  ColumnSize,
+  TwoColumnsLayoutProps,
+} from './TwoColumnsLayout';
+interface Props extends TwoColumnsLayoutProps {
   vehicle: VehicleReferenceProps;
-  header?: ReactNode;
   leftColumnSize?: ColumnSize;
   rightColumnSize?: ColumnSize;
-  maxContentWidth?: keyof typeof sizes.container;
 }
 
 const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -6,7 +6,7 @@ import TwoColumnsLayout, {
   ColumnSize,
   TwoColumnsLayoutProps,
 } from './TwoColumnsLayout';
-interface Props extends TwoColumnsLayoutProps {
+interface Props extends Omit<TwoColumnsLayoutProps, 'left' | 'right'> {
   vehicle: VehicleReferenceProps;
   leftColumnSize?: ColumnSize;
   rightColumnSize?: ColumnSize;


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

So that we can support client side routing within the new stack as well as full redirects to the legacy, we need to be able to pass in NextLink, normal Links or buttons with click handlers. Because of that, I enabled passing a ReactNode to the layout.

