### PR TITLE
fix: entitlements prop type

### DIFF
--- a/src/components/navigation/BaseConfig.tsx
+++ b/src/components/navigation/BaseConfig.tsx
@@ -1,5 +1,4 @@
 import { Environment } from 'src/types/environment';
-import { Entitlement } from 'src/types/entitlements';
 import { Brand } from 'src/types/brand';
 
 import { Domains, LinkConfig, LinkInstance } from './link';
@@ -10,7 +9,7 @@ export abstract class BaseConfig<T> {
   useAbsoluteUrls: boolean;
   linkProtocol: string;
   domains: Domains;
-  entitlements?: Entitlement[];
+  entitlements?: string[];
 
   constructor({
     brand,
@@ -21,7 +20,7 @@ export abstract class BaseConfig<T> {
     brand: Brand;
     environment?: Environment;
     useAbsoluteUrls?: boolean;
-    entitlements?: Entitlement[];
+    entitlements?: string[];
   }) {
     this.brand = brand;
     this.environment = environment;

--- a/src/components/navigation/header/config/HeaderNavigationConfig.tsx
+++ b/src/components/navigation/header/config/HeaderNavigationConfig.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 
 import { replaceParameters } from 'src/utilities/replacePathParameters';
 import { Environment } from 'src/types/environment';
-import { Entitlement } from 'src/types/entitlements';
 import { Brand } from 'src/types/brand';
 
 import { BreakpointName } from 'src/themes/shared/breakpoints';
@@ -80,7 +79,7 @@ export class HeaderNavigationConfig extends BaseConfig<HeaderNavigationConfigIns
     config: HeaderNavigationConfigInterface;
     user: User | null;
     urlPathParams?: Record<string, string | number>;
-    entitlements?: Entitlement[];
+    entitlements?: string[];
   }) {
     super({ brand, environment, useAbsoluteUrls, entitlements });
     this.config = config;

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -3,7 +3,6 @@ import React, { FC, PropsWithChildren, useEffect, useMemo } from 'react';
 import { Language } from '@smg-automotive/i18n-pkg';
 
 import { Environment } from 'src/types/environment';
-import { Entitlement } from 'src/types/entitlements';
 import { Brand } from 'src/types/brand';
 
 import TranslationProvider from 'src/components/translationProvider';
@@ -27,7 +26,7 @@ interface NavigationProps {
   user: User | null;
   hasNotification: boolean;
   useAbsoluteUrls?: boolean;
-  entitlements?: Entitlement[];
+  entitlements?: string[];
   onLogin: () => void;
   onLogout: () => void;
 }


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

BE services are returning a lot of entitlements that are not related to header navigation. In order to avoid casting /exporting `Entitlements` type from components-pkg and adding all unnecessary entitlements to components-pkg we will accept array of strings for entitlements prop. This will not affect components-pkg in any way, because we have entitlements defined and we are doing check based on that definition.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
