### PR TITLE
fix: language in logo click on header

### DIFF
--- a/src/components/navigation/header/NavigationItems.tsx
+++ b/src/components/navigation/header/NavigationItems.tsx
@@ -44,7 +44,7 @@ export const NavigationItems: FC<NavigationItemsProps> = ({
 
   return (
     <Stack direction="row" spacing={{ base: 'lg', sm: '2xl' }} align="center">
-      <Link href={`/${language}`}>
+      <Link href={`/${language === 'en' ? 'de' : language}`}>
         <Image
           width={{ sm: '124px', base: '101px' }}
           height={{ sm: '30px', base: 'sm' }}

--- a/src/components/navigation/header/NavigationItems.tsx
+++ b/src/components/navigation/header/NavigationItems.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { Language } from '@smg-automotive/i18n-pkg';
 import { Image } from '@chakra-ui/react';
 
 import Stack from 'src/components/stack';
@@ -21,6 +22,7 @@ interface NavigationItemsProps {
   drawer: UseNavigationDrawer;
   isOpen: boolean;
   createDrawerHandler: ({ nodeName }: { nodeName: DrawerNode }) => () => void;
+  language: Language;
 }
 
 export const NavigationItems: FC<NavigationItemsProps> = ({
@@ -29,6 +31,7 @@ export const NavigationItems: FC<NavigationItemsProps> = ({
   drawer,
   isOpen,
   createDrawerHandler,
+  language,
 }) => {
   const logo = platform === 'autoscout24' ? logoAutoScout24 : logoMotoScout24;
 
@@ -41,7 +44,7 @@ export const NavigationItems: FC<NavigationItemsProps> = ({
 
   return (
     <Stack direction="row" spacing={{ base: 'lg', sm: '2xl' }} align="center">
-      <Link href="/">
+      <Link href={`/${language}`}>
         <Image
           width={{ sm: '124px', base: '101px' }}
           height={{ sm: '30px', base: 'sm' }}

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -114,6 +114,7 @@ const Navigation: FC<NavigationProps> = ({
             drawer={drawer}
             isOpen={isOpen}
             createDrawerHandler={createDrawerHandler}
+            language={language}
           />
           <Stack direction="row" spacing="2xl" align="center">
             <NavigationAvatar


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3131

## Before

1. go to SRP
2. change to french [Voitures - acheter un véhicule d'occasion | AutoScout24](https://www.autoscout24.ch/fr/s) 
3. click the logo in the header

→ you land on the german homepage

## After

Test the same on https://talamcol-add-cache-srp-listings-web.branch.autoscout24.dev/fr

