### PR TITLE
fix: enable style props to alert component

### DIFF
--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -33,12 +33,14 @@ const Alert: FC<AlertProps> = ({
   link,
   type,
   icon,
+  dismissible,
+  onDismiss,
   ...rest
 }) => {
   const { isOpen, onClose } = useDisclosure({ defaultIsOpen: true });
 
-  return isOpen || !rest.dismissible ? (
-    <ChakraAlert status={type}>
+  return isOpen || !dismissible ? (
+    <ChakraAlert status={type} {...rest}>
       <AlertIcon>{icon}</AlertIcon>
       <Flex direction="column" w="100%">
         {title ? <AlertTitle>{title}</AlertTitle> : null}
@@ -49,13 +51,13 @@ const Alert: FC<AlertProps> = ({
           </Link>
         ) : null}
       </Flex>
-      {rest.dismissible ? (
+      {dismissible ? (
         <CloseButton
           alignSelf="flex-start"
           position="relative"
           onClick={() => {
             onClose();
-            rest.onDismiss?.();
+            onDismiss?.();
           }}
         />
       ) : null}


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Enable to pass  'style props' to component. For example to add margin.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
