### PR TITLE
fix: UTM param for insurance comparison header

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -228,7 +228,7 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.insuranceComparison',
           link: {
-            de: `https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_`,
+            de: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',
             en: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',
             fr: 'https://www.financescout24.ch/fr/lp/trouver-assurance-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',
             it: 'https://www.financescout24.ch/it/lp/trova-assicurazione-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -228,7 +228,7 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.insuranceComparison',
           link: {
-            de: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',
+            de: `https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_`,
             en: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',
             fr: 'https://www.financescout24.ch/fr/lp/trouver-assurance-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',
             it: 'https://www.financescout24.ch/it/lp/trova-assicurazione-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',
@@ -240,6 +240,25 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
+              motoscout24: false,
+            },
+          },
+        },
+        {
+          translationKey: 'header.searchMenu.insuranceComparison',
+          link: {
+            de: `https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_`,
+            en: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
+            fr: 'https://www.financescout24.ch/fr/lp/trouver-assurance-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
+            it: 'https://www.financescout24.ch/it/lp/trova-assicurazione-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
+          },
+          visibilitySettings: {
+            userType: {
+              private: true,
+              professional: true,
+            },
+            brand: {
+              autoscout24: false,
               motoscout24: true,
             },
           },
@@ -795,6 +814,25 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
+              motoscout24: false,
+            },
+          },
+        },
+        {
+          translationKey: 'header.userMenu.insuranceComparison',
+          link: {
+            de: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
+            en: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
+            fr: 'https://www.financescout24.ch/fr/lp/trouver-assurance-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
+            it: 'https://www.financescout24.ch/it/lp/trova-assicurazione-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
+          },
+          visibilitySettings: {
+            userType: {
+              private: true,
+              professional: true,
+            },
+            brand: {
+              autoscout24: false,
               motoscout24: true,
             },
           },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -247,7 +247,7 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.insuranceComparison',
           link: {
-            de: `https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_`,
+            de: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
             en: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
             fr: 'https://www.financescout24.ch/fr/lp/trouver-assurance-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',
             it: 'https://www.financescout24.ch/it/lp/trova-assicurazione-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_moto_',


### PR DESCRIPTION
[IN-1383](https://autoricardo.atlassian.net/browse/IN-1384?atlOrigin=eyJpIjoiMWRkNDIxZDZjMDUyNGUzN2E1ZmI0Mzg2OTgwZjE1NWYiLCJwIjoiaiJ9)

## Motivation and context

In the header, the utm_campaign is wrong for Insurance comparison

## Before

![InsuranceComparison_utm_param](https://github.com/smg-automotive/components-pkg/assets/52455155/10cc677c-3fb0-49e7-8a56-e8c2be6fe026)

## After

The insurance comparison links in the header return `subnavigation_moto_ instead` of `subnavigation_car_` for MS24

## How to test

Please make sure the UTM param is correct for both private and professional: https://in-1384-components-pkg.branch.autoscout24.dev/?path=/story/patterns-navigation-header--professional

<img width="786" alt="image" src="https://github.com/smg-automotive/components-pkg/assets/52455155/24052302-8eff-4fa0-a5b1-b9f249ecc81e">

<img width="1160" alt="image" src="https://github.com/smg-automotive/components-pkg/assets/52455155/d6bd5452-3421-4caf-885c-13abe303455e">

Thank you 🍂 


[IN-1383]: https://autoricardo.atlassian.net/browse/IN-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ