### PR TITLE
fix: top listing badge

### DIFF
--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -29,6 +29,7 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
         overflow="hidden"
         position="relative"
         pointerEvents="none"
+        onTouchStart={(e) => e.preventDefault()}
       >
         <Badge
           transform="rotate(-45deg) translateX(-50%) translateY(9px)"

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -29,7 +29,7 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
         overflow="hidden"
         position="relative"
         pointerEvents="none"
-        onTouchStart={(e) => e.preventDefault()}
+        __css={{ touchAction: 'none' }}
       >
         <Badge
           transform="rotate(-45deg) translateX(-50%) translateY(9px)"

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -31,6 +31,7 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
           width="70px"
           textAlign="center"
           paddingLeft="sm"
+          color="gray.900"
         >
           Top
         </Badge>

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -28,6 +28,7 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
         zIndex="docked"
         overflow="hidden"
         position="relative"
+        pointerEvents="none"
       >
         <Badge
           transform="rotate(-45deg) translateX(-50%) translateY(9px)"

--- a/src/components/topListingBadge/index.tsx
+++ b/src/components/topListingBadge/index.tsx
@@ -6,7 +6,7 @@ import Grid from '../grid';
 import AspectRatio from '../aspectRatio';
 
 type Props = {
-  aspectRatio: number;
+  aspectRatio?: number;
 };
 
 const TopListingBadge: FC<PropsWithChildren<Props>> = ({
@@ -16,7 +16,11 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
   return (
     <Grid>
       <GridItem gridColumn={1} gridRow={1}>
-        <AspectRatio ratio={aspectRatio}>{children}</AspectRatio>
+        {aspectRatio ? (
+          <AspectRatio ratio={aspectRatio}>{children}</AspectRatio>
+        ) : (
+          children
+        )}
       </GridItem>
       <GridItem
         gridColumn={1}


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

- Based on the rebranding, the color for MS24 should be black and not white
- the current implementation does not work with the carousel because of the aspect ratio
- carousel is not usable because the badge covers the pointer events

## How to test

https://github.com/smg-automotive/listings-web/pull/1345
