### PR TITLE
feat: add checkmark circle icon

### DIFF
--- a/src/components/icons/CheckmarkCircleIcon.tsx
+++ b/src/components/icons/CheckmarkCircleIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const CheckmarkCircleIcon: ComponentWithAs<'svg', IconProps> =
+  createIcon({
+    displayName: 'CheckmarkCircle',
+    viewBox: '0 0 24 24',
+    path: (
+      <>
+        <title>Checkmark circle icon</title>
+        <path
+          d="M6.444 20.315a10 10 0 1 0 11.112-16.63 10 10 0 0 0-11.112 16.63zM7.555 5.348a8 8 0 1 1 8.89 13.304 8 8 0 0 1-8.89-13.304zM7.01 12.42 11 16.41l7-6.99L16.58 8 11 13.59l-2.58-2.58-1.41 1.41z"
+          fill="currentColor"
+        />
+      </>
+    ),
+    defaultProps: {
+      boxSize: 'sm',
+    },
+  });

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -18,6 +18,7 @@ export { CarIcon } from './CarIcon';
 export { CopyIcon } from './CopyIcon';
 export { ChartIcon } from './ChartIcon';
 export { CheckmarkIcon } from './CheckmarkIcon';
+export { CheckmarkCircleIcon } from './CheckmarkCircleIcon';
 export { CheckShieldIcon } from './CheckShieldIcon';
 export { ChevronDownLargeIcon } from './ChevronDownLargeIcon';
 export { ChevronDownSmallIcon } from './ChevronDownSmallIcon';


### PR DESCRIPTION
References [VSST-2415](https://smg-au.atlassian.net/browse/VSST-2415)

## Motivation and context

The new icon is present in the private seller insertion flow success page.

<img width="1141" alt="Screenshot 2024-06-18 at 11 26 32" src="https://github.com/smg-automotive/components-pkg/assets/141041162/19d3892e-14fa-408c-938c-a835c41674e7">

The svg has been optimized via https://svgoptimizer.com/

## Before

No checkmark circle icon.

## After

<img width="171" alt="Screenshot 2024-06-18 at 11 27 08" src="https://github.com/smg-automotive/components-pkg/assets/141041162/1ad07810-7b70-437b-8844-aaf11ec70930">

## How to test

[Add a deep link and instructions how to verify the new behavior]
