### PR TITLE
fix: link alignment in Alert box

### DIFF
--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -49,8 +49,7 @@ const Alert: FC<AlertProps> = ({
               as="button"
               onClick={() => link.onClick?.()}
               textAlign="left"
-              display="inline-block"
-              width="fit-content"
+              width="max-content"
             >
               {link.text}
             </Link>
@@ -58,8 +57,7 @@ const Alert: FC<AlertProps> = ({
             <Link
               href={link.url}
               isExternal={link.isExternal}
-              display="inline-block"
-              width="fit-content"
+              width="max-content"
             >
               {link.text}
             </Link>

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -45,7 +45,9 @@ const Alert: FC<AlertProps> = ({
         <AlertDescription>{description}</AlertDescription>
         {link ? (
           link.as === 'button' ? (
-            <Link as="button" onClick={() => link.onClick?.()} textAlign='left'>{link.text}</Link>
+            <Link as="button" onClick={() => link.onClick?.()} textAlign="left">
+              {link.text}
+            </Link>
           ) : (
             <Link href={link.url} isExternal={link.isExternal}>
               {link.text}

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -45,11 +45,22 @@ const Alert: FC<AlertProps> = ({
         <AlertDescription>{description}</AlertDescription>
         {link ? (
           link.as === 'button' ? (
-            <Link as="button" onClick={() => link.onClick?.()} textAlign="left">
+            <Link
+              as="button"
+              onClick={() => link.onClick?.()}
+              textAlign="left"
+              display="inline-block"
+              width="fit-content"
+            >
               {link.text}
             </Link>
           ) : (
-            <Link href={link.url} isExternal={link.isExternal}>
+            <Link
+              href={link.url}
+              isExternal={link.isExternal}
+              display="inline-block"
+              width="fit-content"
+            >
               {link.text}
             </Link>
           )

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -45,7 +45,7 @@ const Alert: FC<AlertProps> = ({
         <AlertDescription>{description}</AlertDescription>
         {link ? (
           link.as === 'button' ? (
-            <Link onClick={() => link.onClick?.()}>{link.text}</Link>
+            <Link as="button" onClick={() => link.onClick?.()} textAlign='left'>{link.text}</Link>
           ) : (
             <Link href={link.url} isExternal={link.isExternal}>
               {link.text}


### PR DESCRIPTION
[IN-1884](https://smg-au.atlassian.net/browse/IN-1884?atlOrigin=eyJpIjoiZjhkYjQ5ZGY4MDk4NDA3ZGJiZjdkYWVhZjdjMWM0MzEiLCJwIjoiaiJ9)

## Motivation and context

While working on [this task](https://smg-au.atlassian.net/browse/IN-1820), we removed the `as=button` from the link in the Alert box component to fix a CSS issue, [here](https://github.com/smg-automotive/components-pkg/pull/1012). However, it’s not right for accessibility.

## Before

Link in the alert box is not marked as button

## After

Link in the alert box is marked as button and text remains on the left even on small screens. 

## How to test

The CSS issue was especially visible [in this PR](https://github.com/smg-automotive/seller-web/pull/1773), I extended the branch and opened a test one for you to check: https://in-1884-seller-web.branch.autoscout24.dev/de/insertion/identify?versionIdentificationMethod=certification-number&certificationNumber=IVI

- Write IVI on Certification Number
- The Alert box with the link should appear
- Check on small screens and in german that the text of the link remains on the left
