### PR TITLE
fix: changed font size

### DIFF
--- a/src/themes/components/button.ts
+++ b/src/themes/components/button.ts
@@ -9,7 +9,7 @@ const baseStyle: SystemStyleObject = {
 const buttonSizes = {
   md: {
     height: 'md',
-    textStyle: 'button-sm',
+    textStyle: 'button',
   },
   lg: {
     height: 'lg',

--- a/src/themes/components/input.ts
+++ b/src/themes/components/input.ts
@@ -34,7 +34,7 @@ const size = {
     [$height.variable]: 'sizes.lg',
   }),
   md: defineStyle({
-    textStyle: 'body-small',
+    textStyle: 'body',
     [$paddingX.variable]: 'space.md',
     [$paddingY.variable]: 'space.xs',
     [$height.variable]: 'sizes.md',

--- a/src/themes/shared/typography.ts
+++ b/src/themes/shared/typography.ts
@@ -94,12 +94,6 @@ export const textStyles = {
     lineHeight: lineHeights.sm,
     fontSize: fontSizes.base,
   },
-  'button-sm': {
-    fontFamily: fonts.makeItSans,
-    fontWeight: fontWeights.bold,
-    lineHeight: lineHeights.sm,
-    fontSize: fontSizes.sm,
-  },
   label: {
     fontFamily: fonts.makeItSans,
     fontWeight: fontWeights.bold,


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/FE-266

## Motivation and context

Input fields need to have at least a font-size of 16px Otherwise, browsers automatically zoom in when the input is focussed.

## Take into consideration

* I will address the radio and checkbox points separately becaussseeee they will cause breakingChanges in listings an seller projects.
* I checked with the UX-Designers  and we won't need the button-small token for future designs. 

## How to test

Please check the fontSize is now 16px instead 14px in all the sizes on: inputs, select and button components

## Thank you 🧝🏽‍♀️ 🩵 🐈 
