### PR TITLE
fix: remove transparent button variant bg color

### DIFF
--- a/src/themes/components/button.ts
+++ b/src/themes/components/button.ts
@@ -72,15 +72,15 @@ const variants = {
     },
   },
   transparent: {
-    bg: 'white',
+    bg: 'transparent',
     color: 'gray.900',
     border: 'none',
     borderColor: 'gray.900',
     _hover: {
-      bg: 'gray.100',
+      color: 'gray.600',
     },
     _active: {
-      bg: 'gray.200',
+      color: 'gray.400',
     },
     _disabled: {
       color: 'gray.300',

--- a/src/themes/components/button.ts
+++ b/src/themes/components/button.ts
@@ -77,10 +77,10 @@ const variants = {
     border: 'none',
     borderColor: 'gray.900',
     _hover: {
-      color: 'gray.600',
+      bg: 'gray.100',
     },
     _active: {
-      color: 'gray.400',
+      bg: 'gray.200',
     },
     _disabled: {
       color: 'gray.300',


### PR DESCRIPTION
References [JIRA ticket](https://autoricardo.atlassian.net/browse/FE-184)

## Motivation and context

When using a transparent button variant in a component that has its own background colour, the button shows white background and on hover its background differs from the parent component.

## Before

Transparent button variant shows white background as a default state.

## After

Transparent button variant shows transparent background as a default state.

## How to test

Use Storybook to access button variants and confirm it works as expected.

https://autoricardo.atlassian.net/browse/FE-184
