### PR TITLE
Phrase branch: improved Github actions

### DIFF
--- a/.github/workflows/lint-i18n-files.yml
+++ b/.github/workflows/lint-i18n-files.yml
@@ -2,7 +2,7 @@ name: Lint i18n files
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, synchronize]
 
 jobs:
   format-and-commit:
@@ -16,8 +16,14 @@ jobs:
 
     - name: Run format:i18n script
       run: npm run format:i18n
+    
+    - name: Check for changes
+      id: check_changes
+      run: |
+         git diff --exit-code || echo "changes=true" >> "$GITHUB_ENV"
 
     - name: Commit changes
+      if: env.changes == 'true'
       run: |
         git config user.name "automotiveengineeringbot"
         git config user.email "automotive.engineering@swissmarketplace.group"

--- a/.github/workflows/phrase-pr-notification.yml
+++ b/.github/workflows/phrase-pr-notification.yml
@@ -1,0 +1,16 @@
+name: Send slack notification for Phrase PR
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+jobs:
+  send-slack-notification:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.ref == 'phrase-translations'
+    steps:
+      - name: Send Slack Notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_AU_PHRASE }}
+        run: |
+            curl -X POST -H 'Content-type: application/json' --data '{"text":":wave: A Phrase pull request have been opened or updated in <https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}|${{ github.repository }}>"}' $SLACK_WEBHOOK_URL


### PR DESCRIPTION
[IN-1463](https://autoricardo.atlassian.net/browse/IN-1466?atlOrigin=eyJpIjoiNmZkNzBlZjM3ZmIzNDIxOGFhZWFhNDczYjE0MGY2MzUiLCJwIjoiaiJ9)

## Motivation and context

I wanted to improve the Github action that formats the i18n files from a Phrase branch. 
+ 
To merge Phrase generated PRs timely, we want to have a Slack channel which send an alert everytime a phrase-translations branch is created or updated.

## Before

If a phrase-translation branch is already open and new changes are done through Phrase, we have to close and reopen the PR to run the format.
If the files are already well linted (it happens in components-pkg), we try to commit nothing so it returns an error.
+
No Slack channel

## After

If a phrase-translation branch is already open and new changes are done through Phrase, format:i18n is triggered automatically.
If the files are already well linted (it happens in components-pkg), we skip the commit part. 
+
Slack Channel is created and we have a GitHub action that will trigger the alert