### PR TITLE
fix: extending radio label

### DIFF
--- a/src/components/radio/index.stories.mdx
+++ b/src/components/radio/index.stories.mdx
@@ -36,9 +36,9 @@ export const Template = ({ isChecked, ...args }) => {
         control: 'select',
       },
       fontWeight: {
-         options: ['fontRegular', 'fontBold'],
+        options: ['fontRegular', 'fontBold'],
         control: 'select',
-      }
+      },
     }}
   >
     {Template.bind({})}

--- a/src/components/radio/index.stories.mdx
+++ b/src/components/radio/index.stories.mdx
@@ -32,9 +32,13 @@ export const Template = ({ isChecked, ...args }) => {
     }}
     argTypes={{
       size: {
-        options: ['sm', 'md'],
+        options: ['sm', 'base', 'md'],
         control: 'select',
       },
+      fontWeight: {
+         options: ['fontRegular', 'fontBold'],
+        control: 'select',
+      }
     }}
   >
     {Template.bind({})}

--- a/src/components/radio/index.stories.mdx
+++ b/src/components/radio/index.stories.mdx
@@ -35,10 +35,6 @@ export const Template = ({ isChecked, ...args }) => {
         options: ['sm', 'base', 'md'],
         control: 'select',
       },
-      fontWeight: {
-        options: ['fontRegular', 'fontBold'],
-        control: 'select',
-      },
     }}
   >
     {Template.bind({})}

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -1,10 +1,10 @@
-import React, { ChangeEvent, forwardRef, ReactNode } from 'react';
+import React, { ChangeEvent, forwardRef } from 'react';
 import { Radio as ChakraRadio, RadioGroup } from '@chakra-ui/react';
 
 interface Props {
   name?: string;
   value: string;
-  label?: ReactNode;
+  label?: string;
   size?: 'sm' | 'md';
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   isChecked?: boolean;

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   isChecked?: boolean;
   isInvalid?: boolean;
   isDisabled?: boolean;
+  fontWeight?: 'regular' | 'bold';
 }
 
 const Radio = forwardRef<HTMLInputElement, Props>(
@@ -23,6 +24,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
       isChecked = false,
       isInvalid,
       isDisabled = false,
+      fontWeight = 'regular',
     },
     ref,
   ) => {
@@ -36,6 +38,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
         isInvalid={isInvalid}
         isDisabled={isDisabled}
         ref={ref}
+        fontWeight={fontWeight}
       >
         {label}
       </ChakraRadio>

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   isChecked?: boolean;
   isInvalid?: boolean;
   isDisabled?: boolean;
-  fontWeight?: 'regular' | 'bold';
+  variant?: 'fontRegular' | 'fontBold';
 }
 
 const Radio = forwardRef<HTMLInputElement, Props>(
@@ -19,12 +19,12 @@ const Radio = forwardRef<HTMLInputElement, Props>(
       name,
       value,
       label,
-      size = 'md',
+      size = 'base',
       onChange,
       isChecked = false,
       isInvalid,
       isDisabled = false,
-      fontWeight = 'regular',
+      variant = 'fontRegular',
     },
     ref,
   ) => {
@@ -38,7 +38,7 @@ const Radio = forwardRef<HTMLInputElement, Props>(
         isInvalid={isInvalid}
         isDisabled={isDisabled}
         ref={ref}
-        fontWeight={fontWeight}
+        variant={variant}
       >
         {label}
       </ChakraRadio>

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -1,10 +1,10 @@
-import React, { ChangeEvent, forwardRef } from 'react';
+import React, { ChangeEvent, forwardRef, ReactNode } from 'react';
 import { Radio as ChakraRadio, RadioGroup } from '@chakra-ui/react';
 
 interface Props {
   name?: string;
   value: string;
-  label?: string;
+  label?: ReactNode;
   size?: 'sm' | 'md';
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   isChecked?: boolean;

--- a/src/themes/components/radio.ts
+++ b/src/themes/components/radio.ts
@@ -1,6 +1,7 @@
 import { createMultiStyleConfigHelpers, defineStyle } from '@chakra-ui/react';
 import { radioAnatomy as parts } from '@chakra-ui/anatomy';
 
+import { fontWeights } from '../shared/fontWeights';
 import checkbox from './checkbox';
 
 const { definePartsStyle, defineMultiStyleConfig } =
@@ -9,6 +10,12 @@ const { definePartsStyle, defineMultiStyleConfig } =
 const sizes = {
   sm: {
     label: { fontSize: 'sm' },
+  },
+  base: {
+    label: { fontSize: 'base' },
+  },
+  md: {
+    label: { fontSize: 'md' },
   },
 };
 
@@ -29,6 +36,19 @@ const baseStyleControl = defineStyle({
   },
 });
 
+const variants = {
+  fontBold: definePartsStyle({
+    label: defineStyle({
+      fontWeight: fontWeights.bold,
+    }),
+  }),
+  fontRegular: definePartsStyle({
+    label: defineStyle({
+      fontWeight: fontWeights.regular,
+    }),
+  }),
+};
+
 const baseStyle = definePartsStyle({
   label: checkbox.baseStyle?.label,
   container: checkbox.baseStyle?.container,
@@ -38,4 +58,5 @@ const baseStyle = definePartsStyle({
 export default defineMultiStyleConfig({
   sizes,
   baseStyle,
+  variants,
 });


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

- Adding font weight variant to input radio component.
- Introducing `md` size for input radio component.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

https://zbiljic-extend-radio-label-components-pkg.branch.autoscout24.dev/?path=/docs/components-forms-radio--docs

- Check `size` prop - `sm` | `base` | `md`
- Check `fontRegular` & `fontBold` variants