### PR TITLE
Update "Verkaufen" link for professional sellers on autoscout24

### DIFF
--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -40,32 +40,11 @@ export const headerLinks: NavigationLinkConfigProps[] = [
     visibilitySettings: {
       userType: {
         private: true,
-        professional: true,
+        professional: false,
       },
       brand: {
         autoscout24: true,
         motoscout24: false,
-      },
-    },
-  },
-  {
-    translationKey: 'header.sell',
-    link: {
-      de: '/de/member/insertion/type',
-      en: '/de/member/insertion/type',
-      fr: '/fr/member/insertion/type',
-      it: '/it/member/insertion/type',
-    },
-    showUnderMoreLinkBelow: 'sm',
-    visibilitySettings: {
-      userType: {
-        private: false,
-        professional: true,
-        guest: false,
-      },
-      brand: {
-        autoscout24: false,
-        motoscout24: true,
       },
     },
   },
@@ -85,6 +64,27 @@ export const headerLinks: NavigationLinkConfigProps[] = [
       },
       brand: {
         autoscout24: false,
+        motoscout24: true,
+      },
+    },
+  },
+  {
+    translationKey: 'header.sell',
+    link: {
+      de: '/de/member/insertion/type',
+      en: '/de/member/insertion/type',
+      fr: '/fr/member/insertion/type',
+      it: '/it/member/insertion/type',
+    },
+    showUnderMoreLinkBelow: 'sm',
+    visibilitySettings: {
+      userType: {
+        private: false,
+        professional: true,
+        guest: false,
+      },
+      brand: {
+        autoscout24: true,
         motoscout24: true,
       },
     },

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -79,9 +79,9 @@ export const headerLinks: NavigationLinkConfigProps[] = [
     showUnderMoreLinkBelow: 'sm',
     visibilitySettings: {
       userType: {
+        guest: false,
         private: false,
         professional: true,
-        guest: false,
       },
       brand: {
         autoscout24: true,

--- a/src/components/navigation/header/index.stories.mdx
+++ b/src/components/navigation/header/index.stories.mdx
@@ -45,7 +45,7 @@ export const Template = (args) => {
       user: {
         id: 123,
         userName: 'John Doe',
-        type: 'professional',
+        userType: 'professional',
         accountId: 525,
       },
       language: 'de',
@@ -78,7 +78,7 @@ export const Template = (args) => {
       user: {
         id: 123,
         name: 'John Doe',
-        type: 'private',
+        userType: 'private',
         accountId: 525,
       },
       useAbsoluteUrls: true,


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/IN-1727

## Motivation and context

Changes the "Verkaufen" Link for professional sellers 

## Before

Link pointed to landingpage

## After

Link points to insertion

## How to test

https://lkappeler-in-1727-update-link-components-pkg.branch.autoscout24.dev/?path=/docs/patterns-navigation-header--docs

