### PR TITLE
fix: add variant to checkbox group

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -12,7 +12,7 @@ export interface CheckboxProps {
   isIndeterminate?: boolean;
   size?: 'sm' | 'lg';
   fontWeight?: 'regular' | 'bold';
-  variant?: 'allignCenter' | 'allignTop';
+  variant?: 'alignCenter' | 'alignTop' | 'alignTopForSmallSize';
   readOnly?: boolean;
 }
 
@@ -29,7 +29,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       isIndeterminate = false,
       size = 'lg',
       fontWeight = 'regular',
-      variant = 'allignCenter',
+      variant = 'alignCenter',
       readOnly = false,
       ...props
     },

--- a/src/components/checkboxGroup/index.tsx
+++ b/src/components/checkboxGroup/index.tsx
@@ -40,7 +40,6 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
         isIndeterminate={isIndeterminate}
         size={size}
         fontWeight="bold"
-        variant={variant}
       />
 
       {checkboxes?.map((item, index) => (

--- a/src/components/checkboxGroup/index.tsx
+++ b/src/components/checkboxGroup/index.tsx
@@ -10,7 +10,6 @@ interface CheckboxGroupProps extends CheckboxProps {
   checkboxes?: CheckboxProps[];
   addDividerAfterIndex?: number[];
   size?: 'sm' | 'lg';
-  variant?: 'allignCenter' | 'allignTop';
 }
 
 const CheckboxGroup: FC<CheckboxGroupProps> = ({
@@ -24,7 +23,7 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
   size = 'lg',
   isIndeterminate,
   addDividerAfterIndex,
-  variant = 'allignCenter',
+  variant = 'alignCenter',
   checkboxes,
 }) => {
   return (
@@ -39,6 +38,7 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
         isInvalid={isInvalid}
         isIndeterminate={isIndeterminate}
         size={size}
+        variant={variant}
         fontWeight="bold"
       />
 

--- a/src/components/checkboxGroup/index.tsx
+++ b/src/components/checkboxGroup/index.tsx
@@ -10,6 +10,7 @@ interface CheckboxGroupProps extends CheckboxProps {
   checkboxes?: CheckboxProps[];
   addDividerAfterIndex?: number[];
   size?: 'sm' | 'lg';
+  variant?: 'allignCenter' | 'allignTop';
 }
 
 const CheckboxGroup: FC<CheckboxGroupProps> = ({
@@ -23,6 +24,7 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
   size = 'lg',
   isIndeterminate,
   addDividerAfterIndex,
+  variant = 'allignCenter',
   checkboxes,
 }) => {
   return (
@@ -38,6 +40,7 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
         isIndeterminate={isIndeterminate}
         size={size}
         fontWeight="bold"
+        variant={variant}
       />
 
       {checkboxes?.map((item, index) => (
@@ -51,6 +54,7 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
             isChecked={item.isChecked}
             size={size}
             pl="md"
+            variant={variant}
             isDisabled={isDisabled}
           />
           {addDividerAfterIndex?.includes(index) ? <Divider /> : null}

--- a/src/themes/components/checkbox.ts
+++ b/src/themes/components/checkbox.ts
@@ -90,7 +90,7 @@ const baseStyle: PartsStyleObject<typeof parts> = {
 const variants = {
   alignTop: alignTop,
   alignCenter: alignCenter,
-  alignTopSmallSize: alignTopForSmallSize,
+  alignTopForSmallSize: alignTopForSmallSize,
 };
 
 export default {

--- a/src/themes/components/checkbox.ts
+++ b/src/themes/components/checkbox.ts
@@ -56,18 +56,27 @@ const baseStyleLabel: SystemStyleObject = {
   },
 };
 
-const allignCenter = {
+const alignCenter = {
   container: {
     alignItems: 'center',
   },
 };
 
-const allignTop = {
+const alignTop = {
   container: {
     alignItems: 'flex-start',
   },
   control: {
     marginTop: 'xs',
+  },
+};
+
+const alignTopForSmallSize = {
+  container: {
+    alignItems: 'flex-start',
+  },
+  control: {
+    marginTop: 'xxs',
   },
 };
 
@@ -79,8 +88,9 @@ const baseStyle: PartsStyleObject<typeof parts> = {
 };
 
 const variants = {
-  allignTop: allignTop,
-  allignCenter: allignCenter,
+  alignTop: alignTop,
+  alignCenter: alignCenter,
+  alignTopSmallSize: alignTopForSmallSize,
 };
 
 export default {


### PR DESCRIPTION
## Motivation and context

Add variant property to Checkbox Group.

## Before

N/A

## After

Variant property exists for checkbox group.

## How to test

[Add a deep link and instructions how to verify the new behavior]
