### PR TITLE
BREAKING CHANGE: removed small variation - radiobutton/checkbox

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -10,7 +10,6 @@ export interface CheckboxProps {
   label?: ReactNode | string;
   isInvalid?: boolean;
   isIndeterminate?: boolean;
-  size?: 'sm' | 'lg';
   fontWeight?: 'regular' | 'bold';
   variant?: 'alignCenter' | 'alignTop' | 'alignTopForSmallSize';
   readOnly?: boolean;
@@ -28,7 +27,6 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       label,
       isInvalid,
       isIndeterminate = false,
-      size = 'lg',
       fontWeight = 'regular',
       variant = 'alignCenter',
       readOnly = false,
@@ -47,7 +45,6 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       onChange={onChange}
       isInvalid={isInvalid}
       isIndeterminate={isIndeterminate}
-      size={size}
       fontWeight={fontWeight}
       variant={variant}
       readOnly={readOnly}

--- a/src/components/checkboxGroup/index.stories.tsx
+++ b/src/components/checkboxGroup/index.stories.tsx
@@ -76,7 +76,6 @@ const meta: Meta<typeof CheckboxGroup> = {
     isInvalid: false,
     label: 'Parent item',
     addDividerAfterIndex: [2],
-    size: 'lg',
     checkboxes: [
       {
         label: 'First child',

--- a/src/components/checkboxGroup/index.tsx
+++ b/src/components/checkboxGroup/index.tsx
@@ -12,7 +12,6 @@ export interface CheckboxGroupProps extends CheckboxProps {
    */
   checkboxes?: CheckboxProps[];
   addDividerAfterIndex?: number[];
-  size?: 'sm' | 'lg';
 }
 
 const CheckboxGroup: FC<CheckboxGroupProps> = ({
@@ -23,7 +22,6 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
   isChecked,
   isDisabled,
   isInvalid,
-  size = 'lg',
   isIndeterminate,
   addDividerAfterIndex,
   variant = 'alignCenter',
@@ -40,7 +38,6 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
         isDisabled={isDisabled}
         isInvalid={isInvalid}
         isIndeterminate={isIndeterminate}
-        size={size}
         variant={variant}
         fontWeight="bold"
       />
@@ -54,7 +51,6 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
             value={item.value}
             onChange={item.onChange}
             isChecked={item.isChecked}
-            size={size}
             pl="md"
             variant={variant}
             isDisabled={isDisabled}

--- a/src/components/radio/index.stories.tsx
+++ b/src/components/radio/index.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta<typeof RadioComponent> = {
 
   argTypes: {
     size: {
-      options: ['sm', 'base', 'md'],
+      options: ['base', 'md'],
       control: 'select',
     },
 
@@ -77,23 +77,6 @@ export const SizeMedium: StoryType = {
   args: {
     size: 'md',
     name: 'test-radio-md',
-  },
-
-  argTypes: {
-    size: {
-      table: {
-        disable: true,
-      },
-    },
-  },
-};
-
-export const SizesSmall: StoryType = {
-  name: 'Sizes > Small',
-
-  args: {
-    size: 'sm',
-    name: 'test-radio-sm',
   },
 
   argTypes: {

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -5,7 +5,7 @@ export interface Props {
   name?: string;
   value: string;
   label?: string;
-  size?: 'sm' | 'md' | 'base';
+  size?: 'md' | 'base';
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   isChecked?: boolean;
   isInvalid?: boolean;

--- a/src/themes/components/checkbox.ts
+++ b/src/themes/components/checkbox.ts
@@ -6,15 +6,6 @@ import { fontWeights } from '../shared/fontWeights';
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys);
 
-const sizes = {
-  sm: {
-    label: { fontSize: 'sm' },
-  },
-  lg: {
-    label: { fontSize: 'base' },
-  },
-};
-
 const baseStyleControl = defineStyle({
   width: 'xs',
   height: 'xs',
@@ -120,7 +111,6 @@ const variants = {
 
 export default defineMultiStyleConfig({
   baseStyle,
-  sizes,
   variants,
   defaultProps: {
     variant: 'alignCenter',

--- a/src/themes/components/radio.ts
+++ b/src/themes/components/radio.ts
@@ -8,9 +8,6 @@ const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys);
 
 const sizes = {
-  sm: {
-    label: { fontSize: 'sm' },
-  },
   base: {
     label: { fontSize: 'base' },
   },


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3111

## Motivation and context

After changing the fontSize on the input/select/button keeping only `16px` and removing the `14px` fontSize. We need to unify the sizes and remove the unnecessary ones for the radioButton and checkbox.

## Take into consideration
* I am checking with the UX-Designer why we have the `md` variation which is too huge `24px`. It doesn't have any sense to have it, we ONLY need the `16px`. In case that we don't need the variation `md` and be sure that we won't introduce it again, I will create a new PR for it.
* I check in seller and listings projects and we don't use the small variation for the radio button. Buuuut in any case I will do a breaking change to be sure that I don't break something

## How to test

Please check:
* We only have two variations `base, md` and no more the `sm` on radioButton
* We don't show/pass size variations on checkbox and checkboxGroup

## Thank you 🧝🏽‍♀️ 🩵 🐈
