### PR TITLE
fix: add transparent button variant

### DIFF
--- a/src/components/button/index.stories.mdx
+++ b/src/components/button/index.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 import { Stack } from 'src/index.ts';
 
-import { ShareIcon, VideoIcon, TrashIcon } from '../index.ts';
+import { ShareIcon, TrashIcon, VideoIcon } from '../index.ts';
 import Button from './index.tsx';
 
 <Meta title="Components/Button" component={Button} />
@@ -107,7 +107,6 @@ export const variants = ['primary', 'secondary', 'success', 'transparent'];
       variant: 'transparent',
       icon: <TrashIcon />,
       size: 'lg',
-      isDisabled: false,
     }}
     argTypes={{
       variant: {

--- a/src/components/button/index.stories.mdx
+++ b/src/components/button/index.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 import { Stack } from 'src/index.ts';
 
-import { ShareIcon, VideoIcon } from '../index.ts';
+import { ShareIcon, VideoIcon, TrashIcon } from '../index.ts';
 import Button from './index.tsx';
 
 <Meta title="Components/Button" component={Button} />
@@ -96,6 +96,40 @@ export const variants = ['primary', 'secondary', 'success', 'transparent'];
 </Canvas>
 
 <ArgsTable story="Success" />
+
+## Transparent
+
+<Canvas>
+  <Story
+    name="Transparent"
+    args={{
+      isDisabled: false,
+      variant: 'transparent',
+      icon: <TrashIcon />,
+      size: 'lg',
+      isDisabled: false,
+    }}
+    argTypes={{
+      variant: {
+        options: variants,
+        control: 'select',
+      },
+      size: {
+        options: ['md', 'lg'],
+        control: 'select',
+      },
+      disabled: {
+        table: {
+          disable: true,
+        },
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Transparent" />
 
 ## Sizes
 

--- a/src/components/button/index.stories.mdx
+++ b/src/components/button/index.stories.mdx
@@ -9,7 +9,7 @@ import Button from './index.tsx';
 
 export const Template = (args) => <Button {...args}>{args.label}</Button>;
 
-export const variants = ['primary', 'secondary', 'success'];
+export const variants = ['primary', 'secondary', 'success', 'transparent'];
 
 # Button
 

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -23,7 +23,7 @@ type ButtonSize = 'md' | 'lg';
 
 type SharedProps = {
   as?: 'button';
-  variant?: 'primary' | 'secondary' | 'success';
+  variant?: 'primary' | 'secondary' | 'success' | 'transparent';
   size?: ButtonSize | ResponsiveValue<ButtonSize>;
   children: ReactNode;
   leftIcon?: ReactElement;
@@ -83,6 +83,7 @@ const Button: FC<Props> = (props) => {
     as = 'button',
     isExternal,
     ariaLabel,
+    removeBorder,
     icon,
     ...rest
   } = props;

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -83,7 +83,6 @@ const Button: FC<Props> = (props) => {
     as = 'button',
     isExternal,
     ariaLabel,
-    removeBorder,
     icon,
     ...rest
   } = props;

--- a/src/themes/components/button.ts
+++ b/src/themes/components/button.ts
@@ -71,6 +71,23 @@ const variants = {
       pointerEvents: 'none',
     },
   },
+  transparent: {
+    bg: 'white',
+    color: 'gray.900',
+    border: 'none',
+    borderColor: 'gray.900',
+    _hover: {
+      bg: 'gray.100',
+    },
+    _active: {
+      bg: 'gray.200',
+    },
+    _disabled: {
+      color: 'gray.300',
+      borderColor: 'gray.300',
+      pointerEvents: 'none',
+    },
+  },
 };
 
 const Button: ComponentStyleConfig = {


### PR DESCRIPTION
References [[link the ticket here](https://autoricardo.atlassian.net/browse/DM-1971)]

## Motivation and context
We need variation for icon button that is transparent (basically without border). One consideration was to have some sort of prop `disable/removeBorder` but then we would need to pass border styles for buttons that are using it. I prefer this way but open for change/adjustment.

## Before
<img width="132" alt="image" src="https://github.com/smg-automotive/components-pkg/assets/28811793/91527052-4476-4e9b-b1e4-9943e1074dc8">

## After
<img width="108" alt="image" src="https://github.com/smg-automotive/components-pkg/assets/28811793/92084f14-52d4-4f7a-84ca-386e76991a7d">

## How to test

