### PR TITLE
fix: z-index for tooltips

### DIFF
--- a/src/themes/components/tooltip.ts
+++ b/src/themes/components/tooltip.ts
@@ -16,6 +16,7 @@ const baseStyle = defineStyle(() => {
     p: 'sm',
     color: 'white',
     textStyle: 'body',
+    zIndex: 'tooltip',
   };
 });
 

--- a/src/themes/shared/zIndices.ts
+++ b/src/themes/shared/zIndices.ts
@@ -12,6 +12,6 @@ export const zIndices = {
   popover: 1500,
   skipLink: 1600,
   toast: 1700,
-  tooltip: 1800,
   fullScreenModal: 2000,
+  tooltip: 2100,
 };


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/IN-1536

## Motivation and context

Tooltips are not visible when rendered within a drawer component

## Before

Tooltip not visible

## After

![image](https://github.com/smg-automotive/components-pkg/assets/3371760/625a0874-c3e2-41a7-95a0-04f2678eba5b)

## How to test

Check the tooltip is visible within the drawer
