### PR TITLE
fix: mobile apps link display

### DIFF
--- a/src/components/navigation/footer/Apps.tsx
+++ b/src/components/navigation/footer/Apps.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { useI18n } from '@smg-automotive/i18n-pkg';
-import { Image } from '@chakra-ui/react';
+import { Image, List, ListItem } from '@chakra-ui/react';
 
 import Text from 'src/components/text';
 import Stack from 'src/components/stack';
@@ -27,23 +27,28 @@ const FooterApps: FC<Props> = ({ config }) => {
         spacing="md"
       >
         <Text textStyle="heading5">{t('footer.apps.title')}</Text>
-        <FooterLink linkInstance={config.apps.android[0]}>
-          <Image
-            src={googleplay}
-            alt={'Googleplay Icon'}
-            width="136px"
-            height="40px"
-          />
-        </FooterLink>
-
-        <FooterLink linkInstance={config.apps.apple[0]}>
-          <Image
-            src={appstore}
-            alt={'Appsore Icon'}
-            width="136px"
-            height="40px"
-          />
-        </FooterLink>
+        <List spacing="md">
+          <ListItem display="flex" alignItems="center">
+            <FooterLink linkInstance={config.apps.android[0]}>
+              <Image
+                src={googleplay}
+                alt={'Googleplay Icon'}
+                width="136px"
+                height="40px"
+              />
+            </FooterLink>
+          </ListItem>
+          <ListItem display="flex" alignItems="center">
+            <FooterLink linkInstance={config.apps.apple[0]}>
+              <Image
+                src={appstore}
+                alt={'Appsore Icon'}
+                width="136px"
+                height="40px"
+              />
+            </FooterLink>
+          </ListItem>
+        </List>
       </Stack>
     </GridItem>
   );


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-1800

## Motivation and context
Links for mobile apps where clickable outside of their image length. 

## Before
You could click on footer mobile links outside of the box. And depending on screen size it can be smaller/larger
![Screenshot 2023-06-30 at 10 08 03](https://github.com/smg-automotive/components-pkg/assets/28811793/a3f798e3-3fdc-4699-96fd-973466abd4f6)

## After
Clickable only on image

## How to test
Try to click on mobile app links outside of their images in the footer.
