### PR TITLE
feat: remove last searches for MS24

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -253,7 +253,7 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
-              motoscout24: true,
+              motoscout24: false,
             },
           },
         },


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Since we don't support last searches once we release the new SRP, we need to remove it. I checked with Raluca and it's ok to remove it from production MS24 as well. We'll still have the link on the search box on home until the day of the release
