### PR TITLE
chore: delete disabled eslint rule

### DIFF
--- a/src/components/carousel/__tests__/Index.Test.tsx
+++ b/src/components/carousel/__tests__/Index.Test.tsx
@@ -9,7 +9,6 @@ jest.mock('embla-carousel-react', () => {
   const embla = jest.requireActual('embla-carousel-react');
 
   return {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     default: jest.fn(embla),
   };


### PR DESCRIPTION
References [JIRA](https://smg-au.atlassian.net/browse/FE-238)

## Motivation and context

Some ESLint configurations were set as global configs and respective lines for disabling them can be removed from the projects.

## Before

ESLint doesn't allow uppercase property names and double leading underscore.

## After

ESLint allows uppercase property names and double leading underscore.
