### PR TITLE
fix: hide estimate link for professional dealers

### DIFF
--- a/src/components/navigation/header/config/drawerNodeItems.ts
+++ b/src/components/navigation/header/config/drawerNodeItems.ts
@@ -1346,7 +1346,7 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: true,
-              professional: true,
+              professional: false,
             },
             brand: {
               autoscout24: true,

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -95,7 +95,7 @@ export const headerLinks: NavigationLinkConfigProps[] = [
     visibilitySettings: {
       userType: {
         private: true,
-        professional: true,
+        professional: false,
       },
       brand: {
         autoscout24: true,


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

hide estimate link for professional dealers

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
