### PR TITLE
feat: add tracking to main header items

### DIFF
--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -143,7 +143,7 @@ describe('Header', () => {
       environment: 'preprod',
       useAbsoluteUrls: false,
       config: {
-        headerItems: headerLinks,
+        headerItems: headerLinks({ trackEvent: jest.fn() }),
         drawerItems: drawerNodeItems({ onLogout: jest.fn() }),
       },
       user: {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1374,7 +1374,6 @@ export const drawerNodeItems = ({
             trackEvent?.({
               eventCategory: navigationEventCategory,
               eventAction: 'sell',
-              eventLabel: 'private',
             }),
         },
         {
@@ -1400,7 +1399,6 @@ export const drawerNodeItems = ({
             trackEvent?.({
               eventCategory: navigationEventCategory,
               eventAction: 'sell',
-              eventLabel: 'professional',
             }),
         },
         {
@@ -1426,7 +1424,6 @@ export const drawerNodeItems = ({
             trackEvent?.({
               eventCategory: navigationEventCategory,
               eventAction: 'sell',
-              eventLabel: 'private',
             }),
         },
         {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -64,10 +64,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.advancedSearch',
           link: {
-            de: '/de/auto/suche',
-            en: '/de/auto/suche',
-            fr: '/fr/voiture/recherche',
-            it: '/it/automobile/ricerca',
+            de: '/de/s/advanced',
+            en: '/de/s/advanced',
+            fr: '/fr/s/advanced',
+            it: '/it/s/advanced',
           },
           visibilitySettings: {
             userType: {
@@ -76,25 +76,6 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
-              motoscout24: false,
-            },
-          },
-        },
-        {
-          translationKey: 'header.searchMenu.advancedSearch',
-          link: {
-            de: '/de/motorrad/suche',
-            en: '/de/motorrad/suche',
-            fr: '/fr/moto/recherche',
-            it: '/it/moto/ricerca',
-          },
-          visibilitySettings: {
-            userType: {
-              private: true,
-              professional: true,
-            },
-            brand: {
-              autoscout24: false,
               motoscout24: true,
             },
           },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1391,7 +1391,7 @@ export const drawerNodeItems = ({
               professional: true,
             },
             brand: {
-              autoscout24: false,
+              autoscout24: true,
               motoscout24: true,
             },
           },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { CustomEvent, navigationEventCategory } from 'src/types/tracking';
 import { Entitlement } from 'src/types/entitlements';
 
 import { CartIcon } from 'src/components/icons';
@@ -34,8 +35,10 @@ export type DrawerNodeLinks = {
 };
 
 export const drawerNodeItems = ({
+  trackEvent,
   onLogout,
 }: {
+  trackEvent?: (event: CustomEvent) => void;
   onLogout: () => void;
 }): DrawerNodeItemsConfig => ({
   search: [
@@ -1360,13 +1363,19 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: true,
-              professional: true,
+              professional: false,
             },
             brand: {
               autoscout24: true,
               motoscout24: false,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'sell',
+              eventLabel: 'private',
+            }),
         },
         {
           translationKey: 'header.sell',
@@ -1387,6 +1396,12 @@ export const drawerNodeItems = ({
               motoscout24: true,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'sell',
+              eventLabel: 'professional',
+            }),
         },
         {
           translationKey: 'header.sell',
@@ -1407,6 +1422,12 @@ export const drawerNodeItems = ({
               motoscout24: true,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'sell',
+              eventLabel: 'private',
+            }),
         },
         {
           translationKey: 'header.estimate',
@@ -1428,6 +1449,11 @@ export const drawerNodeItems = ({
               motoscout24: false,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'estimate',
+            }),
         },
         {
           translationKey: 'header.assure',
@@ -1448,6 +1474,11 @@ export const drawerNodeItems = ({
               motoscout24: false,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'insurance',
+            }),
         },
         {
           translationKey: 'header.assure',
@@ -1468,6 +1499,11 @@ export const drawerNodeItems = ({
               motoscout24: true,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'insurance',
+            }),
         },
         {
           translationKey: 'header.magazine',
@@ -1488,6 +1524,11 @@ export const drawerNodeItems = ({
               motoscout24: false,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'magazine',
+            }),
         },
         {
           translationKey: 'header.magazine',
@@ -1508,6 +1549,11 @@ export const drawerNodeItems = ({
               motoscout24: true,
             },
           },
+          onClick: () =>
+            trackEvent?.({
+              eventCategory: navigationEventCategory,
+              eventAction: 'magazine',
+            }),
         },
       ],
     },

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -57,7 +57,7 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'sell',
-        eventLabel: 'carPrivate',
+        eventLabel: 'private',
       }),
   },
   {
@@ -83,7 +83,7 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'sell',
-        eventLabel: 'motorcyclePrivate',
+        eventLabel: 'private',
       }),
   },
   {
@@ -161,7 +161,6 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'insurance',
-        eventLabel: 'car',
       }),
   },
   {
@@ -187,7 +186,6 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'insurance',
-        eventLabel: 'motorcycle',
       }),
   },
   {
@@ -213,7 +211,6 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'magazine',
-        eventLabel: 'autoscout',
       }),
   },
   {
@@ -239,7 +236,6 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'magazine',
-        eventLabel: 'motoscout',
       }),
   },
 ];

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -57,7 +57,6 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'sell',
-        eventLabel: 'private',
       }),
   },
   {
@@ -83,7 +82,6 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'sell',
-        eventLabel: 'private',
       }),
   },
   {
@@ -110,7 +108,6 @@ export const headerLinks = ({
       trackEvent?.({
         eventCategory: navigationEventCategory,
         eventAction: 'sell',
-        eventLabel: 'professional',
       }),
   },
   {

--- a/src/components/navigation/header/config/headerLinks.ts
+++ b/src/components/navigation/header/config/headerLinks.ts
@@ -1,3 +1,4 @@
+import { CustomEvent, navigationEventCategory } from 'src/types/tracking';
 import { BreakpointName } from 'src/themes/shared/breakpoints';
 
 import { EntitlementConfig } from 'src/components/navigation/link';
@@ -25,9 +26,14 @@ export type NavigationLinkConfigProps = Omit<
   forceMotoscoutLink?: boolean;
   forceAutoscoutLink?: boolean;
   entitlementConfig?: EntitlementConfig;
+  tracking?: CustomEvent;
 };
 
-export const headerLinks: NavigationLinkConfigProps[] = [
+export const headerLinks = ({
+  trackEvent,
+}: {
+  trackEvent?: (event: CustomEvent) => void;
+}): NavigationLinkConfigProps[] => [
   {
     translationKey: 'header.sell',
     link: {
@@ -47,6 +53,12 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: false,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'sell',
+        eventLabel: 'carPrivate',
+      }),
   },
   {
     translationKey: 'header.sell',
@@ -67,6 +79,12 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: true,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'sell',
+        eventLabel: 'motorcyclePrivate',
+      }),
   },
   {
     translationKey: 'header.sell',
@@ -88,6 +106,12 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: true,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'sell',
+        eventLabel: 'professional',
+      }),
   },
   {
     translationKey: 'header.estimate',
@@ -108,6 +132,11 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: false,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'estimate',
+      }),
   },
   {
     translationKey: 'header.assure',
@@ -128,6 +157,12 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: false,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'insurance',
+        eventLabel: 'car',
+      }),
   },
   {
     translationKey: 'header.assure',
@@ -148,6 +183,12 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: true,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'insurance',
+        eventLabel: 'motorcycle',
+      }),
   },
   {
     translationKey: 'header.magazine',
@@ -168,6 +209,12 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: false,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'magazine',
+        eventLabel: 'autoscout',
+      }),
   },
   {
     translationKey: 'header.magazine',
@@ -188,5 +235,11 @@ export const headerLinks: NavigationLinkConfigProps[] = [
         motoscout24: true,
       },
     },
+    onClick: () =>
+      trackEvent?.({
+        eventCategory: navigationEventCategory,
+        eventAction: 'magazine',
+        eventLabel: 'motoscout',
+      }),
   },
 ];

--- a/src/components/navigation/header/index.stories.tsx
+++ b/src/components/navigation/header/index.stories.tsx
@@ -7,6 +7,7 @@ import { Brand } from 'src/types/brand';
 import Box from 'src/components/box';
 
 import Navigation from './index';
+import { action } from '@storybook/addon-actions';
 
 /**
  * Header dropdown navigation uses drawers to display the content.
@@ -34,6 +35,7 @@ const meta: Meta<typeof Navigation> = {
     environment: 'preprod',
     useAbsoluteUrls: false,
     entitlements: [],
+    trackEvent: action('track navigation item click'),
   },
 
   argTypes: {

--- a/src/components/navigation/header/index.stories.tsx
+++ b/src/components/navigation/header/index.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 
+import { action } from '@storybook/addon-actions';
 import { MappedUserType } from '@smg-automotive/auth';
 
 import { Brand } from 'src/types/brand';
 import Box from 'src/components/box';
 
 import Navigation from './index';
-import { action } from '@storybook/addon-actions';
 
 /**
  * Header dropdown navigation uses drawers to display the content.

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -56,7 +56,7 @@ const Navigation: FC<NavigationProps> = ({
       useAbsoluteUrls,
       config: {
         headerItems: headerLinks({ trackEvent }),
-        drawerItems: drawerNodeItems({ onLogout }),
+        drawerItems: drawerNodeItems({ trackEvent, onLogout }),
       },
       user,
       urlPathParams,

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -4,6 +4,7 @@ import { Language } from '@smg-automotive/i18n-pkg';
 
 import { MergedUser } from '@smg-automotive/auth';
 
+import { CustomEvent } from 'src/types/tracking';
 import { Environment } from 'src/types/environment';
 import { Brand } from 'src/types/brand';
 
@@ -30,6 +31,7 @@ interface NavigationProps {
   entitlements?: string[];
   onLogin: () => void;
   onLogout: () => void;
+  trackEvent?: (event: CustomEvent) => void;
 }
 
 const Navigation: FC<NavigationProps> = ({
@@ -42,6 +44,7 @@ const Navigation: FC<NavigationProps> = ({
   entitlements = [],
   onLogin,
   onLogout,
+  trackEvent,
 }) => {
   const config = useMemo(() => {
     const urlPathParams = user?.sellerId
@@ -52,7 +55,7 @@ const Navigation: FC<NavigationProps> = ({
       environment,
       useAbsoluteUrls,
       config: {
-        headerItems: headerLinks,
+        headerItems: headerLinks({ trackEvent }),
         drawerItems: drawerNodeItems({ onLogout }),
       },
       user,

--- a/src/types/tracking.ts
+++ b/src/types/tracking.ts
@@ -1,0 +1,7 @@
+export type CustomEvent = {
+  eventAction: string;
+  eventCategory: string;
+  eventLabel?: string | null;
+};
+
+export const navigationEventCategory = 'www_Interaction_PI-Navigation';


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3049

## Motivation and context

To measure the performance of the new EV hub, we add tracking to the main navigation items in the header to have a baseline.

FYI: as per Raluca, at the moment we only track the main items. The ones collapsed in drawers not.

## Before

No tracking

## After

Tracking

