### PR TITLE
BREAKING CHANGE: removed small variation on checkbox

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -10,7 +10,6 @@ export interface CheckboxProps {
   label?: ReactNode | string;
   isInvalid?: boolean;
   isIndeterminate?: boolean;
-  size?: 'sm' | 'lg';
   fontWeight?: 'regular' | 'bold';
   variant?: 'alignCenter' | 'alignTop' | 'alignTopForSmallSize';
   readOnly?: boolean;
@@ -28,7 +27,6 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       label,
       isInvalid,
       isIndeterminate = false,
-      size = 'lg',
       fontWeight = 'regular',
       variant = 'alignCenter',
       readOnly = false,
@@ -47,7 +45,6 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       onChange={onChange}
       isInvalid={isInvalid}
       isIndeterminate={isIndeterminate}
-      size={size}
       fontWeight={fontWeight}
       variant={variant}
       readOnly={readOnly}

--- a/src/components/checkboxGroup/index.stories.tsx
+++ b/src/components/checkboxGroup/index.stories.tsx
@@ -76,7 +76,6 @@ const meta: Meta<typeof CheckboxGroup> = {
     isInvalid: false,
     label: 'Parent item',
     addDividerAfterIndex: [2],
-    size: 'lg',
     checkboxes: [
       {
         label: 'First child',

--- a/src/components/checkboxGroup/index.tsx
+++ b/src/components/checkboxGroup/index.tsx
@@ -12,7 +12,6 @@ export interface CheckboxGroupProps extends CheckboxProps {
    */
   checkboxes?: CheckboxProps[];
   addDividerAfterIndex?: number[];
-  size?: 'sm' | 'lg';
 }
 
 const CheckboxGroup: FC<CheckboxGroupProps> = ({
@@ -23,7 +22,6 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
   isChecked,
   isDisabled,
   isInvalid,
-  size = 'lg',
   isIndeterminate,
   addDividerAfterIndex,
   variant = 'alignCenter',
@@ -40,7 +38,6 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
         isDisabled={isDisabled}
         isInvalid={isInvalid}
         isIndeterminate={isIndeterminate}
-        size={size}
         variant={variant}
         fontWeight="bold"
       />
@@ -54,7 +51,6 @@ const CheckboxGroup: FC<CheckboxGroupProps> = ({
             value={item.value}
             onChange={item.onChange}
             isChecked={item.isChecked}
-            size={size}
             pl="md"
             variant={variant}
             isDisabled={isDisabled}

--- a/src/themes/components/checkbox.ts
+++ b/src/themes/components/checkbox.ts
@@ -6,15 +6,6 @@ import { fontWeights } from '../shared/fontWeights';
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys);
 
-const sizes = {
-  sm: {
-    label: { fontSize: 'sm' },
-  },
-  lg: {
-    label: { fontSize: 'base' },
-  },
-};
-
 const baseStyleControl = defineStyle({
   width: 'xs',
   height: 'xs',
@@ -120,7 +111,6 @@ const variants = {
 
 export default defineMultiStyleConfig({
   baseStyle,
-  sizes,
   variants,
   defaultProps: {
     variant: 'alignCenter',


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3111

## Motivation and context

After changing the fontSize on the input/select/button keeping only `16px` and removing the `14px` fontSize. We need to unify the sizes and remove the unnecessary ones for the checkbox and checkboxGroup.

## How to test

Please check that we don't show/pass size variations on checkbox and checkboxGroup

## Thank you 🧝🏽‍♀️ 🩵 🐈
