### PR TITLE
fix: adjusted ad layout sizes

### DIFF
--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -1,9 +1,12 @@
 import React, { FC, PropsWithChildren, ReactNode } from 'react';
 
-import { chakra, Container, Flex } from '@chakra-ui/react';
+import { chakra, Container } from '@chakra-ui/react';
 
 import { sizes } from 'src/themes/shared/sizes';
+import { breakpoints } from 'src/themes';
+import { useMediaQuery } from 'src/hooks';
 
+import Flex from '../flex';
 import Divider from '../divider';
 
 interface Props {
@@ -11,6 +14,7 @@ interface Props {
   footer?: ReactNode;
   skyScraperAd?: ReactNode;
   maxContentWidth: keyof typeof sizes.container;
+  isSrpAds?: boolean;
 }
 
 const BaseLayout: FC<PropsWithChildren<Props>> = ({
@@ -19,7 +23,10 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
   skyScraperAd,
   maxContentWidth,
   children,
+  isSrpAds,
 }) => {
+  const desktopLarge = useMediaQuery({ above: `${breakpoints.xl.px}px` });
+
   return (
     <>
       {header ? (
@@ -43,8 +50,8 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
         {skyScraperAd ? (
           <chakra.aside
             display={{ '2xs': 'none', lg: 'block' }}
-            width="300px"
-            minWidth="300px"
+            width={isSrpAds && desktopLarge ? '500px' : '300px'}
+            minWidth={isSrpAds && desktopLarge ? '500px' : '300px'}
             marginRight="2xl"
             position="relative"
             paddingBottom={{ md: '5xl', base: '3xl' }}

--- a/src/components/layout/Page.stories.mdx
+++ b/src/components/layout/Page.stories.mdx
@@ -18,6 +18,7 @@ import PageLayout from './Page';
       </Box>
     ),
     maxContentWidth: 'lg',
+    isSrpAds: false,
     footer: (
       <Box h="400px" bg="gray.50">
         <Divider />
@@ -103,3 +104,28 @@ export const Template = (args) => <PageLayout {...args} />;
 </Canvas>
 
 <ArgsTable story="Layout with ads" />
+
+## Layout with large ads on SRP in xl breakpoint
+
+<Canvas>
+  <Story
+    name="Layout with large ads on SRP in xl breakpoint"
+    args={{
+      skyScraperAd: (
+        <Flex
+          bg="red.100"
+          h="600px"
+          justifyContent="center"
+          alignItems="center"
+        >
+          <Text>Ads</Text>
+        </Flex>
+      ),
+      isSrpAds: true,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Layout with large ads on SRP in xl breakpoint" />

--- a/src/components/layout/Page.tsx
+++ b/src/components/layout/Page.tsx
@@ -9,6 +9,7 @@ interface Props {
   maxContentWidth: keyof typeof sizes.container;
   skyScraperAd?: ReactNode;
   footer?: ReactNode;
+  isSrpAds?: boolean;
 }
 
 const PageLayout: FC<PropsWithChildren<Props>> = ({
@@ -17,6 +18,7 @@ const PageLayout: FC<PropsWithChildren<Props>> = ({
   skyScraperAd,
   footer,
   children,
+  isSrpAds,
 }) => {
   return (
     <BaseLayout
@@ -24,6 +26,7 @@ const PageLayout: FC<PropsWithChildren<Props>> = ({
       footer={footer}
       skyScraperAd={skyScraperAd}
       maxContentWidth={maxContentWidth}
+      isSrpAds={isSrpAds}
     >
       {children}
     </BaseLayout>


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-2289

## Motivation and context
The ads from 500px are displayed only in the breakpoint 1920px on the SRP

## How to test

Please check in different breakpoints and with/without the boolean `isSrpAds`

<img width="1522" alt="Screenshot 2023-10-06 at 20 30 36" src="https://github.com/smg-automotive/components-pkg/assets/37380787/0b23bd32-0697-4c6a-9257-2798410d9286">

## Thank you 🧠 🇲🇽
