### PR TITLE
fix: replaced break-word deprecated

### DIFF
--- a/src/components/checkboxFilter/index.tsx
+++ b/src/components/checkboxFilter/index.tsx
@@ -76,7 +76,8 @@ function CheckboxFilter<ItemKey extends string>({
                       <HighlightedText
                         text={item.label}
                         highlightIndices={item.highlightIndices}
-                        wordBreak="break-word"
+                        overflowWrap="anywhere"
+                        wordBreak="normal"
                       />
                       <chakra.span ml="sm">
                         {addThousandSeparatorToNumber(item.facet)}
@@ -93,7 +94,8 @@ function CheckboxFilter<ItemKey extends string>({
                       text={item.label}
                       highlightIndices={item.highlightIndices}
                       w="full"
-                      wordBreak="break-word"
+                      overflowWrap="anywhere"
+                      wordBreak="normal"
                     />
                     <chakra.span ml="sm">
                       {addThousandSeparatorToNumber(item.facet)}

--- a/src/themes/components/simpleHeader.ts
+++ b/src/themes/components/simpleHeader.ts
@@ -10,7 +10,8 @@ const SimpleHeader: ComponentMultiStyleConfig = {
     header: baseStyleHeader,
     title: {
       textStyle: { '2xs': 'heading3', md: 'heading1' },
-      wordBreak: 'break-word',
+      overflowWrap: 'anywhere',
+      wordBreak: 'normal',
     },
   },
 };

--- a/src/themes/components/vehicleReference.ts
+++ b/src/themes/components/vehicleReference.ts
@@ -1,7 +1,8 @@
 import { ComponentStyleConfig } from '@chakra-ui/react';
 
 const parts = ['carTitle', 'price', 'dealerName', 'dealerAddress'];
-const wordBreak = 'break-word';
+const overflowWrap = 'anywhere';
+const wordBreak = 'normal';
 
 const VehicleReference: ComponentStyleConfig = {
   parts,
@@ -10,6 +11,7 @@ const VehicleReference: ComponentStyleConfig = {
       color: 'gray.900',
       textStyle: { '2xs': 'heading5', md: 'heading3' },
       noOfLines: { '2xs': 1, md: 'none' },
+      overflowWrap,
       wordBreak,
     },
     price: {
@@ -20,12 +22,14 @@ const VehicleReference: ComponentStyleConfig = {
       color: 'gray.900',
       textStyle: 'heading4',
       display: { '2xs': 'none', md: 'flex' },
+      overflowWrap,
       wordBreak,
     },
     dealerAddress: {
       color: 'gray.900',
       textStyle: 'body',
       display: { '2xs': 'none', md: 'flex' },
+      overflowWrap,
       wordBreak,
     },
   },


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-2675

## Motivation and context

The property **word-break: break-word** is deprecated. We need to replace it with other properties.
For more information:
https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
https://caniuse.com/?search=word-break

## Take into consideration
I will do the same for listings project. I checked in seller project and this deprecated property is not applied there.  

## How to test

Please check the next components adding long text to see that the text breaks without overlapping:
* SimpleHeader
* Vehicle reference (car title, price, dealer name, dealer address)
* Checkbox filter

## Thank you 🌷
