### PR TITLE
fix: magazin link

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1551,10 +1551,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.magazine',
           link: {
-            de: '/de/c/h/information',
-            en: '/en/c/h/information',
-            fr: '/fr/c/h/information',
-            it: '/it/c/h/informazione',
+            de: 'https://guide.motoscout24.ch/de/',
+            en: 'https://guide.motoscout24.ch/de/',
+            fr: 'https://guide.motoscout24.ch/fr/',
+            it: 'https://guide.motoscout24.ch/it/',
           },
           showUnderMoreLinkBelow: 'lg',
           visibilitySettings: {

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -172,10 +172,10 @@ export const headerLinks: NavigationLinkConfigProps[] = [
   {
     translationKey: 'header.magazine',
     link: {
-      de: '/de/c/h/information',
-      en: '/en/c/h/information',
-      fr: '/fr/c/h/information',
-      it: '/it/c/h/informazione',
+      de: 'https://guide.motoscout24.ch/de/',
+      en: 'https://guide.motoscout24.ch/de/',
+      fr: 'https://guide.motoscout24.ch/fr/',
+      it: 'https://guide.motoscout24.ch/it/',
     },
     showUnderMoreLinkBelow: 'lg',
     visibilitySettings: {


### PR DESCRIPTION
[IN-1383](https://autoricardo.atlassian.net/browse/IN-1383?atlOrigin=eyJpIjoiZjcxMmE4MDM5ZGFkNGJjN2JkMWZhYzQzYmRiZjkzMjAiLCJwIjoiaiJ9)

## Motivation and context

The link to magazin in MS24 returns an empty page

## Before

Clicking on Magazin in MS24 returns this URL: `fr/c/h/information`

## After

It returns `https://guide.motoscout24.ch/fr/`

## How to test

Make sure the magazin link returns the correct page for MS24

Thank you 
