### PR TITLE
fix: vehicle link

### DIFF
--- a/src/components/navigation/BaseConfig.tsx
+++ b/src/components/navigation/BaseConfig.tsx
@@ -2,14 +2,14 @@ import { Environment } from 'src/types/environment';
 import { Entitlement } from 'src/types/entitlements';
 import { Brand } from 'src/types/brand';
 
-import { LinkConfig, LinkInstance } from './link';
+import { Domains, LinkConfig, LinkInstance } from './link';
 
 export abstract class BaseConfig<T> {
   brand: Brand;
   environment: Environment;
   useAbsoluteUrls: boolean;
   linkProtocol: string;
-  domains: Record<Brand, Record<Environment, string>>;
+  domains: Domains;
   entitlements?: Entitlement[];
 
   constructor({
@@ -28,12 +28,36 @@ export abstract class BaseConfig<T> {
     this.useAbsoluteUrls = useAbsoluteUrls;
     this.domains = {
       autoscout24: {
-        production: 'www.autoscout24.ch',
-        preprod: 'int.autoscout24.ch',
+        main: {
+          production: 'www.autoscout24.ch',
+          preprod: 'int.autoscout24.ch',
+        },
+        internal: {
+          professional: {
+            production: 'dealer.autoscout24.ch',
+            preprod: 'int-dealer.autoscout24.ch',
+          },
+          private: {
+            production: 'my.autoscout24.ch',
+            preprod: 'int-my.autoscout24.ch',
+          },
+        },
       },
       motoscout24: {
-        production: 'www.motoscout24.ch',
-        preprod: 'int.motoscout24.ch',
+        main: {
+          production: 'www.motoscout24.ch',
+          preprod: 'int.motoscout24.ch',
+        },
+        internal: {
+          professional: {
+            production: 'dealer.motoscout24.ch',
+            preprod: 'int-dealer.motoscout24.ch',
+          },
+          private: {
+            production: 'my.motoscout24.ch',
+            preprod: 'int-my.motoscout24.ch',
+          },
+        },
       },
     };
     this.linkProtocol = 'https';

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -302,11 +302,12 @@ export const drawerNodeItems = ({
         },
         {
           translationKey: 'header.userMenu.myVehicles',
+          isInternal: true,
           link: {
-            de: 'https://dealer.autoscout24.ch/de/vehicles',
-            en: 'https://dealer.autoscout24.ch/de/vehicles',
-            fr: 'https://dealer.autoscout24.ch/fr/vehicles',
-            it: 'https://dealer.autoscout24.ch/it/vehicles',
+            de: '/de/vehicles',
+            en: '/de/vehicles',
+            fr: '/fr/vehicles',
+            it: '/it/vehicles',
           },
           visibilitySettings: {
             userType: {
@@ -339,12 +340,13 @@ export const drawerNodeItems = ({
           },
         },
         {
+          isInternal: true,
           translationKey: 'header.userMenu.myMotorcycles',
           link: {
-            de: 'https://dealer.motoscout24.ch/de/vehicles',
-            en: 'https://dealer.motoscout24.ch/de/vehicles',
-            fr: 'https://dealer.motoscout24.ch/fr/vehicles',
-            it: 'https://dealer.motoscout24.ch/it/vehicles',
+            de: '/de/vehicles',
+            en: '/de/vehicles',
+            fr: '/fr/vehicles',
+            it: '/it/vehicles',
           },
           visibilitySettings: {
             userType: {
@@ -377,12 +379,13 @@ export const drawerNodeItems = ({
           },
         },
         {
+          isInternal: true,
           translationKey: 'header.userMenu.dealerDashboard',
           link: {
-            de: 'https://dealer.autoscout24.ch/de/login',
-            en: 'https://dealer.autoscout24.ch/de/login',
-            fr: 'https://dealer.autoscout24.ch/fr/login',
-            it: 'https://dealer.autoscout24.ch/it/login',
+            de: '/de/login',
+            en: '/de/login',
+            fr: '/fr/login',
+            it: '/it/login',
           },
           visibilitySettings: {
             userType: {
@@ -396,12 +399,13 @@ export const drawerNodeItems = ({
           },
         },
         {
+          isInternal: true,
           translationKey: 'header.userMenu.dealerDashboard',
           link: {
-            de: 'https://dealer.motoscout24.ch/de',
-            en: 'https://dealer.motoscout24.ch/de',
-            fr: 'https://dealer.motoscout24.ch/fr',
-            it: 'https://dealer.motoscout24.ch/it',
+            de: '/de',
+            en: '/de',
+            fr: '/fr',
+            it: '/it',
           },
           visibilitySettings: {
             userType: {
@@ -512,10 +516,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.userMenu.motorcyclePark',
           link: {
-            de: 'https://www.motoscout24.ch/de/member/vehiclepool',
-            en: 'https://www.motoscout24.ch/de/member/vehiclepool',
-            fr: 'https://www.motoscout24.ch/fr/member/vehiclepool',
-            it: 'https://www.motoscout24.ch/it/member/vehiclepool',
+            de: '/de/member/vehiclepool',
+            en: '/de/member/vehiclepool',
+            fr: '/fr/member/vehiclepool',
+            it: '/it/member/vehiclepool',
           },
           visibilitySettings: {
             userType: {
@@ -667,12 +671,13 @@ export const drawerNodeItems = ({
           },
         },
         {
+          isInternal: true,
           translationKey: 'header.userMenu.boosteras24',
           link: {
-            de: 'https://dealer.autoscout24.ch/de/booster',
-            en: 'https://dealer.autoscout24.ch/de/booster',
-            fr: 'https://dealer.autoscout24.ch/fr/booster',
-            it: 'https://dealer.autoscout24.ch/it/booster',
+            de: '/de/booster',
+            en: '/de/booster',
+            fr: '/fr/booster',
+            it: '/it/booster',
           },
           visibilitySettings: {
             userType: {
@@ -1335,12 +1340,13 @@ export const drawerNodeItems = ({
           },
         },
         {
+          isInternal: true,
           translationKey: 'header.estimate',
           link: {
-            de: 'https://my.autoscout24.ch/de/fahrzeugbewertung',
-            en: 'https://my.autoscout24.ch/de/fahrzeugbewertung',
-            fr: 'https://my.autoscout24.ch/fr/evaluation-vehicules',
-            it: 'https://my.autoscout24.ch/it/valuazione-vehicoli',
+            de: '/de/fahrzeugbewertung',
+            en: '/de/fahrzeugbewertung',
+            fr: '/fr/evaluation-vehicules',
+            it: '/it/valuazione-vehicoli',
           },
           showUnderMoreLinkBelow: 'sm',
           visibilitySettings: {

--- a/src/components/navigation/header/config/HeaderNavigationConfig.tsx
+++ b/src/components/navigation/header/config/HeaderNavigationConfig.tsx
@@ -151,6 +151,7 @@ export class HeaderNavigationConfig extends BaseConfig<HeaderNavigationConfigIns
         entitlementConfig:
           entitlementConfig && this.mapEntitlementConfig(entitlementConfig),
       },
+      isInternal: link.isInternal ? link.isInternal : false,
       brand: this.brand,
       userType: this.userType,
       environment: this.environment,

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -21,6 +21,7 @@ export type NavigationLinkConfigProps = Omit<
       motoscout24: boolean;
     };
   };
+  isInternal?: boolean;
   entitlementConfig?: EntitlementConfig;
 };
 

--- a/src/components/navigation/header/config/headerNavigationLink.ts
+++ b/src/components/navigation/header/config/headerNavigationLink.ts
@@ -5,7 +5,7 @@ import { Brand } from 'src/types/brand';
 
 import { BreakpointName } from 'src/themes/shared/breakpoints';
 
-import { Link, LinkConfig } from 'src/components/navigation/link';
+import { Domains, Link, LinkConfig } from 'src/components/navigation/link';
 
 import { UserType } from '../types';
 
@@ -33,6 +33,7 @@ export class HeaderNavigationLink extends Link {
     variant,
     color,
     userAvatar,
+    isInternal = false,
     hasEntitlement = false,
   }: {
     config: LinkConfig;
@@ -41,7 +42,7 @@ export class HeaderNavigationLink extends Link {
     environment: Environment;
     useAbsoluteUrls: boolean;
     linkProtocol: string;
-    domains: Record<Brand, Record<Environment, string>>;
+    domains: Domains;
     isNew?: boolean;
     rightIcon?: ReactNode;
     showUnderMoreLinkBelow?: BreakpointName;
@@ -49,6 +50,7 @@ export class HeaderNavigationLink extends Link {
     variant?: 'navigationLink' | 'subNavigationLink';
     color?: string;
     userAvatar?: ReactNode;
+    isInternal?: boolean;
     hasEntitlement?: boolean;
   }) {
     super({
@@ -59,6 +61,7 @@ export class HeaderNavigationLink extends Link {
       useAbsoluteUrls,
       linkProtocol,
       domains,
+      isInternal,
       hasEntitlement,
       rightIcon,
     });
@@ -68,5 +71,6 @@ export class HeaderNavigationLink extends Link {
     this.variant = variant;
     this.color = color;
     this.userAvatar = userAvatar;
+    this.isInternal = isInternal;
   }
 }


### PR DESCRIPTION
[IN-1271](https://autoricardo.atlassian.net/browse/IN-1271?atlOrigin=eyJpIjoiYzllNjk1MjY5OTg5NDhjZjhkYTdlNGY0MmQxYmYyMWIiLCJwIjoiaiJ9)

## Motivation and context

Chad noticed that the link "Meine Fahrzeug" takes us to  prod even though we are on int

## Before

![Screenshot 2023-09-07 at 15 45 29](https://github.com/smg-automotive/components-pkg/assets/52455155/5648513d-930b-4d6a-bed8-30adbae969b3)

## After

I added a condition to return the right link but I am not sure we want to do this. 
Please let me know what you think. 

I merged it too fast, blocking the component update in lsitings, so I reverted it. This was the first approved PR: https://github.com/smg-automotive/components-pkg/pull/731



[IN-1271]: https://autoricardo.atlassian.net/browse/IN-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ