### PR TITLE
feat: expose switch component

### DIFF
--- a/src/components/devOverlay/index.tsx
+++ b/src/components/devOverlay/index.tsx
@@ -95,7 +95,11 @@ const DevOverlay: FC<DevOverlayProps> = ({
       <div>
         <span>🚗</span>
         &nbsp;
-        <Switch onChange={toggleTheme} isChecked={isThemeSwitcherChecked} />
+        <Switch
+          onChange={toggleTheme}
+          isChecked={isThemeSwitcherChecked}
+          variant="themeSwitch"
+        />
         &nbsp;
         <span>🏍️</span>
       </div>
@@ -108,6 +112,7 @@ const DevOverlay: FC<DevOverlayProps> = ({
         <Switch
           onChange={toggleTranslation}
           isChecked={displayTranslationKeys}
+          variant="themeSwitch"
         />
         &nbsp;
         <span>🔑</span>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -56,6 +56,7 @@ export { default as SimpleGrid } from './simpleGrid';
 export { default as SimpleHeader } from './simpleHeader';
 export { default as Stack } from './stack';
 export { default as Spinner } from './spinner';
+export { default as Switch } from './switchComponent';
 export { default as Text } from './text';
 export { default as Textarea } from './textarea';
 export { default as Tooltip } from './tooltip';

--- a/src/components/switchComponent/index.stories.mdx
+++ b/src/components/switchComponent/index.stories.mdx
@@ -8,8 +8,23 @@ import Switch from './index.tsx';
 
 ## Overview
 
+export const Template = (args) => {
+  return <Switch {...args} />;
+};
+
 <Canvas>
-  <Story name="Switch">
-    <Switch />
+  <Story
+    name="Switch"
+    args={{
+      variant: 'default',
+    }}
+    argTypes={{
+      variant: {
+        options: ['themeSwitch', 'default'],
+        control: 'select',
+      },
+    }}
+  >
+    {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/switchComponent/index.tsx
+++ b/src/components/switchComponent/index.tsx
@@ -4,15 +4,14 @@ import {
   SwitchProps as ChakraSwitchProps,
 } from '@chakra-ui/react';
 
-export type SwitchProps = Pick<ChakraSwitchProps, 'onChange' | 'isChecked'>;
+export type SwitchProps = Pick<
+  ChakraSwitchProps,
+  'onChange' | 'isChecked' | 'variant'
+>;
 
-const Switch: FC<SwitchProps> = ({ onChange, isChecked }) => {
+const Switch: FC<SwitchProps> = ({ onChange, isChecked, variant }) => {
   return (
-    <ChakraSwitch
-      onChange={onChange}
-      isChecked={isChecked}
-      variant="themeSwitch"
-    />
+    <ChakraSwitch onChange={onChange} isChecked={isChecked} variant={variant} />
   );
 };
 export default Switch;


### PR DESCRIPTION
References [VSST-1637](https://autoricardo.atlassian.net/browse/VSST-1637)

## Motivation and context

The top vehicle management page has switches used for prioritising specific listings.

Done:
- exposed switch component
- changed switch component default variant to be default instead of `themeSwitch`
- explicitly set `themeSwitch` variant where it was implicitly set before
- added variant change in story

## Before

Switch component is not available to external projects.

## After

Switch component is available to external projects.

## How to test

Check if the component can be imported in an external project.


[VSST-1637]: https://autoricardo.atlassian.net/browse/VSST-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ