### PR TITLE
fix: adjusted margins

### DIFF
--- a/src/themes/components/link.ts
+++ b/src/themes/components/link.ts
@@ -69,8 +69,8 @@ const Link: ComponentMultiStyleConfig = {
   parts: ['link', 'leftIcon', 'rightIcon'],
   baseStyle: {
     link: linkBaseStyle,
-    leftIcon: { ml: 'xs' },
-    rightIcon: { mr: 'xs' },
+    leftIcon: { ml: 'md' },
+    rightIcon: { mr: 'md' },
   },
   variants: {
     navigationLink,


### PR DESCRIPTION
References https://www.notion.so/smgnet/Unify-correct-standardise-spacings-between-icon-and-label-in-BUTTON-and-LINK-component-e01723ba4ef34a32999fca07bf8d3bb9

## Motivation and context

Adjust margins in links

## Thank you 🍻
