### PR TITLE
fix: Discrete slider label centered

### DIFF
--- a/src/components/discreteSlider/index.tsx
+++ b/src/components/discreteSlider/index.tsx
@@ -7,6 +7,8 @@ import {
   SliderTrack,
 } from '@chakra-ui/react';
 
+import { Box } from '../index';
+
 const emptyItemOffset = 0;
 const firstItemOffset = 1;
 
@@ -80,9 +82,8 @@ const DiscreteSlider = <T,>({
             key={index}
             value={stepValue as number}
             fontWeight={sliderStepValue === stepValue ? 'bold' : 'normal'}
-            ml={`-${label.length}%`}
           >
-            {label}
+            <Box style={{ pointerEvents: 'all' }}>{label}</Box>
           </ChakraSliderMark>
         );
       })}

--- a/src/components/discreteSlider/index.tsx
+++ b/src/components/discreteSlider/index.tsx
@@ -7,7 +7,7 @@ import {
   SliderTrack,
 } from '@chakra-ui/react';
 
-import { Box } from '../index';
+import Box from '../box';
 
 const emptyItemOffset = 0;
 const firstItemOffset = 1;

--- a/src/themes/components/slider.ts
+++ b/src/themes/components/slider.ts
@@ -97,6 +97,7 @@ const baseStyleMark = defineStyle(() => {
   return {
     mt: '2xl',
     fontSize: 'sm',
+    transform: 'translateX(-50%)',
   };
 });
 


### PR DESCRIPTION
JIRA Reference: [JIRA](https://smg-au.atlassian.net/browse/VSST-1786)

Design Reference: [Design](https://www.figma.com/file/MxJLYwGMJB5m1VDGgi8Lku/Private-insertion-flow?type=design&node-id=75-20572&mode=design&t=cMpN8ZzECCeX6drv-0)

## Motivation and context

Discrete slider label should be properly centered below slider thumb.

## Before

<img width="1012" alt="Screenshot 2024-01-25 at 10 57 18" src="https://github.com/smg-automotive/components-pkg/assets/153915313/b840b339-a1c8-45af-91f6-b54eb2cb5bb4">


## After

<img width="1003" alt="Screenshot 2024-01-25 at 10 57 38" src="https://github.com/smg-automotive/components-pkg/assets/153915313/5e405667-18d9-418b-bd7a-489439da8732">


## How to test

[Storybook - DiscreteSlider](https://discrete-slider-label-centered-components-pkg.branch.autoscout24.dev/?path=/docs/components-filter-discrete-slider--docs)