### PR TITLE
fix: iphone zoom on input focus

### DIFF
--- a/src/components/rangeFilterInput/InputGroup.tsx
+++ b/src/components/rangeFilterInput/InputGroup.tsx
@@ -51,7 +51,7 @@ function InputGroup<Name extends string>({
       {unit ? <InputLeftElement unit={unit} /> : null}
       <NumberInputField
         placeholder={inputProps.placeholder ? inputProps.placeholder : ''}
-        fontSize="body"
+        fontSize="base"
         autoFocus={refocus}
         aria-label={inputProps.ariaLabel}
       />


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Iphones do zoom in when an input field is focussed. This is the case when the fontSize of the input field is set to something else than 1rem. `body` didn't even exist. This makes the text a bit bigger, but it was wrong anyway. Based on the design it should be 16px
