### PR TITLE
fix: hide checkout navigation item

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -511,7 +511,7 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
-              motoscout24: true,
+              motoscout24: false,
             },
           },
         },
@@ -632,6 +632,25 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
+              motoscout24: false,
+            },
+          },
+        },
+        {
+          translationKey: 'header.userMenu.topListingPro',
+          link: {
+            de: '/de/features/top-list/manage',
+            en: '/de/features/top-list/manage',
+            fr: '/fr/features/top-list/manage',
+            it: '/it/features/top-list/manage',
+          },
+          visibilitySettings: {
+            userType: {
+              private: false,
+              professional: true,
+            },
+            brand: {
+              autoscout24: false,
               motoscout24: true,
             },
           },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -632,7 +632,7 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
-              motoscout24: false,
+              motoscout24: true,
             },
           },
         },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -637,25 +637,6 @@ export const drawerNodeItems = ({
           },
         },
         {
-          translationKey: 'header.userMenu.topListingPro',
-          link: {
-            de: '/de/features/top-list/manage',
-            en: '/de/features/top-list/manage',
-            fr: '/fr/features/top-list/manage',
-            it: '/it/features/top-list/manage',
-          },
-          visibilitySettings: {
-            userType: {
-              private: false,
-              professional: true,
-            },
-            brand: {
-              autoscout24: false,
-              motoscout24: true,
-            },
-          },
-        },
-        {
           translationKey: 'header.userMenu.topCars',
           link: {
             de: '/de/member/topvehicles',


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-1600

## Motivation and context

Before the insertion flow release we want to make sure there are no links to checkout page. There is a difference between new (replatformed) and legacy checkout page, therefore we are removing link from navigation.

## Before

Link to checkout page in navigation.

## After

No checkout link in navigation.

## How to test

[Add a deep link and instructions how to verify the new behavior]
