### PR TITLE
feat: expose SingleColumnCentered max content width prop

### DIFF
--- a/src/components/layout/SingleColumnCentered.tsx
+++ b/src/components/layout/SingleColumnCentered.tsx
@@ -2,15 +2,24 @@ import React, { FC, PropsWithChildren } from 'react';
 
 import { Box, Container } from '@chakra-ui/react';
 
+import { sizes } from 'src/themes/shared/sizes';
+
 import BaseLayout from './BaseLayout';
 
-const SingleColumnCenteredLayout: FC<PropsWithChildren> = ({ children }) => {
+type SingleColumnCenteredLayoutProps = PropsWithChildren<{
+  maxContentWidth?: keyof typeof sizes.container;
+}>;
+
+const SingleColumnCenteredLayout: FC<SingleColumnCenteredLayoutProps> = ({
+  children,
+  maxContentWidth = 'md',
+}) => {
   const isSingleChild = !Array.isArray(children);
   const [stepper, content] = isSingleChild ? [null, children] : children;
 
   return (
     <Container width="full" height="full" background="gray.100">
-      <BaseLayout header={null} maxContentWidth="md">
+      <BaseLayout header={null} maxContentWidth={maxContentWidth}>
         {!stepper ? null : <Box marginBottom="2xl">{stepper}</Box>}
         <Box>{content}</Box>
       </BaseLayout>


### PR DESCRIPTION
References [VSST-1918](https://autoricardo.atlassian.net/browse/VSST-1918)

## Motivation and context

The private seller insertion flow packages page content width is wider than what is currently configured. This PR adds the ability to customize the insertion layout max width via prop.

<img width="1419" alt="Screenshot 2024-01-15 at 14 00 02" src="https://github.com/smg-automotive/components-pkg/assets/141041162/0c4110e7-56b8-41b5-9b4f-2c424b7ce132">

## Before

Insertion flow layout max width must be `md`.

## After

Insertion flow layout max width is customizable via prop.

## How to test

[Add a deep link and instructions how to verify the new behavior]


[VSST-1918]: https://autoricardo.atlassian.net/browse/VSST-1918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ