### PR TITLE
remove twitter account from motoscout

### DIFF
--- a/src/components/navigation/footer/Link.tsx
+++ b/src/components/navigation/footer/Link.tsx
@@ -23,6 +23,10 @@ const FooterLink: FC<PropsWithChildren<FooterLinkProps>> = ({
       }
     : {};
 
+  if (!linkInstance) {
+    return null;
+  }
+
   if (!linkInstance.link?.[language] && !linkInstance.onClick) {
     return (
       <Text {...boldStyles}>

--- a/src/components/navigation/footer/config/__tests__/index.Test.ts
+++ b/src/components/navigation/footer/config/__tests__/index.Test.ts
@@ -62,7 +62,7 @@ describe('The footer configuration', () => {
   it('returns only one link item per social media type', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,
-      brand: Brand.MotoScout24,
+      brand: Brand.AutoScout24,
       environment: 'production',
       useAbsoluteUrls: true,
     });

--- a/src/components/navigation/footer/config/__tests__/index.Test.ts
+++ b/src/components/navigation/footer/config/__tests__/index.Test.ts
@@ -74,6 +74,28 @@ describe('The footer configuration', () => {
     expect(config.socialMedia.youtube.length).toEqual(1);
   });
 
+  it('returns twitter link item only for AutoScout24', () => {
+    let footerConfigInstance = new FooterConfig({
+      config: footerConfig,
+      brand: Brand.AutoScout24,
+      environment: 'production',
+      useAbsoluteUrls: true,
+    });
+    let config = footerConfigInstance.getMappedConfig();
+
+    expect(config.socialMedia.twitter.length).toEqual(1);
+
+    footerConfigInstance = new FooterConfig({
+      config: footerConfig,
+      brand: Brand.MotoScout24,
+      environment: 'production',
+      useAbsoluteUrls: true,
+    });
+    config = footerConfigInstance.getMappedConfig();
+
+    expect(config.socialMedia.twitter.length).toEqual(0);
+  });
+
   it('returns five company links', () => {
     const footerConfigInstance = new FooterConfig({
       config: footerConfig,

--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -531,19 +531,6 @@ export const footerConfig: FooterConfigInterface = {
         },
         target: '_blank',
       },
-      {
-        translationKey: '',
-        visibilitySettings: {
-          brand: { [Brand.AutoScout24]: false, [Brand.MotoScout24]: true },
-        },
-        link: {
-          de: 'https://twitter.com/motoscout24_ch?lang=de',
-          en: 'https://twitter.com/motoscout24_ch?lang=en',
-          fr: 'https://twitter.com/motoscout24_ch?lang=fr',
-          it: 'https://twitter.com/motoscout24_ch?lang=it',
-        },
-        target: '_blank',
-      },
     ],
     youtube: [
       {


### PR DESCRIPTION
References [DM-1828](https://autoricardo.atlassian.net/browse/DM-1828)

## Motivation and context

Current twitter account does not belong to our company. We decide to remove icon button link for twitter in case of motoscout brand.

## Before

Twitter icon link to twitter account 

## After

No twitter link for motoscout

## How to test

[Add a deep link and instructions how to verify the new behavior]


[DM-1828]: https://autoricardo.atlassian.net/browse/DM-1828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ