### PR TITLE
"fix: revert override for tooltip stacking order (#873)"

### DIFF
--- a/src/components/tooltip/index.stories.mdx
+++ b/src/components/tooltip/index.stories.mdx
@@ -1,39 +1,17 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
-import { useDisclosure } from '@chakra-ui/react';
 
-import Modal from '../modal';
 import { TooltipIcon } from '../icons';
-import Button from '../button';
-import Box from '../box';
 import Tooltip from './index.tsx';
 
 <Meta title="Components/Overlay/Tooltip" component={Tooltip} />
 
-export const TooltipTemplate = (args) => {
+export const Template = (args) => {
   return (
     <Tooltip {...args}>
       <TooltipIcon />
     </Tooltip>
   );
 };
-
-export const ModalTemplate = (args) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const ref = React.useRef(null);
-
-return (
-
-<Box>
-  <Button onClick={onOpen}>Open Tooltip inside Modal</Button>
-  <Modal isOpen={isOpen} onClose={onClose}>
-    <Box ref={ref}>
-      <Tooltip {...args} containerRef={ref}>
-        <TooltipIcon />
-      </Tooltip>
-    </Box>
-  </Modal>
-</Box>
-); };
 
 # Tooltip
 
@@ -65,20 +43,6 @@ return (
       },
     }}
   >
-    {TooltipTemplate.bind({})}
-  </Story>
-</Canvas>
-
-## Stacking Order (Inside Modal component)
-
-<Canvas>
-  <Story
-    name="Override Stacking Order"
-    args={{
-      label: 'I am a tooltip in the modal',
-      placement: 'auto',
-    }}
-  >
-    {ModalTemplate.bind({})}
+    {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,17 +1,12 @@
 import React, { cloneElement, FC, useState } from 'react';
 
-import {
-  Tooltip as ChakraTooltip,
-  Portal,
-  TooltipProps,
-} from '@chakra-ui/react';
+import { Tooltip as ChakraTooltip, TooltipProps } from '@chakra-ui/react';
 
 type Props = {
   children: React.ReactNode;
-  containerRef?: React.RefObject<HTMLElement | null>;
 } & Pick<TooltipProps, 'label' | 'placement' | 'maxWidth'>;
 
-const Tooltip: FC<Props> = ({ children, containerRef, ...props }) => {
+const Tooltip: FC<Props> = ({ children, ...props }) => {
   const [isLabelOpen, setIsLabelOpen] = useState<boolean>(false);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -22,17 +17,15 @@ const Tooltip: FC<Props> = ({ children, containerRef, ...props }) => {
   });
 
   return (
-    <Portal containerRef={containerRef}>
-      <ChakraTooltip
-        hasArrow
-        placement="auto"
-        maxWidth="6xl"
-        isOpen={isLabelOpen}
-        {...props}
-      >
-        {childrenWithProps}
-      </ChakraTooltip>
-    </Portal>
+    <ChakraTooltip
+      hasArrow
+      placement="auto"
+      maxWidth="6xl"
+      isOpen={isLabelOpen}
+      {...props}
+    >
+      {childrenWithProps}
+    </ChakraTooltip>
   );
 };
 


### PR DESCRIPTION
This reverts commit 0a7847ea31f8d536704c53791209f855c0f94d9d.

References [JIRA](https://autoricardo.atlassian.net/browse/IN-1536)

## Motivation and context

Revert the Tooltip changes due to an UI breaking change: Portals get rendered as `div`, which breaks a layout where it is used inline with a text.
