### PR TITLE
fix: adjusted right margin

### DIFF
--- a/src/themes/components/select.ts
+++ b/src/themes/components/select.ts
@@ -10,7 +10,7 @@ const selectStyles: StyleConfig = {
       paddingInlineEnd: '3xl',
     },
     icon: {
-      right: 'md',
+      right: 'sm',
       _disabled: {
         color: 'gray.200',
       },


### PR DESCRIPTION
References https://www.notion.so/smgnet/the-dropdown-icon-in-Select-component-should-be-more-to-the-right-0fca177dd7f948c28f773ee4ffc85db5

## Motivation and context

There is 12 px margin right but because of the spacing inside the icon it adds up and ends up with too much empty space on the right.

## Thank you 🌺
