### PR TITLE
feat: show filter label on popover in applied state

### DIFF
--- a/src/components/filterPatterns/popover/__tests__/Index.Test.tsx
+++ b/src/components/filterPatterns/popover/__tests__/Index.Test.tsx
@@ -215,4 +215,21 @@ describe('<PopoverFilter />', () => {
     );
     expect(screen.getByText('Treibstoff')).toBeInTheDocument();
   });
+
+  it('should allow to overwrite the applied label if the real label is for example too long', () => {
+    render(
+      <PopoverFilter
+        {...validProps}
+        label="Treibstoff von Agrola"
+        appliedLabel="T-Stoff"
+        isApplied={true}
+        displayValue="Benzin, Wasserstoff"
+      >
+        <div>Popover content</div>
+      </PopoverFilter>,
+    );
+    expect(
+      screen.getByText('T-Stoff: Benzin, Wasserstoff'),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -22,6 +22,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
   initialPopoverState = 'closed',
   isApplied,
   label,
+  appliedLabel,
   language,
   numberOfAppliedFilters,
   onPopoverClose,
@@ -104,7 +105,10 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
                     textOverflow="ellipsis"
                     whiteSpace="nowrap"
                   >
-                    {[label, displayValue && isApplied ? displayValue : null]
+                    {[
+                      isApplied ? appliedLabel ?? label : label,
+                      displayValue && isApplied ? displayValue : null,
+                    ]
                       .filter(Boolean)
                       .join(': ')}
                   </chakra.span>

--- a/src/components/filterPatterns/popover/props.ts
+++ b/src/components/filterPatterns/popover/props.ts
@@ -7,4 +7,5 @@ export type PopoverFilterProps = FilterPatternProps &
 
     onPopoverClose?: () => void;
     onPopoverOpen?: () => void;
+    appliedLabel?: string;
   };


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-2480

## Motivation and context

So that users can easily see what filter is applied, we add the label in applied state

## Before

Hard to see what filter it is

![Bildschirmfoto 2023-12-04 um 09 07 04](https://github.com/smg-automotive/components-pkg/assets/71456764/18c97bba-5c4f-4c8a-9949-068b7cd9694c)


## After
<img width="1072" alt="Bildschirmfoto 2023-12-04 um 09 23 38" src="https://github.com/smg-automotive/components-pkg/assets/71456764/97a2da25-873c-44e6-8148-8efebd04ad60">


## How to test

https://talamcol-filter-labels-listings-web.branch.autoscout24.dev/de/s?weightTotalFrom=1000&weightTotalTo=2000&weightCurbFrom=1000&weightCurbTo=2000&payloadFrom=500&payloadTo=2000
