### PR TITLE
fix: remove sm size from radio

### DIFF
--- a/src/components/radio/index.stories.tsx
+++ b/src/components/radio/index.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta<typeof RadioComponent> = {
 
   argTypes: {
     size: {
-      options: ['base', 'md', 'sm'],
+      options: ['base', 'md'],
       control: 'select',
     },
 

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -5,7 +5,7 @@ export interface Props {
   name?: string;
   value: string;
   label?: string;
-  size?: 'sm' | 'md' | 'base';
+  size?: 'md' | 'base';
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   isChecked?: boolean;
   isInvalid?: boolean;

--- a/src/themes/components/radio.ts
+++ b/src/themes/components/radio.ts
@@ -14,9 +14,6 @@ const sizes = {
   md: {
     label: { fontSize: 'md' },
   },
-  sm: {
-    label: { fontSize: 'sm' },
-  },
 };
 
 const baseStyleControl = defineStyle({


### PR DESCRIPTION
## Motivation and context

Based on design system we use `md` and `base` sizes for radio buttons.
