### PR TITLE
feat: render popover in portal

### DIFF
--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -1,11 +1,13 @@
 import React, { FC, PropsWithChildren, ReactElement } from 'react';
 import {
+  Box,
   Popover as ChakraPopover,
   PopoverProps as ChakraPopoverProps,
   PopoverArrow,
   PopoverBody,
   PopoverContent,
   PopoverTrigger,
+  Portal,
 } from '@chakra-ui/react';
 
 type PopoverProps = PropsWithChildren<
@@ -24,18 +26,22 @@ const Popover: FC<PopoverProps> = ({ content, children, placement }) => {
       gutter={12}
     >
       <PopoverTrigger>{children}</PopoverTrigger>
-      <PopoverContent
-        borderRadius="sm"
-        boxShadow="md"
-        maxW="6xl"
-        p="2xl"
-        // required for arrow to popup above shadow
-        zIndex="0"
-        backgroundColor="white"
-      >
-        <PopoverArrow backgroundColor="white" />
-        <PopoverBody>{content}</PopoverBody>
-      </PopoverContent>
+      <Portal>
+        <Box zIndex="popover" w="full" h="full" position="relative">
+          <PopoverContent
+            borderRadius="sm"
+            boxShadow="md"
+            maxW="6xl"
+            p="2xl"
+            // required for arrow to popup above shadow
+            zIndex="0"
+            backgroundColor="white"
+          >
+            <PopoverArrow backgroundColor="white" />
+            <PopoverBody>{content}</PopoverBody>
+          </PopoverContent>
+        </Box>
+      </Portal>
     </ChakraPopover>
   );
 };


### PR DESCRIPTION
References [VSST-2072](https://smg-au.atlassian.net/browse/VSST-2072)

## Motivation and context

Renders popover in a portal with a popover specific popover `zIndex` in order to internalize overlay functionality. The implementation is similar to existing filter popover.

## Before

Need to add `zIndex` and `position` in places where popover is used.

## After

Overlaying is handled internally.

## How to test

https://render-popover-in-portal-components-pkg.branch.autoscout24.dev/?path=/story/components-overlay-popover--popover