### PR TITLE
fix: link in alert component

### DIFF
--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -49,7 +49,8 @@ const Alert: FC<AlertProps> = ({
               as="button"
               onClick={() => link.onClick?.()}
               textAlign="left"
-              width="max-content"
+              display="inline-block"
+              width="fit-content"
             >
               {link.text}
             </Link>
@@ -57,7 +58,8 @@ const Alert: FC<AlertProps> = ({
             <Link
               href={link.url}
               isExternal={link.isExternal}
-              width="max-content"
+              display="inline-block"
+              width="fit-content"
             >
               {link.text}
             </Link>


### PR DESCRIPTION
[Reference](https://github.com/smg-automotive/components-pkg/pull/1030#issuecomment-2107086952)

## Motivation and context

Following [this PR](https://github.com/smg-automotive/components-pkg/pull/1030), Nenad noticed that with `width="max-content"`,  the content of the whole page is zoomed out. 
It's not the case using
`display="inline-block" width="fit-content"`, so I went back to this. 

## Before

https://github.com/smg-automotive/components-pkg/assets/52455155/cc5cd3c8-b59e-4b59-aeb7-16bfbfc09059

## After

https://github.com/smg-automotive/components-pkg/assets/52455155/4ab9d928-e4c0-4cab-98e5-55f0af7e13be

## How to test

The CSS issue is visible in the IVI PR, I extended the branch and opened a test one for you to check: https://test-component-seller-web.branch.autoscout24.dev/de/insertion/identify?versionIdentificationMethod=certification-number&certificationNumber=IVI

- Write IVI on Certification Number
- The Alert box with the link should appear
- Check on small screens and in german that the text of the link remains on the left and that you don't have the zoom out effect

Thank you

