### PR TITLE
fix: adjusted the pressed state color

### DIFF
--- a/src/themes/components/pagination.ts
+++ b/src/themes/components/pagination.ts
@@ -25,6 +25,9 @@ const baseStyle = {
     _hover: {
       backgroundColor: 'gray.100',
     },
+    _active: {
+      backgroundColor: 'gray.200',
+    },
     _disabled: {
       cursor: 'default',
       _hover: {


### PR DESCRIPTION
References https://www.notion.so/smgnet/Review-Pagination-component-in-the-insertion-2f391a7358ce4db8b8c2e099bd2ebfd4

## Motivation and context

Add background color to the active pagination buttons

## Ho to test

Check the corresponding color as in the figma design when pressing the pagination button

## Thank you 🍄
