### PR TITLE
feat: custom filter header

### DIFF
--- a/src/components/filterPatterns/modal/__tests__/Index.Test.tsx
+++ b/src/components/filterPatterns/modal/__tests__/Index.Test.tsx
@@ -55,6 +55,23 @@ describe('<ModalFilter />', () => {
     ).toHaveLength(2);
   });
 
+  it('should show no action button', async () => {
+    render(
+      <ModalFilter
+        {...validProps}
+        isApplied={false}
+        showCallToActionButton={false}
+      >
+        <div>Modal content</div>
+      </ModalFilter>
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Treibstoff' }));
+    // close button on the top right
+    expect(
+      await screen.findAllByRole('button', { name: 'Schliessen' })
+    ).toHaveLength(1);
+  });
+
   it('should show the primary action button if a filter is applied', async () => {
     const mockSearchButton = jest.fn();
     render(
@@ -73,6 +90,16 @@ describe('<ModalFilter />', () => {
     ).toHaveLength(1);
     userEvent.click(screen.getByRole('button', { name: 'Search' }));
     await waitFor(() => expect(mockSearchButton).toHaveBeenCalledTimes(1));
+  });
+
+  it('should show a custom header', async () => {
+    render(
+      <ModalFilter {...validProps} header={<div>custom header</div>}>
+        <div>Modal content</div>
+      </ModalFilter>
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Treibstoff' }));
+    expect(await screen.findByText('custom header')).toBeInTheDocument();
   });
 
   it('should call the callback if the modal opens', async () => {

--- a/src/components/filterPatterns/modal/index.stories.mdx
+++ b/src/components/filterPatterns/modal/index.stories.mdx
@@ -1,6 +1,9 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { action } from '@storybook/addon-actions';
 
+import Text from 'src/components/text';
+import { ChevronLeftSmallIcon } from 'src/components/icons';
+import Flex from 'src/components/flex';
 import CheckboxFilter from 'src/components/checkboxFilter';
 import Box from 'src/components/box';
 
@@ -52,6 +55,23 @@ export const Template = (args) => (
       />
     </ModalFilter>
   </Box>
+);
+
+export const CustomHeader = () => (
+  <Flex justifyContent="center" alignItems="center" width="full">
+    <ChevronLeftSmallIcon color="blue.700" />
+    <Flex
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      width="full"
+    >
+      <Text textStyle="body-small" color="gray.500">
+        VW
+      </Text>
+      <Text textStyle="heading3">Modell auswählen</Text>
+    </Flex>
+  </Flex>
 );
 
 # Modal filter
@@ -111,6 +131,23 @@ export const Template = (args) => (
       displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
       numberOfAppliedFilters: 5,
       showCallToActionButton: false,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## With custom header
+
+<Canvas>
+  <Story
+    name="With custom header"
+    args={{
+      label: 'Treibstoff',
+      displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
+      numberOfAppliedFilters: 5,
+      showCallToActionButton: false,
+      header: <CustomHeader />,
     }}
   >
     {Template.bind({})}

--- a/src/components/filterPatterns/modal/index.stories.mdx
+++ b/src/components/filterPatterns/modal/index.stories.mdx
@@ -100,3 +100,19 @@ export const Template = (args) => (
     {Template.bind({})}
   </Story>
 </Canvas>
+
+## Without call-to-action button
+
+<Canvas>
+    <Story
+        name="Without call-to-action button"
+        args={{
+            label: 'Treibstoff',
+            displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
+            numberOfAppliedFilters: 5,
+            showCallToActionButton: false,
+        }}
+    >
+        {Template.bind({})}
+    </Story>
+</Canvas>

--- a/src/components/filterPatterns/modal/index.stories.mdx
+++ b/src/components/filterPatterns/modal/index.stories.mdx
@@ -104,15 +104,15 @@ export const Template = (args) => (
 ## Without call-to-action button
 
 <Canvas>
-    <Story
-        name="Without call-to-action button"
-        args={{
-            label: 'Treibstoff',
-            displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
-            numberOfAppliedFilters: 5,
-            showCallToActionButton: false,
-        }}
-    >
-        {Template.bind({})}
-    </Story>
+  <Story
+    name="Without call-to-action button"
+    args={{
+      label: 'Treibstoff',
+      displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
+      numberOfAppliedFilters: 5,
+      showCallToActionButton: false,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
 </Canvas>

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -86,6 +86,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
               alignItems="flex-start"
               paddingTop="2xl"
               paddingBottom="0"
+              paddingX="2xl"
             >
               {header ? (
                 header
@@ -104,7 +105,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
               {children}
             </ModalBody>
             {showCallToActionButton ? (
-              <ModalFooter paddingBottom="2xl" paddingTop="0">
+              <ModalFooter paddingBottom="2xl" paddingTop="0" paddingX="2xl">
                 <FilterActionButton
                   actionButton={actionButton}
                   isApplied={isApplied}

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -104,7 +104,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
               {children}
             </ModalBody>
             {showCallToActionButton ? (
-              <ModalFooter paddingBottom="2xl">
+              <ModalFooter paddingBottom="2xl" paddingTop="0">
                 <FilterActionButton
                   actionButton={actionButton}
                   isApplied={isApplied}

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -99,7 +99,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
                 />
               )}
             </ModalHeader>
-            <ModalBody overflowY="scroll" paddingY={0}>
+            <ModalBody overflowY="scroll" paddingTop={0}>
               {children}
             </ModalBody>
             {showCallToActionButton ? (

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -94,7 +94,9 @@ export const ModalFilter: FC<ModalFilterProps> = ({
                 onResetFilter={onResetFilter}
               />
             </ModalHeader>
-            <ModalBody overflowY="scroll">{children}</ModalBody>
+            <ModalBody overflowY="scroll" paddingY={0}>
+              {children}
+            </ModalBody>
             {showCallToActionButton ? (
               <ModalFooter padding="2xl">
                 <FilterActionButton

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -30,6 +30,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
   onModalClose,
   onModalOpen,
   onResetFilter,
+  showCallToActionButton = true,
   children,
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
@@ -94,13 +95,15 @@ export const ModalFilter: FC<ModalFilterProps> = ({
               />
             </ModalHeader>
             <ModalBody overflowY="scroll">{children}</ModalBody>
-            <ModalFooter padding="2xl">
-              <FilterActionButton
-                actionButton={actionButton}
-                isApplied={isApplied}
-                onClose={onClose}
-              />
-            </ModalFooter>
+            {showCallToActionButton ? (
+              <ModalFooter padding="2xl">
+                <FilterActionButton
+                  actionButton={actionButton}
+                  isApplied={isApplied}
+                  onClose={onClose}
+                />
+              </ModalFooter>
+            ) : null}
           </ModalContent>
         </ChakraModal>
       </>

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -31,6 +31,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
   onModalOpen,
   onResetFilter,
   showCallToActionButton = true,
+  header,
   children,
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
@@ -85,14 +86,18 @@ export const ModalFilter: FC<ModalFilterProps> = ({
               alignItems="flex-start"
               padding="2xl"
             >
-              <FilterHeading
-                language={language}
-                isApplied={isApplied}
-                label={label}
-                numberOfAppliedFilters={numberOfAppliedFilters}
-                onClose={onClose}
-                onResetFilter={onResetFilter}
-              />
+              {header ? (
+                header
+              ) : (
+                <FilterHeading
+                  language={language}
+                  isApplied={isApplied}
+                  label={label}
+                  numberOfAppliedFilters={numberOfAppliedFilters}
+                  onClose={onClose}
+                  onResetFilter={onResetFilter}
+                />
+              )}
             </ModalHeader>
             <ModalBody overflowY="scroll" paddingY={0}>
               {children}

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -84,7 +84,8 @@ export const ModalFilter: FC<ModalFilterProps> = ({
               display="flex"
               flexDirection="column"
               alignItems="flex-start"
-              padding="2xl"
+              paddingTop="2xl"
+              paddingBottom="0"
             >
               {header ? (
                 header
@@ -99,11 +100,11 @@ export const ModalFilter: FC<ModalFilterProps> = ({
                 />
               )}
             </ModalHeader>
-            <ModalBody overflowY="scroll" paddingTop={0}>
+            <ModalBody overflowY="scroll" paddingY="0" marginY="2xl">
               {children}
             </ModalBody>
             {showCallToActionButton ? (
-              <ModalFooter padding="2xl">
+              <ModalFooter paddingBottom="2xl">
                 <FilterActionButton
                   actionButton={actionButton}
                   isApplied={isApplied}

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -79,14 +79,12 @@ export const ModalFilter: FC<ModalFilterProps> = ({
           size="full"
           motionPreset="slideInBottom"
         >
-          <ModalContent h="full" w="full">
+          <ModalContent h="full" w="full" padding="2xl">
             <ModalHeader
               display="flex"
               flexDirection="column"
               alignItems="flex-start"
-              paddingTop="2xl"
-              paddingBottom="0"
-              paddingX="2xl"
+              padding="0"
             >
               {header ? (
                 header
@@ -101,11 +99,16 @@ export const ModalFilter: FC<ModalFilterProps> = ({
                 />
               )}
             </ModalHeader>
-            <ModalBody overflowY="scroll" paddingY="0" marginY="2xl">
+            <ModalBody
+              overflowY="scroll"
+              padding="0"
+              marginTop="2xl"
+              marginBottom={showCallToActionButton ? '2xl' : '0'}
+            >
               {children}
             </ModalBody>
             {showCallToActionButton ? (
-              <ModalFooter paddingBottom="2xl" paddingTop="0" paddingX="2xl">
+              <ModalFooter padding="0">
                 <FilterActionButton
                   actionButton={actionButton}
                   isApplied={isApplied}

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -24,6 +24,7 @@ type Props = {
   | 'numberOfAppliedFilters'
   | 'onResetFilter'
   | 'showCallToActionButton'
+  | 'header'
   | 'children'
 >;
 
@@ -35,6 +36,7 @@ const Popover: FC<Props> = ({
   onClose,
   onResetFilter,
   showCallToActionButton,
+  header,
   children,
 }) => {
   const { language } = useI18n();
@@ -49,14 +51,18 @@ const Popover: FC<Props> = ({
           w="6xl"
         >
           <PopoverHeader>
-            <FilterHeading
-              isApplied={isApplied}
-              label={label}
-              numberOfAppliedFilters={numberOfAppliedFilters}
-              onClose={onClose}
-              language={language}
-              onResetFilter={onResetFilter}
-            />
+            {header ? (
+              header
+            ) : (
+              <FilterHeading
+                isApplied={isApplied}
+                label={label}
+                numberOfAppliedFilters={numberOfAppliedFilters}
+                onClose={onClose}
+                language={language}
+                onResetFilter={onResetFilter}
+              />
+            )}
           </PopoverHeader>
           <PopoverBody
             marginY="2xl"

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -67,11 +67,7 @@ const Popover: FC<Props> = ({
           <PopoverBody
             marginTop="2xl"
             marginBottom={showCallToActionButton ? '2xl' : '0'}
-            maxH={
-              showCallToActionButton
-                ? '6xl'
-                : 'calc(var(--chakra-sizes-lg) + var(--chakra-sizes-6xl))'
-            }
+            maxH="6xl"
             overflowY="scroll"
           >
             {children}

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -23,6 +23,7 @@ type Props = {
   | 'label'
   | 'numberOfAppliedFilters'
   | 'onResetFilter'
+  | 'showCallToActionButton'
   | 'children'
 >;
 
@@ -33,6 +34,7 @@ const Popover: FC<Props> = ({
   numberOfAppliedFilters,
   onClose,
   onResetFilter,
+  showCallToActionButton,
   children,
 }) => {
   const { language } = useI18n();
@@ -56,16 +58,25 @@ const Popover: FC<Props> = ({
               onResetFilter={onResetFilter}
             />
           </PopoverHeader>
-          <PopoverBody maxH="6xl" overflowY="scroll">
+          <PopoverBody
+            maxH={
+              showCallToActionButton
+                ? '6xl'
+                : 'calc(var(--chakra-sizes-lg) + var(--chakra-space-2xl))'
+            }
+            overflowY="scroll"
+          >
             {children}
           </PopoverBody>
-          <PopoverFooter paddingTop="2xl">
-            <FilterActionButton
-              actionButton={actionButton}
-              isApplied={isApplied}
-              onClose={onClose}
-            />
-          </PopoverFooter>
+          {showCallToActionButton ? (
+            <PopoverFooter paddingTop="2xl">
+              <FilterActionButton
+                actionButton={actionButton}
+                isApplied={isApplied}
+                onClose={onClose}
+              />
+            </PopoverFooter>
+          ) : null}
         </PopoverContent>
       </Box>
     </Portal>

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -48,7 +48,7 @@ const Popover: FC<Props> = ({
           shadow="xs"
           w="6xl"
         >
-          <PopoverHeader paddingBottom="2xl">
+          <PopoverHeader>
             <FilterHeading
               isApplied={isApplied}
               label={label}
@@ -59,17 +59,18 @@ const Popover: FC<Props> = ({
             />
           </PopoverHeader>
           <PopoverBody
+            marginY="2xl"
             maxH={
               showCallToActionButton
                 ? '6xl'
-                : 'calc(var(--chakra-sizes-lg) + var(--chakra-space-2xl))'
+                : 'calc(var(--chakra-sizes-lg) + var(--chakra-sizes-6xl))'
             }
             overflowY="scroll"
           >
             {children}
           </PopoverBody>
           {showCallToActionButton ? (
-            <PopoverFooter paddingTop="2xl">
+            <PopoverFooter>
               <FilterActionButton
                 actionButton={actionButton}
                 isApplied={isApplied}

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -65,7 +65,8 @@ const Popover: FC<Props> = ({
             )}
           </PopoverHeader>
           <PopoverBody
-            marginY="2xl"
+            marginTop="2xl"
+            marginBottom={showCallToActionButton ? '2xl' : '0'}
             maxH={
               showCallToActionButton
                 ? '6xl'

--- a/src/components/filterPatterns/popover/__tests__/Index.Test.tsx
+++ b/src/components/filterPatterns/popover/__tests__/Index.Test.tsx
@@ -73,6 +73,23 @@ describe('<PopoverFilter />', () => {
     ).toHaveLength(2);
   });
 
+  it('should show no action button', async () => {
+    render(
+      <PopoverFilter
+        {...validProps}
+        isApplied={false}
+        showCallToActionButton={false}
+      >
+        <div>Popover content</div>
+      </PopoverFilter>
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Treibstoff' }));
+    // close button on the top right
+    expect(
+      await screen.findAllByRole('button', { name: 'Schliessen' })
+    ).toHaveLength(1);
+  });
+
   it('should show the primary action button if a filter is applied', async () => {
     const mockSearchButton = jest.fn();
     render(
@@ -91,6 +108,16 @@ describe('<PopoverFilter />', () => {
     ).toHaveLength(1);
     userEvent.click(screen.getByRole('button', { name: 'Search' }));
     await waitFor(() => expect(mockSearchButton).toHaveBeenCalledTimes(1));
+  });
+
+  it('should show a custom header', async () => {
+    render(
+      <PopoverFilter {...validProps} header={<div>custom header</div>}>
+        <div>Popover content</div>
+      </PopoverFilter>
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Treibstoff' }));
+    expect(await screen.findByText('custom header')).toBeInTheDocument();
   });
 
   it('should call the callback if the popover opens', async () => {

--- a/src/components/filterPatterns/popover/index.stories.mdx
+++ b/src/components/filterPatterns/popover/index.stories.mdx
@@ -122,3 +122,19 @@ export const Template = (args) => (
     {Template.bind({})}
   </Story>
 </Canvas>
+
+## Without call-to-action button
+
+<Canvas>
+    <Story
+        name="Without call-to-action button"
+        args={{
+            label: 'Treibstoff',
+            displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
+            numberOfAppliedFilters: 5,
+            showCallToActionButton: false,
+        }}
+    >
+        {Template.bind({})}
+    </Story>
+</Canvas>

--- a/src/components/filterPatterns/popover/index.stories.mdx
+++ b/src/components/filterPatterns/popover/index.stories.mdx
@@ -126,15 +126,15 @@ export const Template = (args) => (
 ## Without call-to-action button
 
 <Canvas>
-    <Story
-        name="Without call-to-action button"
-        args={{
-            label: 'Treibstoff',
-            displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
-            numberOfAppliedFilters: 5,
-            showCallToActionButton: false,
-        }}
-    >
-        {Template.bind({})}
-    </Story>
+  <Story
+    name="Without call-to-action button"
+    args={{
+      label: 'Treibstoff',
+      displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
+      numberOfAppliedFilters: 5,
+      showCallToActionButton: false,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
 </Canvas>

--- a/src/components/filterPatterns/popover/index.stories.mdx
+++ b/src/components/filterPatterns/popover/index.stories.mdx
@@ -1,6 +1,9 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { action } from '@storybook/addon-actions';
 
+import Text from 'src/components/text';
+import { ChevronLeftSmallIcon } from 'src/components/icons';
+import Flex from 'src/components/flex';
 import CheckboxFilter from 'src/components/checkboxFilter';
 import Box from 'src/components/box';
 
@@ -49,6 +52,23 @@ export const Template = (args) => (
       />
     </PopoverFilter>
   </Box>
+);
+
+export const CustomHeader = () => (
+  <Flex justifyContent="center" alignItems="center" width="full">
+    <ChevronLeftSmallIcon color="blue.700" />
+    <Flex
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      width="full"
+    >
+      <Text textStyle="body-small" color="gray.500">
+        VW
+      </Text>
+      <Text textStyle="heading3">Modell auswählen</Text>
+    </Flex>
+  </Flex>
 );
 
 # Popover filter
@@ -133,6 +153,23 @@ export const Template = (args) => (
       displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
       numberOfAppliedFilters: 5,
       showCallToActionButton: false,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## With custom header
+
+<Canvas>
+  <Story
+    name="With custom header"
+    args={{
+      label: 'Treibstoff',
+      displayValue: 'Benzin, Diesel, Elektro, Hybrid, Plug-In',
+      numberOfAppliedFilters: 5,
+      showCallToActionButton: false,
+      header: <CustomHeader />,
     }}
   >
     {Template.bind({})}

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -27,6 +27,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
   onPopoverClose,
   onPopoverOpen,
   onResetFilter,
+  showCallToActionButton = true,
   children,
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
@@ -126,6 +127,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
               numberOfAppliedFilters={numberOfAppliedFilters}
               onClose={onClose}
               onResetFilter={onResetFilter}
+              showCallToActionButton={showCallToActionButton}
             >
               {children}
             </FilterPopover>

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -28,6 +28,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
   onPopoverOpen,
   onResetFilter,
   showCallToActionButton = true,
+  header,
   children,
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
@@ -128,6 +129,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
               onClose={onClose}
               onResetFilter={onResetFilter}
               showCallToActionButton={showCallToActionButton}
+              header={header}
             >
               {children}
             </FilterPopover>

--- a/src/components/filterPatterns/props.ts
+++ b/src/components/filterPatterns/props.ts
@@ -31,6 +31,10 @@ export type FilterPatternProps = {
    */
   showCallToActionButton?: boolean;
   /**
+   * To show a custom filter header.
+   */
+  header?: ReactNode;
+  /**
    * Content of the filter.
    */
   children: ReactNode;

--- a/src/components/filterPatterns/props.ts
+++ b/src/components/filterPatterns/props.ts
@@ -26,6 +26,11 @@ export type FilterPatternProps = {
    */
   onResetFilter: () => void;
   /**
+   * If a call-to-action button is displayed in the filter footer
+   * @default true
+   */
+  showCallToActionButton?: boolean;
+  /**
    * Content of the filter.
    */
   children: ReactNode;


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-1809

## Motivation and context

For the make model filter, we need to be able to pass a custom filter header and to toggle the visibility of the action button.

https://www.figma.com/file/WvYYKrx8rxw80fwkzhAQwh/Search-Results-%26-Advanced-Search?node-id=1174%3A244074&mode=dev

## Before

Fixed header and action button is always shown

## After

Button and header can be customized

## How to test

https://talamcol-custom-filter-header-components-pkg.branch.autoscout24.dev/?path=/story/patterns-filter-modal--with-custom-header
https://talamcol-custom-filter-header-components-pkg.branch.autoscout24.dev/?path=/story/patterns-filter-modal--without-call-to-action-button
https://talamcol-custom-filter-header-components-pkg.branch.autoscout24.dev/?path=/story/patterns-filter-popover--without-call-to-action-button
https://talamcol-custom-filter-header-components-pkg.branch.autoscout24.dev/?path=/story/patterns-filter-popover--with-custom-header