### PR TITLE
chore: increase drawer close button

### DIFF
--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -15,7 +15,7 @@ const DrawerContent: FC<PropsWithChildren<Props>> = (props) => {
 
   return (
     <ChakraDrawerContent {...drawerContentProps}>
-      {withCloseButton && <DrawerCloseButton style={{ fontSize: '14px' }} />}
+      {withCloseButton && <DrawerCloseButton fontSize="base" />}
       {children}
     </ChakraDrawerContent>
   );

--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -15,7 +15,7 @@ const DrawerContent: FC<PropsWithChildren<Props>> = (props) => {
 
   return (
     <ChakraDrawerContent {...drawerContentProps}>
-      {withCloseButton && <DrawerCloseButton />}
+      {withCloseButton && <DrawerCloseButton style={{ fontSize: '14px' }} />}
       {children}
     </ChakraDrawerContent>
   );


### PR DESCRIPTION
References [JIRA](https://autoricardo.atlassian.net/browse/IN-1073)

## Motivation and context

While implementing drawer component for VP card, we noticed that close button is too small.

## Before

Close button very small (8px).

## After

Close button medium (14px, more clickable).

## How to test

Test from Storybook: `?path=/story/components-data-display-drawer--drawer&args=withCloseButton:!true`
