### PR TITLE
feat: allow to have checkbox always expanded

### DIFF
--- a/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
+++ b/src/components/checkboxFilter/CheckboxGroupCollapsibleWithChildren.tsx
@@ -13,17 +13,21 @@ type CheckboxCollapsibleProps<
   FilterName extends string,
 > = {
   item: Item<ItemKey, FilterName>;
-} & Pick<Props<ItemKey, FilterName>, 'onApply' | 'onToggleCheckboxGroup'>;
+} & Pick<
+  Props<ItemKey, FilterName>,
+  'onApply' | 'onToggleCheckboxGroup' | 'alwaysExpanded'
+>;
 
 function CheckboxGroupCollapsibleWithChildren<
   ItemKey extends string,
   FilterName extends string,
 >({
+  alwaysExpanded = false,
   item,
   onApply,
   onToggleCheckboxGroup,
 }: CheckboxCollapsibleProps<ItemKey, FilterName>) {
-  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: false });
+  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: alwaysExpanded });
   const { t } = useI18n();
   const checkboxes = item.childCheckboxes ?? [];
   const numberOfAppliedChildren = checkboxes.filter(
@@ -43,37 +47,39 @@ function CheckboxGroupCollapsibleWithChildren<
             numberOfAppliedChildren < checkboxes.length
           }
           contentRight={
-            <IconButton
-              aria-controls={groupDomId}
-              aria-expanded={isOpen}
-              aria-label={`${item.label}: ${
-                isOpen
-                  ? t('checkboxFilter.expanded')
-                  : t('checkboxFilter.collapsed')
-              }`}
-              onClick={() => {
-                onToggle();
-                onToggleCheckboxGroup?.(item);
-              }}
-              w="full"
-              h="sm"
-              display="flex"
-              justifyContent="flex-end"
-              icon={
-                <ChevronDownLargeIcon
-                  w="xs"
-                  h="xs"
-                  transition="0.2s"
-                  color="gray.500"
-                  transform={isOpen ? 'rotate(180deg)' : 'rotate(0deg)'}
-                  cursor="pointer"
-                />
-              }
-            />
+            alwaysExpanded ? null : (
+              <IconButton
+                aria-controls={groupDomId}
+                aria-expanded={isOpen}
+                aria-label={`${item.label}: ${
+                  isOpen
+                    ? t('checkboxFilter.expanded')
+                    : t('checkboxFilter.collapsed')
+                }`}
+                onClick={() => {
+                  onToggle();
+                  onToggleCheckboxGroup?.(item);
+                }}
+                w="full"
+                h="sm"
+                display="flex"
+                justifyContent="flex-end"
+                icon={
+                  <ChevronDownLargeIcon
+                    w="xs"
+                    h="xs"
+                    transition="0.2s"
+                    color="gray.500"
+                    transform={isOpen ? 'rotate(180deg)' : 'rotate(0deg)'}
+                    cursor="pointer"
+                  />
+                }
+              />
+            )
           }
         />
       </Box>
-      <Collapse in={isOpen}>
+      <Collapse in={alwaysExpanded || isOpen}>
         <Box id={groupDomId} ml={checkboxes.length > 0 ? '2xl' : '0px'}>
           {checkboxes?.map((checkbox) => (
             <CheckboxWithFacet
@@ -85,7 +91,7 @@ function CheckboxGroupCollapsibleWithChildren<
               }}
               onApply={onApply}
               isIndeterminate={false}
-              indentFacet={true}
+              indentFacet={!alwaysExpanded}
             />
           ))}
         </Box>

--- a/src/components/checkboxFilter/index.stories.tsx
+++ b/src/components/checkboxFilter/index.stories.tsx
@@ -332,6 +332,7 @@ export const WithMultipleColumns: StoryType = {
 
 export const WithGroupedItems: StoryType = {
   args: {
+    alwaysExpanded: false,
     numberOfColumnsOnDesktop: 2,
     items: [
       {

--- a/src/components/checkboxFilter/index.tsx
+++ b/src/components/checkboxFilter/index.tsx
@@ -26,6 +26,7 @@ const groupItems = <ItemKey extends string, FilterName extends string>(
 };
 
 function CheckboxFilter<ItemKey extends string, FilterName extends string>({
+  alwaysExpanded = false,
   items,
   onApply,
   numberOfColumnsOnDesktop = 1,
@@ -62,6 +63,7 @@ function CheckboxFilter<ItemKey extends string, FilterName extends string>({
               <Fragment key={item.key}>
                 {item.childCheckboxes && item.childCheckboxes.length > 0 ? (
                   <CheckboxGroupCollapsibleWithChildren
+                    alwaysExpanded={alwaysExpanded}
                     item={item}
                     onApply={onApply}
                     onToggleCheckboxGroup={onToggleCheckboxGroup}
@@ -70,7 +72,7 @@ function CheckboxFilter<ItemKey extends string, FilterName extends string>({
                   <CheckboxWithFacet
                     item={item}
                     onApply={onApply}
-                    indentFacet={hasGroups}
+                    indentFacet={hasGroups && !alwaysExpanded}
                   />
                 )}
               </Fragment>

--- a/src/components/checkboxFilter/type.ts
+++ b/src/components/checkboxFilter/type.ts
@@ -13,6 +13,7 @@ export type Item<ItemKey, FilterName> = {
 };
 
 export type Props<ItemKey extends string, FilterName extends string> = {
+  alwaysExpanded?: boolean;
   /**
    * @template ItemKey
    * @template FilterName


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3109

## Motivation and context

Since we have a search field on equipment and we need more horizontal space, it does not make sense to collapse the checkboxes in that case (for fuel type and others it still makes a lot of sense)
Therefore we add the possibility to have the checkboxes always expanded

## How to test

https://talamcol-always-expand-equipment-listings-web.branch.autoscout24.dev/de/s/advanced