### PR TITLE
feat: expose tab component as prop

### DIFF
--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -5,7 +5,7 @@ import { Space } from 'src/themes';
 
 type Props = {
   marginX?: Space;
-} & Pick<TabProps, 'isDisabled'>;
+} & Pick<TabProps, 'isDisabled' | 'as'>;
 
 const Tab: FC<PropsWithChildren<Props>> = (props) => {
   return <ChakraTab {...props}>{props.children}</ChakraTab>;


### PR DESCRIPTION
No ticket.

## Motivation and context

There is an error appearing in case we are nesting a menu within a tab.

```
Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.
```

We use this pattern on the identify page of the insertion flow (mobile version) tabs and will most likely use it on the top vehicle management page tabs.

This PR allows for rendering of the tab component as something other than a button which is a prerequisite for removal of the specified error.

Note that the after image is taken after the tab component is instantiated as `<Tab as={Box} ... />` in specific project.

## Before

<img width="1728" alt="Screenshot 2023-10-24 at 15 38 48" src="https://github.com/smg-automotive/components-pkg/assets/141041162/08b1452a-fefa-4946-9496-789236ef6ba0">

## After

<img width="1728" alt="Screenshot 2023-10-24 at 15 39 25" src="https://github.com/smg-automotive/components-pkg/assets/141041162/dee9923c-43c8-40f2-af07-834f3b4b2b88">

## How to test

Visit insertion flow identify page on a mobile viewport width setting and inspect the dev tools console. The error should not occur.
