### PR TITLE
fix: histogram colors for better contrast

### DIFF
--- a/src/components/rangeSlider/Chart.tsx
+++ b/src/components/rangeSlider/Chart.tsx
@@ -26,7 +26,7 @@ const Chart: React.FC<Props> = ({ facets, range }) => {
           flexGrow={1}
           key={from}
           bg={
-            index < range[0] || index > range[1] - 1 ? 'gray.300' : 'gray.900'
+            index < range[0] || index > range[1] - 1 ? 'gray.200' : 'gray.400'
           }
           transition="transform 1s"
           transformOrigin="bottom"


### PR DESCRIPTION
[TICKET](https://smg-au.atlassian.net/browse/DM-2836)

## Motivation and context
Designers wanted to reduce visual weight for histograms on advanced search page by lowering the contrast of it.

## Before
<img width="456" alt="image" src="https://github.com/smg-automotive/components-pkg/assets/28811793/410da6f9-7e4b-443f-9b31-43db1001d0fc">


## After
<img width="464" alt="image" src="https://github.com/smg-automotive/components-pkg/assets/28811793/14144fd7-c095-4744-9c84-cd14c469006d">


