### PR TITLE
feat: input left addon

### DIFF
--- a/src/components/input/index.stories.tsx
+++ b/src/components/input/index.stories.tsx
@@ -214,3 +214,35 @@ export const WithRightAddonElementSelect: StoryType = {
     ),
   },
 };
+
+export const WithLeftAddonElementButton: StoryType = {
+  args: {
+    ...WithIcon.args,
+    leftAddonElement: (
+      <Button
+        borderColor="gray.400"
+        borderRightRadius="0"
+        onClick={() => {}}
+        variant="secondary"
+      >
+        Test
+      </Button>
+    ),
+  },
+};
+
+export const WithLeftAddonElementSelect: StoryType = {
+  args: {
+    type: 'number',
+    placeholder: 'i.e. 791234567',
+    leftAddonElement: (
+      <Box width={96}>
+        <Select
+          name="Test select"
+          options={[{ label: '+41', value: 'CH' }]}
+          borderRightRadius="0"
+        />
+      </Box>
+    ),
+  },
+};

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -13,6 +13,7 @@ import React, {
 } from 'react';
 import {
   Input as ChakraInput,
+  InputLeftAddon,
   InputLeftElement,
   InputRightAddon,
   InputRightElement,
@@ -34,6 +35,7 @@ type SharedProps = {
   icon?: ComponentType;
   isClearable?: boolean;
   rightAddonElement?: ReactElement;
+  leftAddonElement?: ReactElement;
 };
 
 type ControlledInputProps = {
@@ -79,6 +81,9 @@ const renderClearButton = ({
     </InputRightElement>
   ) : null;
 
+const renderLeftAddonElement = (LeftAddonElement?: ReactElement) =>
+  LeftAddonElement ? <InputLeftAddon>{LeftAddonElement}</InputLeftAddon> : null;
+
 const renderRightAddonElement = (RightAddonElement?: ReactElement) =>
   RightAddonElement ? (
     <InputRightAddon>{RightAddonElement}</InputRightAddon>
@@ -112,6 +117,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
       icon: Icon,
       isClearable = false,
       rightAddonElement: RightAddonElement,
+      leftAddonElement: LeftAddonElement,
       ...props
     },
     ref,
@@ -153,7 +159,11 @@ const Input = forwardRef<HTMLInputElement, Props>(
       : defaultOnChangeHandler;
 
     return (
-      <InputWrapper size={props.size} shouldWrap={!!RightAddonElement}>
+      <InputWrapper
+        size={props.size}
+        shouldWrap={Boolean(LeftAddonElement || RightAddonElement)}
+      >
+        {renderLeftAddonElement(LeftAddonElement)}
         <InputWrapper size={props.size} shouldWrap={!!Icon || isClearable}>
           {renderIcon(Icon)}
           <ChakraInput
@@ -166,6 +176,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
               localRef: inputRef,
             })}
             borderRightRadius={RightAddonElement ? '0' : 'sm'}
+            borderLeftRadius={LeftAddonElement ? '0' : 'sm'}
           />
           {renderClearButton({
             isClearable: isClearable && !!internalUIValue,

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -26,6 +26,7 @@ export type Props = Pick<
   | 'onChange'
   | 'autoFocus'
   | 'borderLeftRadius'
+  | 'borderRightRadius'
 > & {
   size?: 'md' | 'lg';
   name: string;


### PR DESCRIPTION
References [VSST-2481](https://smg-au.atlassian.net/browse/VSST-2481)

## Motivation and context

Added input field left addon prop.

This is required for profile page phone number input:
<img width="479" alt="Screenshot 2024-07-01 at 14 24 39" src="https://github.com/smg-automotive/components-pkg/assets/141041162/c924c8d6-05cc-4cf5-9e91-f1c49cae5fc1">

## Before

Left addon cannot be added to input field.

## After

Left addon can be added to input field.

## How to test

- https://input-left-addon-components-pkg.branch.autoscout24.dev/?path=/story/components-forms-input--with-left-addon-element-select
