### PR TITLE
feat: add initial hero ad layout option for page layout

### DIFF
--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -11,6 +11,7 @@ interface Props {
   header?: ReactNode;
   footer?: ReactNode;
   skyScraperAd?: ReactNode;
+  heroAd?: ReactNode;
   maxContentWidth: keyof typeof sizes.container;
 }
 
@@ -18,6 +19,7 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
   header,
   footer,
   skyScraperAd,
+  heroAd,
   maxContentWidth,
   children,
 }) => {
@@ -29,6 +31,7 @@ const BaseLayout: FC<PropsWithChildren<Props>> = ({
           <Divider />
         </>
       ) : null}
+      {heroAd ? heroAd : null}
       <Flex justifyContent="center">
         <Container
           as="main"

--- a/src/components/layout/Page.stories.mdx
+++ b/src/components/layout/Page.stories.mdx
@@ -53,6 +53,11 @@ import PageLayout from './Page';
         disable: true,
       },
     },
+    heroAd: {
+      table: {
+        disable: true,
+      },
+    },
     children: {
       table: {
         disable: true,
@@ -80,11 +85,11 @@ export const Template = (args) => <PageLayout {...args} />;
 
 <ArgsTable story="Layout without ads" />
 
-## Layout with ads
+## Layout with sidebar ads
 
 <Canvas>
   <Story
-    name="Layout with ads"
+    name="Layout with sidebar ads"
     args={{
       skyScraperAd: (
         <Flex
@@ -93,7 +98,7 @@ export const Template = (args) => <PageLayout {...args} />;
           justifyContent="center"
           alignItems="center"
         >
-          <Text>Ads</Text>
+          <Text>Sidebar Ads</Text>
         </Flex>
       ),
     }}
@@ -102,4 +107,38 @@ export const Template = (args) => <PageLayout {...args} />;
   </Story>
 </Canvas>
 
-<ArgsTable story="Layout with ads" />
+<ArgsTable story="Layout with sidebar ads" />
+
+## Layout with hero and sidebar ads
+
+    <Canvas>
+          <Story
+              name="Layout with hero and sidebar ads"
+              args={{
+                skyScraperAd: (
+                  <Flex
+                    bg="red.100"
+                    h="600px"
+                    justifyContent="center"
+                    alignItems="center"
+                  >
+                    <Text>Sidebar Ads</Text>
+                  </Flex>
+                ),
+                heroAd: (
+                  <Flex
+                    bg="blue.100"
+                    h="300px"
+                    justifyContent="center"
+                    alignItems="center"
+                  >
+                    <Text>Hero Ad</Text>
+                  </Flex>
+                )
+              }}
+            >
+              {Template.bind({})}
+              </Story>
+          </Canvas>
+
+    <ArgsTable story="Layout with hero and sidebar ads" />

--- a/src/components/layout/Page.tsx
+++ b/src/components/layout/Page.tsx
@@ -8,6 +8,7 @@ interface Props {
   header: ReactNode;
   maxContentWidth: keyof typeof sizes.container;
   skyScraperAd?: ReactNode;
+  heroAd?: ReactNode;
   footer?: ReactNode;
 }
 
@@ -16,6 +17,7 @@ const PageLayout: FC<PropsWithChildren<Props>> = ({
   maxContentWidth,
   skyScraperAd,
   footer,
+  heroAd,
   children,
 }) => {
   return (
@@ -23,6 +25,7 @@ const PageLayout: FC<PropsWithChildren<Props>> = ({
       header={header}
       footer={footer}
       skyScraperAd={skyScraperAd}
+      heroAd={heroAd}
       maxContentWidth={maxContentWidth}
     >
       {children}


### PR DESCRIPTION
References [[link the ticket here](https://autoricardo.atlassian.net/browse/DM-2535?atlOrigin=eyJpIjoiNzA2NWFmMTFhYzlhNGQ1YjkwYmVjYmFkMThiYjA5YzAiLCJwIjoiaiJ9)]

## Motivation and context
Add additional `heroAd` prop to Page and Base Layout component to utilize full functionality of our existing page layout that we are using. This is only for needs of home Page on listings-web.

## Before
No Hero Ad option

## After
![image](https://github.com/smg-automotive/components-pkg/assets/28811793/da5e625e-999b-445a-8fe8-dad03edb378c)

## How to test

