### PR TITLE
fix: disabled link color

### DIFF
--- a/src/themes/components/link.ts
+++ b/src/themes/components/link.ts
@@ -11,7 +11,7 @@ export const linkBaseStyle: SystemStyleObject = {
   },
   _disabled: {
     textDecoration: 'none',
-    color: 'gray.300',
+    color: 'gray.500',
   },
 };
 


### PR DESCRIPTION
References [[link the ticket here](https://autoricardo.atlassian.net/browse/DM-2450)]

## Motivation and context
This PR changes the default disabled color for links. Based on the latest design changes, we should have disabled link color to gray.500

## Before
![image](https://github.com/smg-automotive/components-pkg/assets/28811793/beddc447-c832-4d41-b666-ad8e2d2bacce)

## After
![image](https://github.com/smg-automotive/components-pkg/assets/28811793/1513db3c-5b21-4cf8-a5b5-9a54d10d98a7)


## How to test
Disabled link color anywhere should be gray.500
