### PR TITLE
feat: top vehicle badge

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -76,6 +76,7 @@ export { default as HeaderNavigation } from './navigation/header';
 export { UserType } from './navigation/header/types';
 export { default as GalleryHeader } from './galleryHeader';
 export { default as SelectMenu } from './selectMenu';
+export { default as TopVehicleSharedBadge } from './topVehicleSharedBadge';
 
 export {
   default as ThemeProvider,

--- a/src/components/topVehicleSharedBadge/index.stories.mdx
+++ b/src/components/topVehicleSharedBadge/index.stories.mdx
@@ -1,0 +1,31 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Box, Image } from '@chakra-ui/react';
+
+import TopVehicleBadge from './index.tsx';
+
+<Meta
+  title="Components/Features/TopVehicleBadge"
+  component={TopVehicleBadge}
+  args={{
+    aspectRatio: 4 / 3,
+  }}
+  argTypes={{
+    aspectRatio: 'number',
+  }}
+/>
+
+export const Template = (args) => (
+  <Box maxW="400px">
+    <TopVehicleBadge {...args}>
+      <Image src="https://placekitten.com/g/800/800" objectFit="cover" />
+    </TopVehicleBadge>
+  </Box>
+);
+
+# Top Vehicle Badge
+
+<Canvas>
+  <Story name="TopVehicleBadge">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="TopVehicleBadge" />

--- a/src/components/topVehicleSharedBadge/index.tsx
+++ b/src/components/topVehicleSharedBadge/index.tsx
@@ -25,9 +25,9 @@ const TopVehicleSharedBadge: FC<PropsWithChildren<Props>> = ({
       <Box
         w="full"
         textAlign="center"
-        fontWeight="bold"
-        color="blue.700"
-        p="xxs"
+        textStyle="heading4"
+        p="xs"
+        textColor="gray.900"
       >
         {badgeText[brand as Brand]}
       </Box>

--- a/src/components/topVehicleSharedBadge/index.tsx
+++ b/src/components/topVehicleSharedBadge/index.tsx
@@ -1,0 +1,43 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { Box, useTheme } from '@chakra-ui/react';
+
+import { Brand } from 'src/types/brand';
+
+import AspectRatio from '../aspectRatio';
+
+type Props = {
+  aspectRatio?: number;
+};
+
+const badgeText = {
+  [Brand.AutoScout24]: 'TopCar',
+  [Brand.MotoScout24]: 'TopMoto',
+};
+
+const TopListingBadge: FC<PropsWithChildren<Props>> = ({
+  children,
+  aspectRatio,
+}) => {
+  const { brand } = useTheme();
+
+  return (
+    <Box>
+      <Box
+        w="full"
+        textAlign="center"
+        fontWeight="bold"
+        color="blue.700"
+        p="xxs"
+      >
+        {badgeText[brand as Brand]}
+      </Box>
+      {aspectRatio ? (
+        <AspectRatio ratio={aspectRatio}>{children}</AspectRatio>
+      ) : (
+        children
+      )}
+    </Box>
+  );
+};
+
+export default TopListingBadge;

--- a/src/components/topVehicleSharedBadge/index.tsx
+++ b/src/components/topVehicleSharedBadge/index.tsx
@@ -14,7 +14,7 @@ const badgeText = {
   [Brand.MotoScout24]: 'TopMoto',
 };
 
-const TopListingBadge: FC<PropsWithChildren<Props>> = ({
+const TopVehicleSharedBadge: FC<PropsWithChildren<Props>> = ({
   children,
   aspectRatio,
 }) => {
@@ -40,4 +40,4 @@ const TopListingBadge: FC<PropsWithChildren<Props>> = ({
   );
 };
 
-export default TopListingBadge;
+export default TopVehicleSharedBadge;

--- a/src/themes/autoscout24/index.ts
+++ b/src/themes/autoscout24/index.ts
@@ -1,3 +1,5 @@
+import { Brand } from 'src/types/brand';
+
 import { shared } from '../shared';
 import { components } from '../components';
 import { colors } from './colors';
@@ -8,5 +10,6 @@ export const theme: Record<string, any> = {
   colors,
   components,
   name: 'AutoScout 24',
+  brand: Brand.AutoScout24,
   color: colors.brand.primary,
 };

--- a/src/themes/motoscout24/index.ts
+++ b/src/themes/motoscout24/index.ts
@@ -1,3 +1,5 @@
+import { Brand } from 'src/types/brand';
+
 import { shared } from '../shared';
 import { components } from '../components';
 import { colors } from './colors';
@@ -8,5 +10,6 @@ export const theme: Record<string, any> = {
   colors,
   components,
   name: 'MotoScout 24',
+  brand: Brand.MotoScout24,
   color: colors.brand.primary,
 };


### PR DESCRIPTION
## Motivation and context

Adds a badge used for shared top vehicle slot.
The intention is to replace the uploaded image with a component.

Design https://www.figma.com/file/hMOmjeR3dH6k0eNzwX1G5T/TopCars?node-id=563%3A19803&mode=dev
