### PR TITLE
fix: range input value while sliding

### DIFF
--- a/src/components/rangeFilterInputWithSlider/index.tsx
+++ b/src/components/rangeFilterInputWithSlider/index.tsx
@@ -46,11 +46,14 @@ function RangeFilterInputWithSlider<
     });
   }, [from.value, to.value]);
 
-  const handleSliderChange = (newValue: NumericMinMaxValue) => {
+  const handleSliderChange = (event: ChangeSliderCallback) => {
     if (!isSliding) {
       setIsSliding(true);
     }
-    setValuesWhileSliding(newValue);
+    setValuesWhileSliding((prevValuesWhileSliding) => ({
+      ...prevValuesWhileSliding,
+      [event.touched]: event.value[event.touched],
+    }));
   };
 
   const handleSliderRelease = (event: ChangeSliderCallback) => {

--- a/src/components/rangeSlider/RangeSliderWithChart.tsx
+++ b/src/components/rangeSlider/RangeSliderWithChart.tsx
@@ -59,7 +59,7 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
   const toMinMax = (
     minIndex: number,
     maxIndex: number,
-    previousSelection: NumericMinMaxValue,
+    previousSelection: NumericMinMaxValue
   ): NumericMinMaxValue => ({
     min: minIndex ? toValue(minIndex) : null,
     max: maxIndex ? toValue(maxIndex) : previousSelection.max,
@@ -79,7 +79,7 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
 
   const getChangedThumb = (
     initial: number[],
-    current: number[],
+    current: number[]
   ): 'max' | 'min' | null => {
     const [initialMinIndex, initialMaxIndex] = initial;
     const [currentMinIndex, currentMaxIndex] = current;
@@ -111,10 +111,10 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
   };
 
   const handleChange = (
-    [newMinIndex, newMaxIndex]: number[],
-    callback: (event: ChangeCallback) => void,
+    newValues: number[],
+    callback: (event: ChangeCallback) => void
   ) => {
-    const changeEvent = getChangeEvent([newMinIndex, newMaxIndex]);
+    const changeEvent = getChangeEvent(newValues);
     if (changeEvent) {
       callback(changeEvent);
     }
@@ -129,12 +129,8 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
         step={1}
         min={0}
         max={scale.length}
-        onChange={([newMinIndex, newMaxIndex]) =>
-          handleChange([newMinIndex, newMaxIndex], onSliderChange)
-        }
-        onChangeEnd={([newMinIndex, newMaxIndex]) =>
-          handleChange([newMinIndex, newMaxIndex], onSliderRelease)
-        }
+        onChange={(newValues) => handleChange(newValues, onSliderChange)}
+        onChangeEnd={(newValues) => handleChange(newValues, onSliderRelease)}
         onChangeStart={setStartRange}
         value={toRange(selection)}
       />

--- a/src/components/rangeSlider/RangeSliderWithChart.tsx
+++ b/src/components/rangeSlider/RangeSliderWithChart.tsx
@@ -24,7 +24,7 @@ export type Facet = {
 interface RangeSliderWithChartProps {
   facets: Array<Facet>;
   selection: NumericMinMaxValue;
-  onSliderChange: (values: NumericMinMaxValue) => void;
+  onSliderChange: (event: ChangeCallback) => void;
   onSliderRelease: (event: ChangeCallback) => void;
 }
 
@@ -93,16 +93,30 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
     return initialMinIndex !== currentMinIndex ? 'min' : 'max';
   };
 
-  const handleChangeEnd = ([newMinIndex, newMaxIndex]: number[]) => {
+  const getChangeEvent = ([
+    newMinIndex,
+    newMaxIndex,
+  ]: number[]): ChangeCallback | null => {
     const changedThumb = getChangedThumb(startRange, [
       newMinIndex,
       newMaxIndex,
     ]);
-    if (changedThumb) {
-      onSliderRelease({
-        touched: changedThumb,
-        value: toMinMax(newMinIndex, newMaxIndex, selection),
-      });
+
+    if (!changedThumb) return null;
+
+    return {
+      touched: changedThumb,
+      value: toMinMax(newMinIndex, newMaxIndex, selection),
+    };
+  };
+
+  const handleChange = (
+    [newMinIndex, newMaxIndex]: number[],
+    callback: (event: ChangeCallback) => void,
+  ) => {
+    const changeEvent = getChangeEvent([newMinIndex, newMaxIndex]);
+    if (changeEvent) {
+      callback(changeEvent);
     }
   };
 
@@ -115,10 +129,12 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
         step={1}
         min={0}
         max={scale.length}
-        onChange={([newMinIndex, newMaxIndex]) => {
-          onSliderChange(toMinMax(newMinIndex, newMaxIndex, selection));
-        }}
-        onChangeEnd={handleChangeEnd}
+        onChange={([newMinIndex, newMaxIndex]) =>
+          handleChange([newMinIndex, newMaxIndex], onSliderChange)
+        }
+        onChangeEnd={([newMinIndex, newMaxIndex]) =>
+          handleChange([newMinIndex, newMaxIndex], onSliderRelease)
+        }
         onChangeStart={setStartRange}
         value={toRange(selection)}
       />

--- a/src/components/rangeSlider/RangeSliderWithChart.tsx
+++ b/src/components/rangeSlider/RangeSliderWithChart.tsx
@@ -59,7 +59,7 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
   const toMinMax = (
     minIndex: number,
     maxIndex: number,
-    previousSelection: NumericMinMaxValue
+    previousSelection: NumericMinMaxValue,
   ): NumericMinMaxValue => ({
     min: minIndex ? toValue(minIndex) : null,
     max: maxIndex ? toValue(maxIndex) : previousSelection.max,
@@ -79,7 +79,7 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
 
   const getChangedThumb = (
     initial: number[],
-    current: number[]
+    current: number[],
   ): 'max' | 'min' | null => {
     const [initialMinIndex, initialMaxIndex] = initial;
     const [currentMinIndex, currentMaxIndex] = current;
@@ -112,7 +112,7 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
 
   const handleChange = (
     newValues: number[],
-    callback: (event: ChangeCallback) => void
+    callback: (event: ChangeCallback) => void,
   ) => {
     const changeEvent = getChangeEvent(newValues);
     if (changeEvent) {

--- a/src/components/rangeSlider/RangeSliderWithChart.tsx
+++ b/src/components/rangeSlider/RangeSliderWithChart.tsx
@@ -34,7 +34,7 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
   onSliderChange,
   onSliderRelease,
 }) => {
-  const [startRange, setStartRange] = useState<number[]>([]);
+  const [startRange, setStartRange] = useState<number[] | null>(null);
 
   const sortedFacetsByFromKey = facets.sort((a, b) => a.from - b.from);
 
@@ -97,10 +97,10 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
     newMinIndex,
     newMaxIndex,
   ]: number[]): ChangeCallback | null => {
-    const changedThumb = getChangedThumb(startRange, [
-      newMinIndex,
-      newMaxIndex,
-    ]);
+    const changedThumb = getChangedThumb(
+      startRange ? startRange : toRange(selection),
+      [newMinIndex, newMaxIndex],
+    );
 
     if (!changedThumb) return null;
 
@@ -130,7 +130,13 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
         min={0}
         max={scale.length}
         onChange={(newValues) => handleChange(newValues, onSliderChange)}
-        onChangeEnd={(newValues) => handleChange(newValues, onSliderRelease)}
+        onChangeEnd={(newValues) => {
+          const callback = (event: ChangeCallback) => {
+            onSliderRelease(event);
+            setStartRange(newValues);
+          };
+          handleChange(newValues, callback);
+        }}
         onChangeStart={setStartRange}
         value={toRange(selection)}
       />


### PR DESCRIPTION
References https://github.com/smg-automotive/listings-web/pull/1612#pullrequestreview-1731948544

## Before

1. go to https://main-components-pkg.branch.autoscout24.dev/?path=/docs/components-filter-range-filter-input-with-slider--docs
2. edit the `to` field to be something that is not selectable via the slider (e.g. 10006)
3. grab the slider and change the `from` value
4. you'll notice that the `to` value changes while sliding and resets to 10006 after the slider is released

## After

Fixed
