### PR TITLE
fix: increase indentation for checkbox group

### DIFF
--- a/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
+++ b/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
@@ -74,7 +74,7 @@ function CheckboxGroupCollapsibleWithChildren<
         />
       </Box>
       <Collapse in={isOpen}>
-        <Box id={groupDomId} ml={checkboxes.length > 0 ? 'lg' : '0px'}>
+        <Box id={groupDomId} ml={checkboxes.length > 0 ? '2xl' : '0px'}>
           {checkboxes?.map((checkbox) => (
             <CheckboxWithFacet
               key={checkbox.key}


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3110

The indent of the checkbox should align with the label of the parent

<img width="471" alt="Bildschirmfoto 2024-05-07 um 09 21 31" src="https://github.com/smg-automotive/components-pkg/assets/71456764/4dcd9d49-67e4-4dc8-a16f-208458105733">


https://talamcol-group-indent-components-pkg.branch.autoscout24.dev/?path=/story/components-filter-checkbox--with-grouped-items