### PR TITLE
feat: Add icons for Search trends section on Home page.

### DIFF
--- a/src/components/icons/CategoryAIcon.tsx
+++ b/src/components/icons/CategoryAIcon.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const CategoryAIcon: ComponentWithAs<'svg', IconProps> = createIcon({
+  displayName: 'CategoryAIcon',
+  viewBox: '0 0 24 24',
+  path: (
+    <>
+      <title>Category A icon</title>
+      <path fill="currentColor" d="M1 4h10v2H1zM13 4h10v2H13z" />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M13 2h-2v4h2zM9 0v8h6V0z"
+        clipRule="evenodd"
+      />
+      <path fill="currentColor" d="M3 4v6H1V4zM23 4v16h-2V4z" />
+      <path
+        fill="currentColor"
+        d="M12 18h11v2H12zM8.728 20.002H6.796l-.528-1.716H3.34l-.552 1.716H1l2.76-8.052h2.196zm-3.924-6.3L3.796 16.87h2.028l-.984-3.168z"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/CategoryAMinusIcon.tsx
+++ b/src/components/icons/CategoryAMinusIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const CategoryAMinusIcon: ComponentWithAs<'svg', IconProps> = createIcon(
+  {
+    displayName: 'CategoryAMinusIcon',
+    viewBox: '0 0 24 24',
+    path: (
+      <>
+        <title>Category A minus icon</title>
+        <path fill="currentColor" d="M1 4h10v2H1zM13 4h10v2H13z" />
+        <path
+          fill="currentColor"
+          fillRule="evenodd"
+          d="M13 2h-2v4h2zM9 0v8h6V0z"
+          clipRule="evenodd"
+        />
+        <path fill="currentColor" d="M3 4v6H1V4zM23 4v16h-2V4z" />
+        <path
+          fill="currentColor"
+          d="M16 18h7v2h-7zM12.55 17.494H8.866v-1.44h3.684zM8.728 20.002H6.796l-.528-1.716H3.34l-.552 1.716H1l2.76-8.052h2.196zm-3.924-6.3L3.796 16.87h2.028l-.984-3.168z"
+        />
+      </>
+    ),
+    defaultProps: {
+      boxSize: 'sm',
+    },
+  },
+);

--- a/src/components/icons/CategoryAOneIcon.tsx
+++ b/src/components/icons/CategoryAOneIcon.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const CategoryAOneIcon: ComponentWithAs<'svg', IconProps> = createIcon({
+  displayName: 'CategoryAOneIcon',
+  viewBox: '0 0 24 24',
+  path: (
+    <>
+      <title>Category A one icon</title>
+      <path fill="currentColor" d="M1 4h10v2H1zM13 4h10v2H13z" />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M13 2h-2v4h2zM9 0v8h6V0z"
+        clipRule="evenodd"
+      />
+      <path fill="currentColor" d="M3 4v6H1V4zM23 4v16h-2V4z" />
+      <path
+        fill="currentColor"
+        d="M16 18h7v2h-7zM8.977 14.952V13.2l3.504-1.38v8.184h-1.788v-5.736zM8.728 20.004H6.796l-.528-1.716H3.34l-.552 1.716H1l2.76-8.052h2.196zm-3.924-6.3-1.008 3.168h2.028l-.984-3.168z"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/VehicleTypesMotorcycleStarIcon.tsx
+++ b/src/components/icons/VehicleTypesMotorcycleStarIcon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const VehicleTypesMotorcycleStarIcon: ComponentWithAs<'svg', IconProps> =
+  createIcon({
+    displayName: 'VehicleTypesMotorcycleStarIcon',
+    viewBox: '0 0 24 24',
+    path: (
+      <>
+        <title>Vehicle types motorcycle star icon</title>
+        <g fill="currentColor" clipPath="url(#a)">
+          <path d="m12 10.5-2-1.37H8h.05L6.5 10.5 4 7H0l1 2h1.92l2.16 3.22A4 4 0 0 0 5 13l-2 3v4h3v4h6v-4h3v-4l-2-3q0-.323-.06-.64zM6 18H5v-1.4l.8-1.2.2.24zm4 4H8v-5.13a3.9 3.9 0 0 0 2 0zm-1-7a2 2 0 0 1-2-2 1.94 1.94 0 0 1 .55-1.37 2 2 0 0 1 2.9 0c.357.366.554.859.55 1.37a2 2 0 0 1-2 2m4 1.6V18h-1v-2.36l.2-.24z" />
+          <path d="m6 10.5 2-1.37h2-.05l1.55 1.37 2-2 2 1-2.58 2.72q.078.386.08.78l2 3v4h-3v4H6v-4H3v-4l2-3q0-.323.06-.64zm6 7.5h1v-1.4l-.8-1.2-.2.24zm-4 4h2v-5.13a3.9 3.9 0 0 1-2 0zm1-7a2 2 0 0 0 2-2 1.94 1.94 0 0 0-.55-1.37 2 2 0 0 0-2.9 0A1.94 1.94 0 0 0 7 13a2 2 0 0 0 2 2m-4 1.6V18h1v-2.36l-.2-.24z" />
+          <path d="m18 0 1.697 4.303L24 6l-4.303 1.697L18 12l-1.697-4.303L12 6l4.303-1.697z" />
+          <path
+            fillRule="evenodd"
+            d="M9 17a4 4 0 1 0 0-8 4 4 0 0 0 0 8m0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4"
+            clipRule="evenodd"
+          />
+        </g>
+        <defs>
+          <clipPath id="a">
+            <path fill="currentColor" d="M0 0h24v24H0z" />
+          </clipPath>
+        </defs>
+      </>
+    ),
+    defaultProps: {
+      boxSize: 'sm',
+    },
+  });

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -113,3 +113,7 @@ export { TiltedRectangleIcon } from './TiltedRectangleIcon';
 export { PlusCircleIcon } from './PlusCircleIcon';
 export { StarCircleIcon } from './StarCircleIcon';
 export { InfinityCircleIcon } from './InfinityCircleIcon';
+export { VehicleTypesMotorcycleStarIcon } from './VehicleTypesMotorcycleStarIcon';
+export { CategoryAOneIcon } from './CategoryAOneIcon';
+export { CategoryAIcon } from './CategoryAIcon';
+export { CategoryAMinusIcon } from './CategoryAMinusIcon';


### PR DESCRIPTION
References
[JIRA](https://smg-au.atlassian.net/browse/DM-2411)
[Design](https://www.figma.com/file/mitrdndvcCjzikpQiLwZxJ/AS24-Home-Design?type=design&node-id=1684-154150&mode=design&t=9J6onANcLn75fiRj-0)

## Motivation and context

Add missing icons for Search trends section links on Home page.

## Before

Missing icons: 
  - VehicleTypesMotorcycleStarIcon
  - CategoryAOneIcon
  - CategoryAIcon
  - CategoryAMinusIcon

## After

Added icons: 
  - VehicleTypesMotorcycleStarIcon
  - CategoryAOneIcon
  - CategoryAIcon
  - CategoryAMinusIcon
  
Icons are optimized using svgo.

## How to test

[Storybook - Icons](https://dm-3037-search-trend-icons-components-pkg.branch.autoscout24.dev/?path=/docs/foundations-icons--docs)