### PR TITLE
feat: adding enclosed tab variant

### DIFF
--- a/src/components/tab/index.stories.tsx
+++ b/src/components/tab/index.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof TabsComponent> = {
   title: 'Components/Navigation/Tabs',
   component: TabsComponent,
 
-  render: ({ children, ...args }) => {
+  render: (args) => {
     return (
       <Tabs
         {...args}

--- a/src/components/tab/index.stories.tsx
+++ b/src/components/tab/index.stories.tsx
@@ -8,37 +8,50 @@ import TabPanel from './TabPanel';
 import TabList from './TabList';
 import Tab from './Tab';
 
+import Tabs from './index';
+
 import TabsComponent from './index';
 
 const meta: Meta<typeof TabsComponent> = {
   title: 'Components/Navigation/Tabs',
   component: TabsComponent,
 
+  render: ({ children, ...args }) => {
+    return (
+      <Tabs
+        {...args}
+        {...(args.variant === ('default' as unknown as undefined) && {
+          variant: undefined,
+        })}
+      >
+        <TabList key="tab-list">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Tab key={`tab-${index}`}>Tab: {index}</Tab>
+          ))}
+        </TabList>
+        <TabPanels key="tab-panels">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <TabPanel key={`tab-panel-${index}`}>
+              <Box backgroundColor="gray.50" w="full" h="300px">
+                <p>Tab panel: {index}</p>
+              </Box>
+            </TabPanel>
+          ))}
+        </TabPanels>
+      </Tabs>
+    );
+  },
+
   args: {
     defaultIndex: 2,
-    children: [
-      <TabList width="max-content" key="tab-list">
-        {Array.from({ length: 3 }).map((_, index) => (
-          <Tab key={`tab-${index}`}>Tab: {index}</Tab>
-        ))}
-      </TabList>,
-      <TabPanels key="tab-panels">
-        {Array.from({ length: 3 }).map((_, index) => (
-          <TabPanel key={`tab-panel-${index}`}>
-            <Box backgroundColor="gray.50" w="full" h="300px">
-              <p>Tab panel: {index}</p>
-            </Box>
-          </TabPanel>
-        ))}
-      </TabPanels>,
-    ],
     onChange: action('onChange'),
     isLazy: true,
+    variant: 'default' as unknown as undefined,
   },
 
   argTypes: {
     variant: {
-      options: ['spaceBetween', 'spaceAround'],
+      options: ['spaceBetween', 'spaceAround', 'enclosed', 'default'],
       control: 'select',
     },
     children: {

--- a/src/components/tab/index.stories.tsx
+++ b/src/components/tab/index.stories.tsx
@@ -14,16 +14,10 @@ import TabsComponent from './index';
 
 const meta: Meta<typeof TabsComponent> = {
   title: 'Components/Navigation/Tabs',
-  component: TabsComponent,
 
   render: (args) => {
     return (
-      <Tabs
-        {...args}
-        {...(args.variant === ('default' as unknown as undefined) && {
-          variant: undefined,
-        })}
-      >
+      <Tabs {...args}>
         <TabList key="tab-list">
           {Array.from({ length: 3 }).map((_, index) => (
             <Tab key={`tab-${index}`}>Tab: {index}</Tab>

--- a/src/components/tab/index.tsx
+++ b/src/components/tab/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, PropsWithChildren } from 'react';
 import { Tabs as ChakraTabs, TabsProps } from '@chakra-ui/react';
 
 export type Props = {
-  variant?: 'spaceBetween' | 'spaceAround';
+  variant?: 'spaceBetween' | 'spaceAround' | 'enclosed';
 } & Pick<TabsProps, 'defaultIndex' | 'isLazy' | 'onChange' | 'index'>;
 
 const Tabs: FC<PropsWithChildren<Props>> = (props) => {

--- a/src/themes/components/tabs.ts
+++ b/src/themes/components/tabs.ts
@@ -57,7 +57,6 @@ const variants = {
   enclosed: {
     tablist: {
       borderBottom: 'none',
-      justifyContent: 'space-around',
     },
     tab: {
       flexBasis: '100%',

--- a/src/themes/components/tabs.ts
+++ b/src/themes/components/tabs.ts
@@ -54,6 +54,24 @@ const variants = {
     tab: baseStyleTab,
     tabpanel: baseStyleTabpanel,
   },
+  enclosed: {
+    tablist: {
+      borderBottom: 'none',
+      justifyContent: 'space-around',
+    },
+    tab: {
+      flexBasis: '100%',
+      borderBottom: '1px',
+      border: '1px solid',
+      borderColor: 'blue.200',
+      backgroundColor: 'blue.50',
+      _selected: {
+        backgroundColor: 'transparent',
+        borderBottom: 'none',
+      },
+    },
+    tabpanel: baseStyleTabpanel,
+  },
 };
 
 export default {


### PR DESCRIPTION
References  https://smg-au.atlassian.net/browse/ST-170 / parent https://smg-au.atlassian.net/browse/ST-67

## Motivation and context

We want to introduce new tab variation for cockpit page in order to display KPI performance.

![image](https://github.com/smg-automotive/components-pkg/assets/12614035/674b1edf-6f91-4163-a847-a8cb0d71149e)

## Before

n/a

## After

![Screenshot 2024-06-26 at 09 45 29](https://github.com/smg-automotive/components-pkg/assets/12614035/a7ba5e4d-cf98-4247-914d-b5a12a45f3a8)

## How to test

https://fitted-tab-variant-components-pkg.branch.autoscout24.dev/?path=/docs/components-navigation-tabs--documentation
