### PR TITLE
fix: adjusted left element on range filter

### DIFF
--- a/src/components/rangeFilterInput/InputLeftElement.tsx
+++ b/src/components/rangeFilterInput/InputLeftElement.tsx
@@ -9,9 +9,7 @@ const InputLeftElement: FC<{ unit: string }> = ({ unit }) => {
       paddingLeft="sm"
       height="full"
       fontSize="sm"
-      width="xl"
-      display="flex"
-      justifyContent="flex-start"
+      width="auto"
     >
       {unit}
     </ChakraInputLeftElement>

--- a/src/components/rangeFilterInput/InputLeftElement.tsx
+++ b/src/components/rangeFilterInput/InputLeftElement.tsx
@@ -9,6 +9,9 @@ const InputLeftElement: FC<{ unit: string }> = ({ unit }) => {
       paddingLeft="sm"
       height="full"
       fontSize="sm"
+      width="xl"
+      display="flex"
+      justifyContent="flex-start"
     >
       {unit}
     </ChakraInputLeftElement>


### PR DESCRIPTION
References
> Bug ticket https://autoricardo.atlassian.net/browse/DM-2505
> Figma https://www.figma.com/file/WvYYKrx8rxw80fwkzhAQwh/Search-Results-%26-Advanced-Search?type=design&node-id=5803-214515&mode=design&t=vk3EFEUKsPXUrLzF-0

## Motivation and context

We give more space to the left element in  the range input for filters.

## Before

![Screenshot 2023-11-21 at 14 05 43](https://github.com/smg-automotive/components-pkg/assets/37380787/51059f00-94a8-4511-a71c-6ba27ae2f583)

## After

<img width="312" alt="Screenshot 2023-11-21 at 15 51 35" src="https://github.com/smg-automotive/components-pkg/assets/37380787/fff814cf-54b4-4004-9ec8-845a44a06129">


## How to test

Please check the range input

## Thank you 🍄
