### PR TITLE
fix: calling reduce with no initial value

### DIFF
--- a/src/components/rangeSlider/RangeSliderWithChart.tsx
+++ b/src/components/rangeSlider/RangeSliderWithChart.tsx
@@ -43,7 +43,7 @@ const RangeSliderWithChart: React.FC<RangeSliderWithChartProps> = ({
   const toIndex = (value: number) => {
     const closestValue = scale.reduce((prev, curr) => {
       return Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev;
-    });
+    }, 0);
 
     return scale.indexOf(closestValue);
   };


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

If facets are an empty array (which is possible since it's a BE response), this throws an error:
https://app.datadoghq.com/logs?query=status%3Aerror%20kube_namespace%3Aprod%20service%3A%2A-web&agg_m=count&agg_q=service&agg_t=count&cols=host%2Cservice&event=AgAAAYvwx6WaRrKiUAAAAAAAAAAYAAAAAEFZdnd4NjVEQUFCSWdhVFQtV0xMNXdCRQAAACQAAAAAMDE4YmYwYzctYmFjMC00NGQyLTk2N2EtODdjZGU1NTY2MjQz&index=main&messageDisplay=inline&panel=%7B%22queryString%22%3A%22service%3Alistings-web%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22tag%22%2C%22path%22%3A%22service%22%2C%22value%22%3A%22listings-web%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1700551690000%2C%22to%22%3A1700551700000%2C%22live%22%3Afalse%7D%7D&refresh_mode=sliding&source=monitor_notif&storage=hot&stream_sort=desc&viz=timeseries&from_ts=1700550825370&to_ts=1700551725370&live=true