### PR TITLE
fix: Indentation on DiscreteSlider causes unexpected state behaviour

### DIFF
--- a/src/components/discreteSlider/__tests__/DiscreteSlider.Test.tsx
+++ b/src/components/discreteSlider/__tests__/DiscreteSlider.Test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import DiscreteSlider from '../index';
 
@@ -43,14 +43,11 @@ describe('DiscreteSlider', () => {
     expect(screen.getByRole('slider')).toBeInTheDocument();
   });
 
-  it('calls onValueChanged when value is changed', async () => {
-    const valueToChange = 1;
-    const onValueChanged = jest.fn();
-    renderWrapper({ onValueChanged });
+  it('should move the thumb', async () => {
+    renderWrapper();
 
     const slider = screen.getByRole('slider');
-    await userEvent.type(slider, String(valueToChange));
-
-    expect(onValueChanged).toHaveBeenCalledTimes(1);
+    await userEvent.keyboard('[ArrowRight]');
+    await waitFor(() => expect(slider).toHaveAttribute('aria-valuenow', '1'));
   });
 });

--- a/src/components/discreteSlider/index.tsx
+++ b/src/components/discreteSlider/index.tsx
@@ -61,6 +61,8 @@ const DiscreteSlider = <T,>({
   const sliderMarks = getSliderMarks(marks, applyIndentation);
 
   const handleOnChange = (newStepValue: number) => {
+    if (applyIndentation && newStepValue < firstItemOffset) return;
+
     const newSliderMark = sliderMarks.find(
       (mark) => mark.stepValue === newStepValue,
     )?.value;


### PR DESCRIPTION
References
[JIRA](https://smg-au.atlassian.net/browse/VSST-2001)
[PR](https://github.com/smg-automotive/seller-web/pull/1475)

## Motivation and context

When applyIndentation is true, which is default value of that prop, moving thumb past the first option on DiscreteSlider causes unexpected state behaviour that lead to weird experience.

## Before

https://github.com/smg-automotive/components-pkg/assets/153915313/de6aba60-8373-43fa-9d75-690264ac89bf

## After

https://github.com/smg-automotive/components-pkg/assets/153915313/7f204b7e-0513-4533-9b3b-916175d7917a

## How to test
[Storybook - DiscreteSlider](https://discrete-slider-bug-fix-undefined-value-components-pkg.branch.autoscout24.dev/?path=/docs/components-filter-discrete-slider--docs)