### PR TITLE
fix: lint locale files

### DIFF
--- a/.github/workflows/lint-i18n-files.yml
+++ b/.github/workflows/lint-i18n-files.yml
@@ -1,0 +1,26 @@
+name: Lint i18n files
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  format-and-commit:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.ref == 'phrase-translations'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: 'refs/heads/phrase-translations'
+
+    - name: Run format:i18n script
+      run: npm run format:i18n
+
+    - name: Commit changes
+      run: |
+        git config user.name "automotiveengineeringbot"
+        git config user.email "automotive.engineering@swissmarketplace.group"
+        git add .
+        git commit -m "Automated i18n formatting"
+        git push origin ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
[FE-180](https://autoricardo.atlassian.net/browse/FE-180?atlOrigin=eyJpIjoiNTJjYTg3MzZlNTk0NDIyODk0MmFkMmYyYTNjMDI5M2YiLCJwIjoiaiJ9)

## Motivation and context

When pushing translations from Phrase, the Pull request opened is not well linted. We need to format the file manually. 

## Before

Files have to be formated manually

## After

Github action automatically format the files


[FE-180]: https://autoricardo.atlassian.net/browse/FE-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ