### PR TITLE
feat: extend tooltip so it can be portaled to another element

### DIFF
--- a/src/components/tooltip/index.stories.mdx
+++ b/src/components/tooltip/index.stories.mdx
@@ -1,17 +1,39 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { useDisclosure } from '@chakra-ui/react';
 
+import Modal from '../modal';
 import { TooltipIcon } from '../icons';
+import Button from '../button';
+import Box from '../box';
 import Tooltip from './index.tsx';
 
 <Meta title="Components/Overlay/Tooltip" component={Tooltip} />
 
-export const Template = (args) => {
+export const TooltipTemplate = (args) => {
   return (
     <Tooltip {...args}>
       <TooltipIcon />
     </Tooltip>
   );
 };
+
+export const ModalTemplate = (args) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const ref = React.useRef(null);
+
+return (
+
+<Box>
+  <Button onClick={onOpen}>Open Tooltip inside Modal</Button>
+  <Modal isOpen={isOpen} onClose={onClose}>
+    <Box ref={ref}>
+      <Tooltip {...args} containerRef={ref}>
+        <TooltipIcon />
+      </Tooltip>
+    </Box>
+  </Modal>
+</Box>
+); };
 
 # Tooltip
 
@@ -43,6 +65,20 @@ export const Template = (args) => {
       },
     }}
   >
-    {Template.bind({})}
+    {TooltipTemplate.bind({})}
+  </Story>
+</Canvas>
+
+## Control stacking order
+
+<Canvas>
+  <Story
+    name="Override Stacking Order"
+    args={{
+      label: 'I am a tooltip in the modal',
+      placement: 'auto',
+    }}
+  >
+    {ModalTemplate.bind({})}
   </Story>
 </Canvas>

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,12 +1,17 @@
 import React, { cloneElement, FC, useState } from 'react';
 
-import { Tooltip as ChakraTooltip, TooltipProps } from '@chakra-ui/react';
+import {
+  Tooltip as ChakraTooltip,
+  Portal,
+  TooltipProps,
+} from '@chakra-ui/react';
 
 type Props = {
   children: React.ReactNode;
+  containerRef?: React.RefObject<HTMLElement>;
 } & Pick<TooltipProps, 'label' | 'placement' | 'maxWidth'>;
 
-const Tooltip: FC<Props> = ({ children, ...props }) => {
+const Tooltip: FC<Props> = ({ children, containerRef, ...props }) => {
   const [isLabelOpen, setIsLabelOpen] = useState<boolean>(false);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -16,14 +21,23 @@ const Tooltip: FC<Props> = ({ children, ...props }) => {
     onClick: () => setIsLabelOpen(true),
   });
 
+  if (containerRef) {
+    return (
+      <Portal containerRef={containerRef}>
+        <ChakraTooltip
+          hasArrow
+          placement="auto"
+          isOpen={isLabelOpen}
+          {...props}
+        >
+          {childrenWithProps}
+        </ChakraTooltip>
+      </Portal>
+    );
+  }
+
   return (
-    <ChakraTooltip
-      hasArrow
-      placement="auto"
-      maxWidth="6xl"
-      isOpen={isLabelOpen}
-      {...props}
-    >
+    <ChakraTooltip hasArrow placement="auto" isOpen={isLabelOpen} {...props}>
       {childrenWithProps}
     </ChakraTooltip>
   );


### PR DESCRIPTION
References [JIRA](https://autoricardo.atlassian.net/browse/IN-1536)

## Motivation and context

When Tooltip (Charka UI uses Portals for tooltips!) is used inside another portal (e.g. modal or drawer), it is stacked behind it and not visible.

## Before

Tooltip can't be attached to another DOM node.

## After

Tooltip can be attached to another DOM node with help of portals.

## How to test

[Add a deep link and instructions how to verify the new behavior]
