### PR TITLE
fix: remove prop to avoid centering link

### DIFF
--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -45,9 +45,7 @@ const Alert: FC<AlertProps> = ({
         <AlertDescription>{description}</AlertDescription>
         {link ? (
           link.as === 'button' ? (
-            <Link as="button" onClick={() => link.onClick?.()}>
-              {link.text}
-            </Link>
+            <Link onClick={() => link.onClick?.()}>{link.text}</Link>
           ) : (
             <Link href={link.url} isExternal={link.isExternal}>
               {link.text}


### PR DESCRIPTION
References [Previous PR](https://github.com/smg-automotive/components-pkg/pull/1008), [IN-1856](https://smg-au.atlassian.net/browse/IN-1856)

## Motivation and context

Link inside information box is centered on small screens so we want to change that and to keep previous behaviour with new functionality.

## Before

![Screenshot 2024-04-23 at 11 25 09](https://github.com/smg-automotive/components-pkg/assets/155623609/d0f7cea9-9789-4efe-9373-b12814b120db)

## After

![image](https://github.com/smg-automotive/components-pkg/assets/155623609/e20733ec-97f7-4acc-ac9c-70fd71d72253)

## How to test

[Test branch](https://in-1820-ivi-information-alert-seller-web.branch.autoscout24.dev/de/insertion/identify?versionIdentificationMethod=certification-number)
