### PR TITLE
fix: useAbsoluteUrl

### DIFF
--- a/src/components/navigation/link.ts
+++ b/src/components/navigation/link.ts
@@ -170,9 +170,6 @@ export class Link {
     forceAutoscoutLink?: boolean;
     userType?: UserType;
   }) {
-    const isAlreadyAbsolute = link?.de.substring(0, 4) === 'http';
-    if (!useAbsoluteUrls || !link || isAlreadyAbsolute) return link;
-
     const forceBrandDomain = () => {
       if (forceAutoscoutLink) {
         return Brand.AutoScout24;
@@ -198,6 +195,19 @@ export class Link {
             environment
           ];
     const baseUrl = `${linkProtocol}://${domain}`;
+    const isAlreadyAbsolute = link?.de.substring(0, 4) === 'http';
+    if (
+      !useAbsoluteUrls &&
+      link &&
+      (isInternal || forceAutoscoutLink || forceMotoscoutLink)
+    ) {
+      return {
+        de: `${baseUrl}${link.de}`,
+        fr: `${baseUrl}${link.fr}`,
+        it: `${baseUrl}${link.it}`,
+        en: `${baseUrl}${link.en}`,
+      };
+    } else if (!useAbsoluteUrls || !link || isAlreadyAbsolute) return link;
 
     return {
       de: `${baseUrl}${link.de}`,

--- a/src/components/navigation/link.ts
+++ b/src/components/navigation/link.ts
@@ -196,18 +196,15 @@ export class Link {
           ];
     const baseUrl = `${linkProtocol}://${domain}`;
     const isAlreadyAbsolute = link?.de.substring(0, 4) === 'http';
-    if (
-      !useAbsoluteUrls &&
-      link &&
-      (isInternal || forceAutoscoutLink || forceMotoscoutLink)
-    ) {
+    if (link && (isInternal || forceAutoscoutLink || forceMotoscoutLink)) {
       return {
         de: `${baseUrl}${link.de}`,
         fr: `${baseUrl}${link.fr}`,
         it: `${baseUrl}${link.it}`,
         en: `${baseUrl}${link.en}`,
       };
-    } else if (!useAbsoluteUrls || !link || isAlreadyAbsolute) return link;
+    }
+    if (!useAbsoluteUrls || !link || isAlreadyAbsolute) return link;
 
     return {
       de: `${baseUrl}${link.de}`,


### PR DESCRIPTION
After updating component-pkg version to [20.7.8](https://github.com/smg-automotive/components-pkg/pull/739), internal links in production were broken.
It was because `useAbsoluteUrl` is always false in production so we would not go through the logic for internal links.
