### PR TITLE
fix: remove header drawer link

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -207,25 +207,6 @@ export const drawerNodeItems = ({
           },
         },
         {
-          translationKey: 'header.searchMenu.vehicleRating',
-          link: {
-            de: '/de/content/fahrzeugbewertung',
-            en: '/de/content/fahrzeugbewertung',
-            fr: '/fr/content/evaluation-vehicule',
-            it: '/it/content/valutazione-veicolo',
-          },
-          visibilitySettings: {
-            userType: {
-              private: true,
-              professional: true,
-            },
-            brand: {
-              autoscout24: true,
-              motoscout24: true,
-            },
-          },
-        },
-        {
           translationKey: 'header.searchMenu.insuranceComparison',
           link: {
             de: 'https://www.financescout24.ch/de/lp/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=subnavigation_car_',

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -113,7 +113,6 @@
       "searchMerchant": "Händler suchen",
       "searchMotorcycles": "Motorräder suchen",
       "simpleSearch": "Einfache Suche (Startseite)",
-      "vehicleRating": "Fahrzeugbewertung",
       "vehicles": "Fahrzeuge",
       "viewedListings": "Angesehene Inserate"
     },

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -113,7 +113,6 @@
       "searchMerchant": "Search a merchant",
       "searchMotorcycles": "Search motorcycles",
       "simpleSearch": "Simple Search (Home)",
-      "vehicleRating": "Vehicle Rating",
       "vehicles": "Vehicles",
       "viewedListings": "Viewed listings"
     },

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -113,7 +113,6 @@
       "searchMerchant": "Rechercher point de vente",
       "searchMotorcycles": "Rechercher des motos",
       "simpleSearch": "Recherche simple (page d'accueil)",
-      "vehicleRating": "Evaluer le véhicule",
       "vehicles": "Véhicules",
       "viewedListings": "Annonces vues"
     },

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -113,7 +113,6 @@
       "searchMerchant": "Ricerca commerciante",
       "searchMotorcycles": "Ricerca moto",
       "simpleSearch": "Ricerca semplice (pagina iniziale)",
-      "vehicleRating": "Valutare veicolo",
       "vehicles": "Veicoli",
       "viewedListings": "Annunci visualizzati"
     },


### PR DESCRIPTION


References [DM-2877](https://smg-au.atlassian.net/browse/DM-2877)

## Motivation and context

## Before

Link is present in header
<img width="1592" alt="Screenshot 2024-03-01 at 14 19 36" src="https://github.com/smg-automotive/components-pkg/assets/55357316/0ecafc7d-aa86-4c01-9253-e28d58406bf3">


## After

Link is not present in header
<img width="1187" alt="Screenshot 2024-03-01 at 14 20 20" src="https://github.com/smg-automotive/components-pkg/assets/55357316/17b86357-efe6-4097-81b9-3d00b2343160">

## How to test



[Add a deep link and instructions how to verify the new behavior]
