### PR TITLE
feat: return button position on reset

### DIFF
--- a/src/components/filterPatterns/Heading.tsx
+++ b/src/components/filterPatterns/Heading.tsx
@@ -61,7 +61,7 @@ export const FilterHeading: FC<Props> = ({
               as="button"
               disabled={!isApplied}
               onClick={() => {
-                onResetFilter();
+                onResetFilter('filter');
                 contentRef?.current?.focus();
               }}
             >

--- a/src/components/filterPatterns/modal/index.tsx
+++ b/src/components/filterPatterns/modal/index.tsx
@@ -69,7 +69,7 @@ export const ModalFilter: FC<ModalFilterProps> = ({
                   label={label}
                   numberOfAppliedFilters={numberOfAppliedFilters}
                   onClose={onClose}
-                  onResetFilter={onResetFilter}
+                  onResetFilter={() => onResetFilter('filter')}
                 />
               )}
             </ModalHeader>

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -121,7 +121,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
                   h="md"
                   icon={<CloseIcon w="xs" h="xs" />}
                   minW="md"
-                  onClick={onResetFilter}
+                  onClick={() => onResetFilter('filterButton')}
                   w="md"
                   {...appliedOrOpenColorScheme}
                 />
@@ -133,7 +133,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
               label={label}
               numberOfAppliedFilters={numberOfAppliedFilters}
               onClose={onClose}
-              onResetFilter={onResetFilter}
+              onResetFilter={() => onResetFilter('filter')}
               showCallToActionButton={showCallToActionButton}
               header={header}
             >

--- a/src/components/filterPatterns/props.ts
+++ b/src/components/filterPatterns/props.ts
@@ -24,7 +24,7 @@ export type FilterPatternProps = {
   /**
    * Callback that is called if the reset filter button is pressed.
    */
-  onResetFilter: () => void;
+  onResetFilter: (placement?: 'filterButton' | 'filter') => void;
   /**
    * If a call-to-action button is displayed in the filter footer
    * @default true

--- a/src/components/filterPatterns/props.ts
+++ b/src/components/filterPatterns/props.ts
@@ -24,7 +24,7 @@ export type FilterPatternProps = {
   /**
    * Callback that is called if the reset filter button is pressed.
    */
-  onResetFilter: (placement?: 'filterButton' | 'filter') => void;
+  onResetFilter: (placement: 'filterButton' | 'filter') => void;
   /**
    * If a call-to-action button is displayed in the filter footer
    * @default true


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

The new requirement is that the reset button on the popover should not immediately reset the filters. The one on the filter button does. This also differs between SRP and advanced search. If we now which reset button was pressed, it allows us to make that behavior.
