### PR TITLE
fix: required entitlements array

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1130,7 +1130,7 @@ export const drawerNodeItems = ({
             },
           },
           entitlementConfig: {
-            requiredEntitlement: Entitlement.BusinessImage,
+            singleRequiredEntitlement: [Entitlement.BusinessImage],
             missingEntitlementFallbackLink: {
               de: '/de/productdescription/as24_businessimage',
               en: '/de/productdescription/as24_businessimage',

--- a/src/components/navigation/header/config/HeaderNavigationConfig.tsx
+++ b/src/components/navigation/header/config/HeaderNavigationConfig.tsx
@@ -129,7 +129,7 @@ export class HeaderNavigationConfig extends BaseConfig<HeaderNavigationConfigIns
         entitlementConfig.missingEntitlementFallbackLink,
       ),
       missingEntitlementLinkIcon: entitlementConfig.missingEntitlementLinkIcon,
-      requiredEntitlement: entitlementConfig.requiredEntitlement,
+      singleRequiredEntitlement: entitlementConfig.singleRequiredEntitlement,
     } as EntitlementConfig;
   }
 
@@ -137,7 +137,9 @@ export class HeaderNavigationConfig extends BaseConfig<HeaderNavigationConfigIns
     const { entitlementConfig } = link;
 
     const hasEntitlement = entitlementConfig
-      ? this.entitlements?.includes(entitlementConfig.requiredEntitlement)
+      ? entitlementConfig.singleRequiredEntitlement.some(
+          (entitlement) => this.entitlements?.includes(entitlement),
+        )
       : false;
 
     return new HeaderNavigationLink({

--- a/src/components/navigation/link.ts
+++ b/src/components/navigation/link.ts
@@ -21,7 +21,7 @@ export interface VisibilitySettings {
 export type LocalizedLinks = Record<Language, string>;
 
 export interface EntitlementConfig {
-  requiredEntitlement: Entitlement;
+  singleRequiredEntitlement: Entitlement[];
   missingEntitlementFallbackLink: LocalizedLinks;
   missingEntitlementLinkIcon: ReactNode;
 }


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-1741

## Motivation and context

Instead of requiring only one entitlements to display link, we are now able to require one of provides entitlements.

## Before

Only one required entitlement

## After

Requring ony of entitlements in defined in `singleRequiredEntitlement` array.

## How to test

[Add a deep link and instructions how to verify the new behavior]
