### PR TITLE
fix: toplisting entitlement

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -641,6 +641,13 @@ export const drawerNodeItems = ({
               motoscout24: true,
             },
           },
+          entitlementConfig: {
+            singleRequiredEntitlement: [
+              Entitlement.ListingVisibilityStandard,
+              Entitlement.ListingVisibilityPremium,
+            ],
+            missingEntitlementTranslationKey: 'header.userMenu.topListing',
+          },
         },
         {
           translationKey: 'header.userMenu.topCars',

--- a/src/components/navigation/header/config/HeaderNavigationConfig.tsx
+++ b/src/components/navigation/header/config/HeaderNavigationConfig.tsx
@@ -125,12 +125,11 @@ export class HeaderNavigationConfig extends BaseConfig<HeaderNavigationConfigIns
 
   mapEntitlementConfig(entitlementConfig: EntitlementConfig) {
     return {
+      ...entitlementConfig,
       missingEntitlementFallbackLink: this.replacePathParams(
         entitlementConfig.missingEntitlementFallbackLink,
       ),
-      missingEntitlementLinkIcon: entitlementConfig.missingEntitlementLinkIcon,
-      singleRequiredEntitlement: entitlementConfig.singleRequiredEntitlement,
-    } as EntitlementConfig;
+    };
   }
 
   mapLink(link: HeaderNavigationLinkConfig) {

--- a/src/components/navigation/header/index.stories.mdx
+++ b/src/components/navigation/header/index.stories.mdx
@@ -58,6 +58,8 @@ export const Template = (args) => {
         'optimizer-pro',
         'auto-radar',
         'auto-radar-fast',
+        'listing-visibility-standard',
+        'listing-visibility-premium'
       ],
     }}
   >

--- a/src/components/navigation/header/index.stories.mdx
+++ b/src/components/navigation/header/index.stories.mdx
@@ -59,7 +59,7 @@ export const Template = (args) => {
         'auto-radar',
         'auto-radar-fast',
         'listing-visibility-standard',
-        'listing-visibility-premium'
+        'listing-visibility-premium',
       ],
     }}
   >

--- a/src/components/navigation/link.ts
+++ b/src/components/navigation/link.ts
@@ -22,8 +22,9 @@ export type LocalizedLinks = Record<Language, string>;
 
 export interface EntitlementConfig {
   singleRequiredEntitlement: Entitlement[];
-  missingEntitlementFallbackLink: LocalizedLinks;
-  missingEntitlementLinkIcon: ReactNode;
+  missingEntitlementFallbackLink?: LocalizedLinks;
+  missingEntitlementLinkIcon?: ReactNode;
+  missingEntitlementTranslationKey?: string;
 }
 
 export interface LinkConfig {
@@ -94,9 +95,7 @@ export class Link {
     forceAutoscoutLink?: boolean;
     hasEntitlement?: boolean;
     rightIcon?: ReactNode;
-    shouldDisplayMissingEntitlementIcon?: boolean;
   }) {
-    this.translationKey = config.translationKey;
     this.target = config.target;
     this.onClick = config.onClick;
     this.isVisible = Link.determineVisibility({
@@ -126,6 +125,22 @@ export class Link {
     )
       ? config.entitlementConfig?.missingEntitlementLinkIcon
       : rightIcon;
+
+    this.translationKey = Link.shouldDisplayMissingEntitlementTranslation(
+      hasEntitlement,
+      config.entitlementConfig,
+    )
+      ? config.entitlementConfig?.missingEntitlementTranslationKey
+      : config.translationKey;
+  }
+
+  private static shouldDisplayMissingEntitlementTranslation(
+    hasEntitlement: boolean,
+    entitlementConfig?: EntitlementConfig,
+  ) {
+    return (
+      !hasEntitlement && !!entitlementConfig?.missingEntitlementTranslationKey
+    );
   }
 
   private static shouldDisplayMissingEntitlementIcon(

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -167,6 +167,7 @@
       "toolsForPurchasing": "Tools für den Einkauf",
       "toolsForSelling": "Tools für den Verkauf",
       "topCars": "TopCars",
+      "topListing": "TopListing",
       "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "Benutzersprache"

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Tools für den Verkauf",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListingPro",
+      "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "Benutzersprache"
     }

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Tools für den Verkauf",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListing Pro",
+      "topListingPro": "TopListingPro",
       "topMotos": "TopMotos",
       "userLanguage": "Benutzersprache"
     }

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -167,6 +167,7 @@
       "toolsForPurchasing": "Tools for purchasing",
       "toolsForSelling": "Tools for Selling",
       "topCars": "TopCars",
+      "topListing": "TopListing",
       "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "User language"

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Tools for Selling",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListingPro",
+      "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "User language"
     }

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Tools for Selling",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListing Pro",
+      "topListingPro": "TopListingPro",
       "topMotos": "TopMotos",
       "userLanguage": "User language"
     }

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Outils pour la vente",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListing Pro",
+      "topListingPro": "TopListingPro",
       "topMotos": "TopMotos",
       "userLanguage": "Langue de l'utilisateur"
     }

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Outils pour la vente",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListingPro",
+      "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "Langue de l'utilisateur"
     }

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -167,6 +167,7 @@
       "toolsForPurchasing": "Outils pour l'achat",
       "toolsForSelling": "Outils pour la vente",
       "topCars": "TopCars",
+      "topListing": "TopListing",
       "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "Langue de l'utilisateur"

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Gestire veicoli",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListing Pro",
+      "topListingPro": "TopListingPro",
       "topMotos": "TopMotos",
       "userLanguage": "Lingua utente"
     }

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -167,6 +167,7 @@
       "toolsForPurchasing": "Strumenti per l'acquisto",
       "toolsForSelling": "Gestire veicoli",
       "topCars": "TopCars",
+      "topListing": "TopListing",
       "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "Lingua utente"

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -168,7 +168,7 @@
       "toolsForSelling": "Gestire veicoli",
       "topCars": "TopCars",
       "topListing": "TopListing",
-      "topListingPro": "TopListingPro",
+      "topListingPro": "TopListing Pro",
       "topMotos": "TopMotos",
       "userLanguage": "Lingua utente"
     }

--- a/src/types/entitlements.ts
+++ b/src/types/entitlements.ts
@@ -1,10 +1,9 @@
-// This enum will be populated with same entitlements keys that are coming
-// from BE services. We will add them here one by one as BE services add
-// support for them. This will be subject to change.
 export enum Entitlement {
   BusinessImage = 'business-image',
   Optimizer = 'optimizer',
   OptimizerPro = 'optimizer-pro',
   AutoRadar = 'auto-radar',
   AutoRadarFast = 'auto-radar-fast',
+  ListingVisibilityStandard = 'listing-visibility-standard',
+  ListingVisibilityPremium = 'listing-visibility-premium',
 }


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/VSST-1364

## Motivation and context

We should display different translation for `Toplisting` link based on entitlements user have.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

Displaying `Toplisting` or `ToplistingPro` link text depending on user entitlements.

## How to test

https://zbiljic-toplisting-entitlements-components-pkg.branch.autoscout24.dev/

- go to header navigation story
- add or remove `listing-visibility-standard` or `listing-visibility-premium` entitlement using story controls and observe changes to the `Toplisting` item inside drawer menu
