### PR TITLE
fix: DiscreteSlider mark label type

### DIFF
--- a/src/components/discreteSlider/index.tsx
+++ b/src/components/discreteSlider/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Slider as ChakraSlider,
   SliderMark as ChakraSliderMark,
@@ -14,7 +14,7 @@ const firstItemOffset = 1;
 
 type SliderMark<T> = {
   stepValue?: number;
-  label: string;
+  label: ReactNode;
   value: T;
 };
 

--- a/src/components/discreteSlider/index.tsx
+++ b/src/components/discreteSlider/index.tsx
@@ -12,15 +12,15 @@ import Box from '../box';
 const emptyItemOffset = 0;
 const firstItemOffset = 1;
 
-type SliderMark<T> = {
+export type DiscreteSliderMark<T> = {
   stepValue?: number;
   label: ReactNode;
   value: T;
 };
 
-type SliderProps<T> = {
+type DiscreteSliderProps<T> = {
   applyIndentation?: boolean;
-  marks: SliderMark<T>[];
+  marks: DiscreteSliderMark<T>[];
   value: T;
   onValueChanged: (arg: T) => void;
 };
@@ -30,7 +30,7 @@ const getItemOffset = (applyIndentation: boolean) => {
 };
 
 const getSliderStepValue = <T,>(
-  marks: SliderMark<T>[],
+  marks: DiscreteSliderMark<T>[],
   applyIndentation: boolean,
   value: T,
 ) => {
@@ -42,7 +42,7 @@ const getSliderStepValue = <T,>(
 };
 
 const getSliderMarks = <T,>(
-  marks: SliderMark<T>[],
+  marks: DiscreteSliderMark<T>[],
   applyIndentation: boolean,
 ) =>
   marks.map((mark, index) => ({
@@ -55,7 +55,7 @@ const DiscreteSlider = <T,>({
   applyIndentation = true,
   onValueChanged,
   value,
-}: SliderProps<T>) => {
+}: DiscreteSliderProps<T>) => {
   const sliderStepValue = getSliderStepValue(marks, applyIndentation, value);
 
   const sliderMarks = getSliderMarks(marks, applyIndentation);


### PR DESCRIPTION
References:

[JIRA](https://smg-au.atlassian.net/browse/VSST-1786)
[Design](https://www.figma.com/file/MxJLYwGMJB5m1VDGgi8Lku/Private-insertion-flow?type=design&node-id=75-19614&mode=design&t=1oOm0ryuGQF86P0q-0)

## Motivation and context

DiscreteSlider mark label type should be changed from string to ReactNode. This way there can be versatile and custom implementation of label that depends on design requirement. (E.g.: On larger devices show text as label, but on smaller devices show an icon instead)

## Before

<img width="576" alt="Screenshot 2024-01-29 at 14 28 41" src="https://github.com/smg-automotive/components-pkg/assets/153915313/e228a37b-76e4-4f67-a653-588b32399bc1">

## After

<img width="448" alt="Screenshot 2024-01-29 at 14 29 11" src="https://github.com/smg-automotive/components-pkg/assets/153915313/4fcd4a9e-bc9d-4cb7-abc8-4292450a5af7">

## How to test

[Storybook - DiscreteSlider](https://discrete-slider-mark-label-type-components-pkg.branch.autoscout24.dev/?path=/story/components-filter-discrete-slider--overview)