### PR TITLE
fix: lock focus on popover content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "framer-motion": "10.16.4",
         "fs-extra": "11.1.1",
         "merge-json-file": "1.0.1",
+        "react-focus-lock": "^2.9.5",
         "use-debounce": "9.0.4",
         "yargs": "17.7.2"
       },
@@ -27378,9 +27379,9 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.6",
@@ -52129,9 +52130,9 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.6",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "framer-motion": "10.16.4",
     "fs-extra": "11.1.1",
     "merge-json-file": "1.0.1",
+    "react-focus-lock": "^2.9.5",
     "use-debounce": "9.0.4",
     "yargs": "17.7.2"
   }

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -1,3 +1,4 @@
+import FocusLock from 'react-focus-lock';
 import React, { FC } from 'react';
 import { useI18n } from '@smg-automotive/i18n-pkg';
 import {
@@ -43,45 +44,47 @@ const Popover: FC<Props> = ({
   return (
     <Portal>
       <Box zIndex="popover" w="full" h="full" position="relative">
-        <PopoverContent
-          backgroundColor="white"
-          borderRadius="sm"
-          padding="2xl"
-          shadow="xs"
-          w="6xl"
-        >
-          <PopoverHeader>
-            {header ? (
-              header
-            ) : (
-              <FilterHeading
-                isApplied={isApplied}
-                label={label}
-                numberOfAppliedFilters={numberOfAppliedFilters}
-                onClose={onClose}
-                language={language}
-                onResetFilter={onResetFilter}
-              />
-            )}
-          </PopoverHeader>
-          <PopoverBody
-            marginTop="2xl"
-            marginBottom={showCallToActionButton ? '2xl' : '0'}
-            maxH="6xl"
-            overflowY="scroll"
+        <FocusLock returnFocus={true} persistentFocus={false}>
+          <PopoverContent
+            backgroundColor="white"
+            borderRadius="sm"
+            padding="2xl"
+            shadow="xs"
+            w="6xl"
           >
-            {children}
-          </PopoverBody>
-          {showCallToActionButton ? (
-            <PopoverFooter>
-              <FilterActionButton
-                actionButton={actionButton}
-                isApplied={isApplied}
-                onClose={onClose}
-              />
-            </PopoverFooter>
-          ) : null}
-        </PopoverContent>
+            <PopoverHeader>
+              {header ? (
+                header
+              ) : (
+                <FilterHeading
+                  isApplied={isApplied}
+                  label={label}
+                  numberOfAppliedFilters={numberOfAppliedFilters}
+                  onClose={onClose}
+                  language={language}
+                  onResetFilter={onResetFilter}
+                />
+              )}
+            </PopoverHeader>
+            <PopoverBody
+              marginTop="2xl"
+              marginBottom={showCallToActionButton ? '2xl' : '0'}
+              maxH="6xl"
+              overflowY="scroll"
+            >
+              {children}
+            </PopoverBody>
+            {showCallToActionButton ? (
+              <PopoverFooter>
+                <FilterActionButton
+                  actionButton={actionButton}
+                  isApplied={isApplied}
+                  onClose={onClose}
+                />
+              </PopoverFooter>
+            ) : null}
+          </PopoverContent>
+        </FocusLock>
       </Box>
     </Portal>
   );

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -1,10 +1,10 @@
+import FocusLock from 'react-focus-lock';
 import React, { FC } from 'react';
 import { I18nContext } from '@smg-automotive/i18n-pkg';
 import {
   ButtonGroup,
   chakra,
   Button as ChakraButton,
-  FocusLock,
   IconButton,
   Popover,
   PopoverTrigger,
@@ -30,7 +30,6 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
   onResetFilter,
   showCallToActionButton = true,
   header,
-  initialFocusRef,
   children,
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
@@ -123,12 +122,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
                 />
               ) : null}
             </ButtonGroup>
-            <FocusLock
-              restoreFocus={true}
-              persistentFocus={false}
-              autoFocus={!initialFocusRef}
-              initialFocusRef={initialFocusRef}
-            >
+            <FocusLock returnFocus={true} persistentFocus={false}>
               <FilterPopover
                 actionButton={actionButton}
                 isApplied={isApplied}

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -4,11 +4,11 @@ import {
   ButtonGroup,
   chakra,
   Button as ChakraButton,
+  FocusLock,
   IconButton,
   Popover,
   PopoverTrigger,
   useDisclosure,
-  FocusLock,
 } from '@chakra-ui/react';
 
 import TranslationProvider from 'src/components/translationProvider';

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -1,4 +1,3 @@
-import FocusLock from 'react-focus-lock';
 import React, { FC } from 'react';
 import { I18nContext } from '@smg-automotive/i18n-pkg';
 import {
@@ -122,20 +121,19 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
                 />
               ) : null}
             </ButtonGroup>
-            <FocusLock returnFocus={true} persistentFocus={false}>
-              <FilterPopover
-                actionButton={actionButton}
-                isApplied={isApplied}
-                label={label}
-                numberOfAppliedFilters={numberOfAppliedFilters}
-                onClose={onClose}
-                onResetFilter={onResetFilter}
-                showCallToActionButton={showCallToActionButton}
-                header={header}
-              >
-                {children}
-              </FilterPopover>
-            </FocusLock>
+
+            <FilterPopover
+              actionButton={actionButton}
+              isApplied={isApplied}
+              label={label}
+              numberOfAppliedFilters={numberOfAppliedFilters}
+              onClose={onClose}
+              onResetFilter={onResetFilter}
+              showCallToActionButton={showCallToActionButton}
+              header={header}
+            >
+              {children}
+            </FilterPopover>
           </Popover>
         )}
       </I18nContext.Consumer>

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -8,6 +8,7 @@ import {
   Popover,
   PopoverTrigger,
   useDisclosure,
+  FocusLock,
 } from '@chakra-ui/react';
 
 import TranslationProvider from 'src/components/translationProvider';
@@ -29,6 +30,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
   onResetFilter,
   showCallToActionButton = true,
   header,
+  initialFocusRef,
   children,
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
@@ -121,18 +123,25 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
                 />
               ) : null}
             </ButtonGroup>
-            <FilterPopover
-              actionButton={actionButton}
-              isApplied={isApplied}
-              label={label}
-              numberOfAppliedFilters={numberOfAppliedFilters}
-              onClose={onClose}
-              onResetFilter={onResetFilter}
-              showCallToActionButton={showCallToActionButton}
-              header={header}
+            <FocusLock
+              restoreFocus={true}
+              persistentFocus={false}
+              autoFocus={!initialFocusRef}
+              initialFocusRef={initialFocusRef}
             >
-              {children}
-            </FilterPopover>
+              <FilterPopover
+                actionButton={actionButton}
+                isApplied={isApplied}
+                label={label}
+                numberOfAppliedFilters={numberOfAppliedFilters}
+                onClose={onClose}
+                onResetFilter={onResetFilter}
+                showCallToActionButton={showCallToActionButton}
+                header={header}
+              >
+                {children}
+              </FilterPopover>
+            </FocusLock>
           </Popover>
         )}
       </I18nContext.Consumer>

--- a/src/components/filterPatterns/popover/props.ts
+++ b/src/components/filterPatterns/popover/props.ts
@@ -1,12 +1,9 @@
-import { FocusLockProps } from '@chakra-ui/react';
-
 import { FilterPatternProps } from '../props';
 import { ActionButtonProps } from '../ActionButton';
 
 export type PopoverFilterProps = FilterPatternProps &
   Omit<ActionButtonProps, 'onClose'> & {
     initialPopoverState?: 'open' | 'closed';
-    initialFocusRef?: FocusLockProps['initialFocusRef'];
     onPopoverClose?: () => void;
     onPopoverOpen?: () => void;
   };

--- a/src/components/filterPatterns/popover/props.ts
+++ b/src/components/filterPatterns/popover/props.ts
@@ -1,12 +1,12 @@
+import { FocusLockProps } from '@chakra-ui/react';
+
 import { FilterPatternProps } from '../props';
 import { ActionButtonProps } from '../ActionButton';
-import { FocusLockProps } from '@chakra-ui/react';
 
 export type PopoverFilterProps = FilterPatternProps &
   Omit<ActionButtonProps, 'onClose'> & {
     initialPopoverState?: 'open' | 'closed';
-    initialFocusRef: FocusLockProps['initialFocusRef'];
-
+    initialFocusRef?: FocusLockProps['initialFocusRef'];
     onPopoverClose?: () => void;
     onPopoverOpen?: () => void;
   };

--- a/src/components/filterPatterns/popover/props.ts
+++ b/src/components/filterPatterns/popover/props.ts
@@ -1,9 +1,11 @@
 import { FilterPatternProps } from '../props';
 import { ActionButtonProps } from '../ActionButton';
+import { FocusLockProps } from '@chakra-ui/react';
 
 export type PopoverFilterProps = FilterPatternProps &
   Omit<ActionButtonProps, 'onClose'> & {
     initialPopoverState?: 'open' | 'closed';
+    initialFocusRef: FocusLockProps['initialFocusRef'];
 
     onPopoverClose?: () => void;
     onPopoverOpen?: () => void;


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

If you have a form inside the popover, or something that changes visibility, it can happen that the popover looses focus and outside clicks are no longer triggered.

Chakra docs suggest to use FocusLock: https://chakra-ui.com/docs/components/popover/usage#trapping-focus-within-popover

## How to test

[Add a deep link and instructions how to verify the new behavior]
