### PR TITLE
chore: hide chakra components from storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,6 +15,11 @@ const config: StorybookConfig = {
   docs: {
     autodocs: 'tag',
   },
+  refs: {
+    '@chakra-ui/react': {
+      disable: true,
+    },
+  },
   webpackFinal: async (webpack) => {
     webpack.resolve = webpack.resolve || {};
     webpack.resolve.plugins = webpack.resolve.plugins || [];


### PR DESCRIPTION
## Motivation and context

Hide chakra components from storybook to reduce confusion.
Let me know if it’s a bad idea :smile:

## Before

Chakra components presented in storybook

## After

Only our components presented in storybook

## How to test

https://chore-disable-chakra-components-pkg.branch.autoscout24.dev/
