### PR TITLE
fix: remove paddingY from popover initial load

### DIFF
--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -8,6 +8,8 @@ import {
   Portal,
 } from '@chakra-ui/react';
 
+import Stack from 'src/components/stack';
+import Flex from 'src/components/flex';
 import Box from 'src/components/box';
 
 import { FilterHeading } from '../Heading';
@@ -42,7 +44,6 @@ const Popover: FC<Props> = ({
   onResetFilter,
   showCallToActionButton,
   header,
-  isOpen,
   children,
 }) => {
   const { language } = useI18n();
@@ -57,55 +58,57 @@ const Popover: FC<Props> = ({
         <PopoverContent
           backgroundColor="white"
           borderRadius="sm"
-          paddingY={isOpen ? '2xl' : 0}
+          paddingY="2xl"
           shadow="md"
           w="6xl"
           minHeight={enforceHeight ? '7xl' : undefined}
           height={enforceHeight ? '7xl' : undefined}
           ref={popoverContentRef}
         >
-          <PopoverHeader paddingX="2xl">
-            {header ?? (
-              <FilterHeading
-                Icon={Icon}
-                isApplied={isApplied}
-                label={label}
-                numberOfAppliedFilters={numberOfAppliedFilters}
-                onClose={onClose}
-                language={language}
-                onResetFilter={onResetFilter}
-                contentRef={popoverContentRef}
-              />
-            )}
-          </PopoverHeader>
-          <PopoverBody
-            sx={{
-              '--call-to-action-height':
-                'calc(var(--chakra-sizes-lg) + var(--chakra-space-2xl))',
-            }}
-            marginTop="2xl"
-            maxH={
-              showCallToActionButton
-                ? '6xl'
-                : 'calc(var(--chakra-sizes-6xl) + var(--call-to-action-height))'
-            }
-            marginBottom={showCallToActionButton ? '2xl' : '0'}
-            height={enforceHeight ? maxHeight : undefined}
-            maxHeight={maxHeight}
-            overflowY="auto"
-            paddingX="2xl"
-          >
-            {children}
-          </PopoverBody>
-          {showCallToActionButton ? (
-            <PopoverFooter paddingX="2xl">
-              <FilterActionButton
-                actionButton={actionButton}
-                isApplied={isApplied}
-                onClose={onClose}
-              />
-            </PopoverFooter>
-          ) : null}
+          <Box as={Stack} h="full">
+            <PopoverHeader paddingX="2xl">
+              {header ?? (
+                <FilterHeading
+                  Icon={Icon}
+                  isApplied={isApplied}
+                  label={label}
+                  numberOfAppliedFilters={numberOfAppliedFilters}
+                  onClose={onClose}
+                  language={language}
+                  onResetFilter={onResetFilter}
+                  contentRef={popoverContentRef}
+                />
+              )}
+            </PopoverHeader>
+            <PopoverBody
+              sx={{
+                '--call-to-action-height':
+                  'calc(var(--chakra-sizes-lg) + var(--chakra-space-2xl))',
+              }}
+              marginTop="2xl"
+              maxH={
+                showCallToActionButton
+                  ? '6xl'
+                  : 'calc(var(--chakra-sizes-6xl) + var(--call-to-action-height))'
+              }
+              marginBottom={showCallToActionButton ? '2xl' : '0'}
+              height={enforceHeight ? maxHeight : undefined}
+              maxHeight={maxHeight}
+              overflowY="auto"
+              paddingX="2xl"
+            >
+              {children}
+            </PopoverBody>
+            {showCallToActionButton ? (
+              <PopoverFooter paddingX="2xl">
+                <FilterActionButton
+                  actionButton={actionButton}
+                  isApplied={isApplied}
+                  onClose={onClose}
+                />
+              </PopoverFooter>
+            ) : null}
+          </Box>
         </PopoverContent>
       </Box>
     </Portal>

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -9,7 +9,6 @@ import {
 } from '@chakra-ui/react';
 
 import Stack from 'src/components/stack';
-import Flex from 'src/components/flex';
 import Box from 'src/components/box';
 
 import { FilterHeading } from '../Heading';

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -16,6 +16,7 @@ import { PopoverFilterProps } from './props';
 
 type Props = {
   onClose: () => void;
+  isOpen?: boolean;
 } & Pick<
   PopoverFilterProps,
   | 'actionButton'
@@ -41,6 +42,7 @@ const Popover: FC<Props> = ({
   onResetFilter,
   showCallToActionButton,
   header,
+  isOpen,
   children,
 }) => {
   const { language } = useI18n();
@@ -55,7 +57,7 @@ const Popover: FC<Props> = ({
         <PopoverContent
           backgroundColor="white"
           borderRadius="sm"
-          paddingY="2xl"
+          paddingY={isOpen ? '2xl' : 0}
           shadow="md"
           w="6xl"
           minHeight={enforceHeight ? '7xl' : undefined}

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -57,14 +57,14 @@ const Popover: FC<Props> = ({
         <PopoverContent
           backgroundColor="white"
           borderRadius="sm"
-          paddingY="2xl"
+          // paddingY="2xl"
           shadow="md"
           w="6xl"
           minHeight={enforceHeight ? '7xl' : undefined}
           height={enforceHeight ? '7xl' : undefined}
           ref={popoverContentRef}
         >
-          <Box as={Stack} h="full">
+          <Box as={Stack} h="full" paddingY="2xl">
             <PopoverHeader paddingX="2xl">
               {header ?? (
                 <FilterHeading

--- a/src/components/filterPatterns/popover/Popover.tsx
+++ b/src/components/filterPatterns/popover/Popover.tsx
@@ -17,7 +17,6 @@ import { PopoverFilterProps } from './props';
 
 type Props = {
   onClose: () => void;
-  isOpen?: boolean;
 } & Pick<
   PopoverFilterProps,
   | 'actionButton'
@@ -57,7 +56,6 @@ const Popover: FC<Props> = ({
         <PopoverContent
           backgroundColor="white"
           borderRadius="sm"
-          // paddingY="2xl"
           shadow="md"
           w="6xl"
           minHeight={enforceHeight ? '7xl' : undefined}

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -146,7 +146,6 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
               showCallToActionButton={showCallToActionButton}
               header={header}
               enforceHeight={enforceHeight}
-              isOpen={isOpen}
             >
               {children}
             </FilterPopover>

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -146,6 +146,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
               showCallToActionButton={showCallToActionButton}
               header={header}
               enforceHeight={enforceHeight}
+              isOpen={isOpen}
             >
               {children}
             </FilterPopover>


### PR DESCRIPTION
[References [link the ticket here]](https://smg-au.atlassian.net/browse/DM-2891)

## Motivation and context

We had some white space at the end of the page. The paddingY="2xl" on popoverContent gives it. So we needed to only apply it when popover is open.

## Before

![image](https://github.com/smg-automotive/components-pkg/assets/155618745/4e739a1b-f096-4f71-89b6-aa97e3198a38)

## After

![image](https://github.com/smg-automotive/components-pkg/assets/155618745/ac9396a6-d2dc-4c44-8ba7-61755cb8726a)

## How to test

Check whether the white space is still present and that all filters are working as before.
