### PR TITLE
fix: add height prop for popover filters

### DIFF
--- a/src/components/filterPatterns/popover/index.stories.mdx
+++ b/src/components/filterPatterns/popover/index.stories.mdx
@@ -18,6 +18,7 @@ import { PopoverFilter } from './index.tsx';
     actionButton: {
       label: '12324 Fahrzeuge',
       onClick: action('actionButton - onClick'),
+      height: ['md', 'lg'],
     },
   }}
   argTypes={{

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -33,7 +33,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
   showCallToActionButton = true,
   header,
   children,
-  height = 'md',
+  triggerHeight = 'md',
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
     defaultIsOpen: initialPopoverState === 'open',
@@ -85,7 +85,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
                   borderRightWidth={displayValue ? '1px' : undefined}
                   display="flex"
                   flex="1"
-                  height={height}
+                  height={triggerHeight}
                   justifyContent="space-between"
                   minW="0"
                   paddingX="md"

--- a/src/components/filterPatterns/popover/index.tsx
+++ b/src/components/filterPatterns/popover/index.tsx
@@ -33,6 +33,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
   showCallToActionButton = true,
   header,
   children,
+  height = 'md',
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure({
     defaultIsOpen: initialPopoverState === 'open',
@@ -84,7 +85,7 @@ export const PopoverFilter: FC<PopoverFilterProps> = ({
                   borderRightWidth={displayValue ? '1px' : undefined}
                   display="flex"
                   flex="1"
-                  h="md"
+                  height={height}
                   justifyContent="space-between"
                   minW="0"
                   paddingX="md"

--- a/src/components/filterPatterns/popover/props.ts
+++ b/src/components/filterPatterns/popover/props.ts
@@ -4,9 +4,9 @@ import { ActionButtonProps } from '../ActionButton';
 export type PopoverFilterProps = FilterPatternProps &
   Omit<ActionButtonProps, 'onClose'> & {
     initialPopoverState?: 'open' | 'closed';
-
     onPopoverClose?: () => void;
     onPopoverOpen?: () => void;
     appliedLabel?: string;
     enforceHeight?: boolean;
+    height?: 'md' | 'lg';
   };

--- a/src/components/filterPatterns/popover/props.ts
+++ b/src/components/filterPatterns/popover/props.ts
@@ -8,5 +8,5 @@ export type PopoverFilterProps = FilterPatternProps &
     onPopoverOpen?: () => void;
     appliedLabel?: string;
     enforceHeight?: boolean;
-    height?: 'md' | 'lg';
+    triggerHeight?: 'md' | 'lg';
   };


### PR DESCRIPTION
[Ticket](https://smg-au.atlassian.net/browse/DM-2923)

## Motivation and context
Add optional prop to popover component so that height of the popover filter can be changed. This is due to different height sizes on homepage.

## Before
![image](https://github.com/smg-automotive/components-pkg/assets/28811793/71ddbb91-387b-4887-b7be-062a45360d80)

## After
![image](https://github.com/smg-automotive/components-pkg/assets/28811793/0610c61f-4258-4e1d-b6f8-16322dfa4cef)