### PR TITLE
fix: magazine link in italian

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1521,7 +1521,7 @@ export const drawerNodeItems = ({
             de: '/de/c/h/information',
             en: '/en/c/h/information',
             fr: '/fr/c/h/information',
-            it: '/it/c/h/information',
+            it: '/it/c/h/informazione',
           },
           showUnderMoreLinkBelow: 'lg',
           visibilitySettings: {

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -175,7 +175,7 @@ export const headerLinks: NavigationLinkConfigProps[] = [
       de: '/de/c/h/information',
       en: '/en/c/h/information',
       fr: '/fr/c/h/information',
-      it: '/it/c/h/information',
+      it: '/it/c/h/informazione',
     },
     showUnderMoreLinkBelow: 'lg',
     visibilitySettings: {


### PR DESCRIPTION
Wrong link in header found by Lien:
In IT, this link is returning 404 page.

![image](https://github.com/smg-automotive/components-pkg/assets/52455155/dbfb14f9-4bd7-45a4-af10-32391920f783)

The correct url should be `https://www.motoscout24.ch/it/c/h/informazione` instead of `https://www.motoscout24.ch/it/c/h/information`
