### PR TITLE
fix: increase header padding from SM break-point and above

### DIFF
--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -103,7 +103,7 @@ const Navigation: FC<NavigationProps> = ({
           margin="auto"
           display="flex"
           justifyContent="space-between"
-          px={{ base: 'sm', xs: 'lg' }}
+          px={{ base: 'sm', xs: 'lg', sm: '2xl' }}
         >
           <NavigationItems
             platform={brand}


### PR DESCRIPTION
References [JIRA](https://smg-au.atlassian.net/browse/IN-1749)

## Motivation and context

We were asked by UX Team to increase header left and right padding for desktop viewports (SM and above, >= 768px).

## Before

From 768px (SM) and above, header left and right padding is 16px.

## After

From 768px (SM) and above, header left and right padding is 24px.

## How to test

https://fix-header-padding-components-pkg.branch.autoscout24.dev/?path=/docs/patterns-navigation-header--docs
