### PR TITLE
fix: padding between checkbox filter group

### DIFF
--- a/src/components/checkboxFilter/index.tsx
+++ b/src/components/checkboxFilter/index.tsx
@@ -60,7 +60,7 @@ function CheckboxFilter<ItemKey extends string>({
     >
       {items.map((item) => {
         return (
-          <Box key={item.key} width="full" marginBottom="2xl">
+          <Box key={item.key} width="full" marginBottom="lg">
             <Checkbox
               name={`filter_${name}_${item.label}`}
               label={


### PR DESCRIPTION
[Ticket](https://smg-au.atlassian.net/browse/DM-2805)

## Motivation and context
Designers wanted smaller padding (in our case it's margin) for grouped checkboxes. Instead of having 12px top and bottom (in our case 24px margin bottom) we want that to be 8px bottom and top (so 16px margin bottom).

## Before
![image](https://github.com/smg-automotive/components-pkg/assets/28811793/9bdae8df-0c29-4888-adc7-d332936045ae)

## After
![image](https://github.com/smg-automotive/components-pkg/assets/28811793/6c67857c-c414-48cb-86d8-38519262ce9c)

## How to test

