### PR TITLE
fix: margin between content and footer component

### DIFF
--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -35,6 +35,8 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
           height="full"
           maxWidth={sizes.container[maxContentWidth]}
           marginX={{ '2xs': 'lg', lg: '2xl' }}
+          paddingBottom={{ md: '5xl', base: '3xl' }}
+          paddingTop={{ '2xs': 'md', md: '2xl' }}
         >
           {children}
         </Container>
@@ -45,6 +47,8 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
             minWidth="300px"
             marginRight="2xl"
             position="relative"
+            paddingBottom={{ md: '5xl', base: '3xl' }}
+            paddingTop={{ '2xs': 'md', md: '2xl' }}
           >
             {skyScraperAd}
           </chakra.aside>

--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -34,7 +34,6 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
           width="full"
           height="full"
           maxWidth={sizes.container[maxContentWidth]}
-          paddingY={{ '2xs': 'md', md: '2xl' }}
           marginX={{ '2xs': 'lg', lg: '2xl' }}
         >
           {children}
@@ -44,7 +43,6 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
             display={{ '2xs': 'none', lg: 'block' }}
             width="300px"
             minWidth="300px"
-            paddingY={{ '2xs': 'md', md: '2xl' }}
             marginRight="2xl"
             position="relative"
           >

--- a/src/components/layout/app/Content.tsx
+++ b/src/components/layout/app/Content.tsx
@@ -12,7 +12,7 @@ const AppLayoutContent: ComponentWithAs<'div', GridItemProps> = forwardRef<
       area="content"
       ref={ref}
       {...(props as GridItemProps)}
-      marginBottom={{ md: '5xl', base: '3xl' }}
+      marginBottom={{ md: '4xl', base: '3xl' }}
     />
   );
 });

--- a/src/components/layout/app/Content.tsx
+++ b/src/components/layout/app/Content.tsx
@@ -12,7 +12,7 @@ const AppLayoutContent: ComponentWithAs<'div', GridItemProps> = forwardRef<
       area="content"
       ref={ref}
       {...(props as GridItemProps)}
-      marginBottom={{ sm: '5xl', base: '3xl' }}
+      marginBottom={{ md: '5xl', base: '3xl' }}
     />
   );
 });

--- a/src/components/layout/app/Content.tsx
+++ b/src/components/layout/app/Content.tsx
@@ -12,7 +12,8 @@ const AppLayoutContent: ComponentWithAs<'div', GridItemProps> = forwardRef<
       area="content"
       ref={ref}
       {...(props as GridItemProps)}
-      marginBottom={{ md: '4xl', base: '3xl' }}
+      paddingBottom={{ md: '5xl', base: '3xl' }}
+      paddingTop={{ '2xs': 'md', md: '2xl' }}
     />
   );
 });

--- a/src/components/layout/app/Content.tsx
+++ b/src/components/layout/app/Content.tsx
@@ -7,15 +7,7 @@ const AppLayoutContent: ComponentWithAs<'div', GridItemProps> = forwardRef<
   GridItemProps,
   'div'
 >((props, ref) => {
-  return (
-    <GridItem
-      area="content"
-      ref={ref}
-      {...(props as GridItemProps)}
-      paddingBottom={{ md: '5xl', base: '3xl' }}
-      paddingTop={{ '2xs': 'md', md: '2xl' }}
-    />
-  );
+  return <GridItem area="content" ref={ref} {...(props as GridItemProps)} />;
 });
 
 AppLayoutContent.displayName = 'AppLayoutContent';

--- a/src/components/layout/app/Content.tsx
+++ b/src/components/layout/app/Content.tsx
@@ -7,7 +7,14 @@ const AppLayoutContent: ComponentWithAs<'div', GridItemProps> = forwardRef<
   GridItemProps,
   'div'
 >((props, ref) => {
-  return <GridItem area="content" ref={ref} {...(props as GridItemProps)} />;
+  return (
+    <GridItem
+      area="content"
+      ref={ref}
+      {...(props as GridItemProps)}
+      marginBottom={{ sm: '5xl', base: '3xl' }}
+    />
+  );
 });
 
 AppLayoutContent.displayName = 'AppLayoutContent';


### PR DESCRIPTION
References 
https://autoricardo.atlassian.net/browse/DM-1754

## Motivation and context
Not enough spacing between footer and content. 
We are currently using spacing (padding) on the `<main>` element but adding it there (expanding) would not solve the issue on PDP for example because we have sticky lead button then goes outside of the <main>. That is just one example.

That is the reason I went with the `content layout` component, to try and simplify solution so that we don't have too much changes in some other components to accommodate this change. One thing I noticed so far, that we will need to remove `margin-bottom`s from our components in the other projects, specially in case if they are last elements.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
