### PR TITLE
fix: change overflow to auto for popover and modal filter

### DIFF
--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -102,9 +102,8 @@ export const ModalFilter: FC<ModalFilterProps> = ({
             </ModalHeader>
             <ModalBody
               overflowY="auto"
-              marginTop="2xl"
-              marginBottom={showCallToActionButton ? '2xl' : '0'}
-              paddingY="0"
+              paddingTop="2xl"
+              paddingBottom={showCallToActionButton ? '2xl' : '0'}
               paddingX="2xl"
             >
               {children}

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -101,7 +101,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
               )}
             </ModalHeader>
             <ModalBody
-              overflowY="scroll"
+              overflowY="auto"
               marginTop="2xl"
               marginBottom={showCallToActionButton ? '2xl' : '0'}
               paddingY="0"

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -102,8 +102,9 @@ export const ModalFilter: FC<ModalFilterProps> = ({
             </ModalHeader>
             <ModalBody
               overflowY="auto"
-              paddingTop="2xl"
-              paddingBottom={showCallToActionButton ? '2xl' : '0'}
+              marginTop="2xl"
+              marginBottom={showCallToActionButton ? '2xl' : '0'}
+              paddingY="0"
               paddingX="2xl"
             >
               {children}

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -67,8 +67,8 @@ const Popover: FC<Props> = ({
             )}
           </PopoverHeader>
           <PopoverBody
-            marginTop="2xl"
-            marginBottom={showCallToActionButton ? '2xl' : '0'}
+            paddingTop="2xl"
+            paddingBottom={showCallToActionButton ? '2xl' : '0'}
             maxH="6xl"
             overflowY="auto"
             paddingX="2xl"

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -70,7 +70,7 @@ const Popover: FC<Props> = ({
             marginTop="2xl"
             marginBottom={showCallToActionButton ? '2xl' : '0'}
             maxH="6xl"
-            overflowY="scroll"
+            overflowY="auto"
             paddingX="2xl"
           >
             {children}

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -67,8 +67,8 @@ const Popover: FC<Props> = ({
             )}
           </PopoverHeader>
           <PopoverBody
-            paddingTop="2xl"
-            paddingBottom={showCallToActionButton ? '2xl' : '0'}
+            marginTop="2xl"
+            marginBottom={showCallToActionButton ? '2xl' : '0'}
             maxH="6xl"
             overflowY="auto"
             paddingX="2xl"


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-2444

## Motivation and context

On Windows (or Mac with external windows mouse) users see scrollbars on the filter even if they are not needed.

## Before

![Bildschirmfoto 2023-11-13 um 10 10 55](https://github.com/smg-automotive/components-pkg/assets/71456764/180e02a4-984d-4af9-9649-7780bf8996e8)

## After

![Bildschirmfoto 2023-11-13 um 10 21 29](https://github.com/smg-automotive/components-pkg/assets/71456764/7bd75439-1531-4917-802b-ec1bb26e57a2)


## How to test

https://talamcol-filter-scrollbar-listings-web.branch.autoscout24.dev/de/s