### PR TITLE
fix: chevron alignment on grouped checkbox filter

### DIFF
--- a/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
+++ b/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
@@ -10,14 +10,14 @@ import CheckboxWithFacet from './CheckboxWithFacet';
 
 type CheckboxCollapsibleProps<
   ItemKey extends string,
-  FilterName extends string
+  FilterName extends string,
 > = {
   item: Item<ItemKey, FilterName>;
 } & Pick<Props<ItemKey, FilterName>, 'onApply' | 'onToggleCheckboxGroup'>;
 
 function CheckboxGroupCollapsibleWithChildren<
   ItemKey extends string,
-  FilterName extends string
+  FilterName extends string,
 >({
   item,
   onApply,
@@ -27,7 +27,7 @@ function CheckboxGroupCollapsibleWithChildren<
   const { t } = useI18n();
   const checkboxes = item.childCheckboxes ?? [];
   const numberOfAppliedChildren = checkboxes.filter(
-    (checkbox) => checkbox.isChecked
+    (checkbox) => checkbox.isChecked,
   ).length;
   const groupDomId = `checkbox-group-${item.key}-${item.filterName ?? ''}`;
 

--- a/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
+++ b/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
@@ -10,14 +10,14 @@ import CheckboxWithFacet from './CheckboxWithFacet';
 
 type CheckboxCollapsibleProps<
   ItemKey extends string,
-  FilterName extends string,
+  FilterName extends string
 > = {
   item: Item<ItemKey, FilterName>;
 } & Pick<Props<ItemKey, FilterName>, 'onApply' | 'onToggleCheckboxGroup'>;
 
 function CheckboxGroupCollapsibleWithChildren<
   ItemKey extends string,
-  FilterName extends string,
+  FilterName extends string
 >({
   item,
   onApply,
@@ -27,7 +27,7 @@ function CheckboxGroupCollapsibleWithChildren<
   const { t } = useI18n();
   const checkboxes = item.childCheckboxes ?? [];
   const numberOfAppliedChildren = checkboxes.filter(
-    (checkbox) => checkbox.isChecked,
+    (checkbox) => checkbox.isChecked
   ).length;
   const groupDomId = `checkbox-group-${item.key}-${item.filterName ?? ''}`;
 
@@ -56,7 +56,7 @@ function CheckboxGroupCollapsibleWithChildren<
                 onToggleCheckboxGroup?.(item);
               }}
               w="full"
-              h="full"
+              h="sm"
               display="flex"
               justifyContent="flex-end"
               icon={

--- a/src/components/checkboxFilter/GroupedCheckboxFilterStoryTemplate.tsx
+++ b/src/components/checkboxFilter/GroupedCheckboxFilterStoryTemplate.tsx
@@ -135,15 +135,15 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const removeParentFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>
+    updatedItem: Item<Values, FilterType>,
   ): Filter => {
     const childrenToUpdate = getAllChildrenByParentKey(updatedItem.key);
     return {
       [parentFilterName]: parentFilter.filter(
-        (parent) => parent !== updatedItem.key
+        (parent) => parent !== updatedItem.key,
       ),
       [childFilterName]: childFilter.filter(
-        (child) => !childrenToUpdate.includes(child)
+        (child) => !childrenToUpdate.includes(child),
       ),
     } as Filter;
   };
@@ -151,13 +151,13 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const addParentFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>
+    updatedItem: Item<Values, FilterType>,
   ): Filter => {
     const childrenToUpdate = getAllChildrenByParentKey(updatedItem.key);
     return {
       [parentFilterName as FilterType]: [...parentFilter, updatedItem.key],
       [childFilterName]: childFilter.filter(
-        (child) => !childrenToUpdate.includes(child)
+        (child) => !childrenToUpdate.includes(child),
       ),
     } as Filter;
   };
@@ -177,7 +177,7 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const getParentItemByChildrenKey = (key?: Values) => {
     if (!key) return null;
     return checkboxes.find((box) =>
-      box.childCheckboxes?.find((child) => child.key === key)
+      box.childCheckboxes?.find((child) => child.key === key),
     );
   };
 
@@ -185,14 +185,14 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
     parentFilter: string[],
     childFilter: string[],
     updatedItem: Item<Values, FilterType>,
-    parentItem: Item<Values, FilterType>
+    parentItem: Item<Values, FilterType>,
   ): Filter => {
     const childrenToUpdate = getAllChildrenByParentKey(parentItem.key).filter(
-      (childKey) => childKey !== updatedItem.key
+      (childKey) => childKey !== updatedItem.key,
     );
     return {
       [parentFilterName]: parentFilter.filter(
-        (parent) => parent !== parentItem.key
+        (parent) => parent !== parentItem.key,
       ),
       [childFilterName]: [...childFilter, ...childrenToUpdate],
     } as Filter;
@@ -201,13 +201,13 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const removeAllChildrenAndAddParent = (
     parentFilter: string[],
     childFilter: string[],
-    parentItem: Item<Values, FilterType>
+    parentItem: Item<Values, FilterType>,
   ): Filter => {
     const childrenToRemove = getAllChildrenByParentKey(parentItem.key);
     return {
       [parentFilterName]: [...parentFilter, parentItem.key],
       [childFilterName]: childFilter.filter(
-        (childKey) => !childrenToRemove.includes(childKey)
+        (childKey) => !childrenToRemove.includes(childKey),
       ),
     } as Filter;
   };
@@ -215,7 +215,7 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const addChildFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>
+    updatedItem: Item<Values, FilterType>,
   ) => {
     return {
       [parentFilterName]: parentFilter,
@@ -226,12 +226,12 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const removeChildFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>
+    updatedItem: Item<Values, FilterType>,
   ) => {
     return {
       [parentFilterName]: parentFilter,
       [childFilterName]: childFilter.filter(
-        (childKey) => childKey !== updatedItem.key
+        (childKey) => childKey !== updatedItem.key,
       ),
     } as Filter;
   };
@@ -247,18 +247,18 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
             parentFilter,
             childFilter,
             updatedItem,
-            parentItem
+            parentItem,
           );
         }
         if (updatedItem.isChecked) {
           const childrenWithoutModified = parentItem.childCheckboxes.filter(
-            (child) => child.key !== updatedItem.key
+            (child) => child.key !== updatedItem.key,
           );
           if (childrenWithoutModified.every((child) => child.isChecked)) {
             return removeAllChildrenAndAddParent(
               parentFilter,
               childFilter,
-              parentItem
+              parentItem,
             );
           }
           return addChildFilter(parentFilter, childFilter, updatedItem);

--- a/src/components/checkboxFilter/GroupedCheckboxFilterStoryTemplate.tsx
+++ b/src/components/checkboxFilter/GroupedCheckboxFilterStoryTemplate.tsx
@@ -6,7 +6,9 @@ import CheckboxFilter from './index';
 
 type Values =
   | 'new'
+  | 'long'
   | 'demonstration'
+  | 'foo'
   | 'brandnew'
   | 'used'
   | 'lowered'
@@ -103,6 +105,23 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
         },
       ],
     },
+    {
+      label:
+        'Super duper long group name that will break on multiple lines. Usually on Italian and French but also happens on other things',
+      key: 'long',
+      facet: 100,
+      isChecked: filter.conditionTypeGroup.includes('long'),
+      filterName: parentFilterName,
+      childCheckboxes: [
+        {
+          label: 'Foo',
+          key: 'foo',
+          facet: 77,
+          isChecked: filter.conditionType.includes('foo'),
+          filterName: childFilterName,
+        },
+      ],
+    },
   ];
 
   const getAllChildrenByParentKey = (key?: Values): string[] => {
@@ -116,15 +135,15 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const removeParentFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>,
+    updatedItem: Item<Values, FilterType>
   ): Filter => {
     const childrenToUpdate = getAllChildrenByParentKey(updatedItem.key);
     return {
       [parentFilterName]: parentFilter.filter(
-        (parent) => parent !== updatedItem.key,
+        (parent) => parent !== updatedItem.key
       ),
       [childFilterName]: childFilter.filter(
-        (child) => !childrenToUpdate.includes(child),
+        (child) => !childrenToUpdate.includes(child)
       ),
     } as Filter;
   };
@@ -132,13 +151,13 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const addParentFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>,
+    updatedItem: Item<Values, FilterType>
   ): Filter => {
     const childrenToUpdate = getAllChildrenByParentKey(updatedItem.key);
     return {
       [parentFilterName as FilterType]: [...parentFilter, updatedItem.key],
       [childFilterName]: childFilter.filter(
-        (child) => !childrenToUpdate.includes(child),
+        (child) => !childrenToUpdate.includes(child)
       ),
     } as Filter;
   };
@@ -158,7 +177,7 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const getParentItemByChildrenKey = (key?: Values) => {
     if (!key) return null;
     return checkboxes.find((box) =>
-      box.childCheckboxes?.find((child) => child.key === key),
+      box.childCheckboxes?.find((child) => child.key === key)
     );
   };
 
@@ -166,14 +185,14 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
     parentFilter: string[],
     childFilter: string[],
     updatedItem: Item<Values, FilterType>,
-    parentItem: Item<Values, FilterType>,
+    parentItem: Item<Values, FilterType>
   ): Filter => {
     const childrenToUpdate = getAllChildrenByParentKey(parentItem.key).filter(
-      (childKey) => childKey !== updatedItem.key,
+      (childKey) => childKey !== updatedItem.key
     );
     return {
       [parentFilterName]: parentFilter.filter(
-        (parent) => parent !== parentItem.key,
+        (parent) => parent !== parentItem.key
       ),
       [childFilterName]: [...childFilter, ...childrenToUpdate],
     } as Filter;
@@ -182,13 +201,13 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const removeAllChildrenAndAddParent = (
     parentFilter: string[],
     childFilter: string[],
-    parentItem: Item<Values, FilterType>,
+    parentItem: Item<Values, FilterType>
   ): Filter => {
     const childrenToRemove = getAllChildrenByParentKey(parentItem.key);
     return {
       [parentFilterName]: [...parentFilter, parentItem.key],
       [childFilterName]: childFilter.filter(
-        (childKey) => !childrenToRemove.includes(childKey),
+        (childKey) => !childrenToRemove.includes(childKey)
       ),
     } as Filter;
   };
@@ -196,7 +215,7 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const addChildFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>,
+    updatedItem: Item<Values, FilterType>
   ) => {
     return {
       [parentFilterName]: parentFilter,
@@ -207,12 +226,12 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
   const removeChildFilter = (
     parentFilter: string[],
     childFilter: string[],
-    updatedItem: Item<Values, FilterType>,
+    updatedItem: Item<Values, FilterType>
   ) => {
     return {
       [parentFilterName]: parentFilter,
       [childFilterName]: childFilter.filter(
-        (childKey) => childKey !== updatedItem.key,
+        (childKey) => childKey !== updatedItem.key
       ),
     } as Filter;
   };
@@ -228,18 +247,18 @@ function StoryTemplate({ onApplyAction, onToggleCheckboxGroupAction }: Props) {
             parentFilter,
             childFilter,
             updatedItem,
-            parentItem,
+            parentItem
           );
         }
         if (updatedItem.isChecked) {
           const childrenWithoutModified = parentItem.childCheckboxes.filter(
-            (child) => child.key !== updatedItem.key,
+            (child) => child.key !== updatedItem.key
           );
           if (childrenWithoutModified.every((child) => child.isChecked)) {
             return removeAllChildrenAndAddParent(
               parentFilter,
               childFilter,
-              parentItem,
+              parentItem
             );
           }
           return addChildFilter(parentFilter, childFilter, updatedItem);

--- a/src/components/filterPatterns/modal/index.stories.mdx
+++ b/src/components/filterPatterns/modal/index.stories.mdx
@@ -44,7 +44,6 @@ export const Template = (args) => (
       onResetFilter={action('onResetFilter')}
     >
       <CheckboxFilter
-        name="fuel-type"
         items={[
           { label: 'Benzin', key: 'petrol', facet: 20, isChecked: true },
           { label: 'Diesel', key: 'diesel', facet: 17, isChecked: true },
@@ -76,6 +75,7 @@ export const Template = (args) => (
           },
         ]}
         onApply={() => null}
+        language="de"
       />
     </ModalFilter>
   </Box>

--- a/src/components/filterPatterns/popover/index.stories.mdx
+++ b/src/components/filterPatterns/popover/index.stories.mdx
@@ -42,7 +42,6 @@ export const Template = (args) => (
       onResetFilter={action('onResetFilter')}
     >
       <CheckboxFilter
-        name="fuel-type"
         items={[
           { label: 'Benzin', key: 'petrol', facet: 20, isChecked: true },
           { label: 'Diesel', key: 'diesel', facet: 17, isChecked: true },
@@ -80,6 +79,7 @@ export const Template = (args) => (
           },
         ]}
         onApply={() => null}
+        language="de"
       />
     </PopoverFilter>
   </Box>


### PR DESCRIPTION
References [link the ticket here]

## Before

When the label was long, the chevron icon was no longer aligned with the facet

## After

Aligned with the facet even if the label breaks on multiple lines
