### PR TITLE
feat: chart icon

### DIFF
--- a/src/components/icons/ChartIcon.tsx
+++ b/src/components/icons/ChartIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const ChartIcon: ComponentWithAs<'svg', IconProps> = createIcon({
+  displayName: 'ChartIcon',
+  viewBox: '0 0 48 48',
+  path: (
+    <>
+      <title>Chart icon</title>
+
+      <path d="M7 39.5v-32l-2 1v33h38v-2H7z" fill="currentColor" />
+      <path
+        d="M21.04 22.91 27 28.87l11-11.04v8.67h2v-12H28v2h8.51L27 26.04l-5.96-5.95-11.03 10.99 1.41 1.42 9.62-9.59z"
+        fill="currentColor"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -14,6 +14,7 @@ export { CallIcon } from './CallIcon';
 export { CamperIcon } from './CamperIcon';
 export { CarIcon } from './CarIcon';
 export { CopyIcon } from './CopyIcon';
+export { ChartIcon } from './ChartIcon';
 export { CheckmarkIcon } from './CheckmarkIcon';
 export { CheckShieldIcon } from './CheckShieldIcon';
 export { ChevronDownLargeIcon } from './ChevronDownLargeIcon';


### PR DESCRIPTION
References [VSST-1945](https://autoricardo.atlassian.net/browse/VSST-1945)

## Motivation and context

- added `chart crossed` icon required for top vehicle management page statistics modal
- svg optimized via https://svgoptimizer.com/ (reduced size by ~25% compared to figma export)

## Before

No `chart` icon.

## After

<img width="260" alt="Screenshot 2024-01-09 at 09 57 49" src="https://github.com/smg-automotive/components-pkg/assets/141041162/b30d92e9-1b0e-41b9-8deb-bd62a6a493e9">

## How to test

https://chart-icon-components-pkg.branch.autoscout24.dev/?path=/story/foundations-icons--icons


[VSST-1945]: https://autoricardo.atlassian.net/browse/VSST-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ