### PR TITLE
fix: tab enclosed variant border & font color

### DIFF
--- a/src/components/tab/index.stories.tsx
+++ b/src/components/tab/index.stories.tsx
@@ -60,6 +60,30 @@ export default meta;
 type StoryType = StoryObj<typeof TabsComponent>;
 export const Overview: StoryType = {};
 
+export const VariantSpaceBetween: StoryType = {
+  name: 'Variant > Space Between',
+
+  args: {
+    variant: 'spaceBetween',
+  },
+};
+
+export const VariantSpaceAround: StoryType = {
+  name: 'Variant > Space Around',
+
+  args: {
+    variant: 'spaceAround',
+  },
+};
+
+export const VariantEnclosed: StoryType = {
+  name: 'Variant > Enclosed',
+
+  args: {
+    variant: 'enclosed',
+  },
+};
+
 export const WithSecondTabSelected: StoryType = {
   name: 'With second tab selected',
 

--- a/src/themes/components/tabs.ts
+++ b/src/themes/components/tabs.ts
@@ -59,14 +59,21 @@ const variants = {
       borderBottom: 'none',
     },
     tab: {
+      color: 'gray.700',
+      fontWeight: 'bold',
       flexBasis: '100%',
       borderBottom: '1px',
       border: '1px solid',
       borderColor: 'blue.200',
       backgroundColor: 'blue.50',
+      borderRight: 'none',
       _selected: {
         backgroundColor: 'transparent',
         borderBottom: 'none',
+      },
+      _last: {
+        border: '1px solid',
+        borderColor: 'blue.200',
       },
     },
     tabpanel: baseStyleTabpanel,

--- a/src/themes/components/tabs.ts
+++ b/src/themes/components/tabs.ts
@@ -72,7 +72,7 @@ const variants = {
         borderBottom: 'none',
       },
       _last: {
-        border: '1px solid',
+        borderRight: '1px solid',
         borderColor: 'blue.200',
       },
     },


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/ST-197

## Motivation and context

Removing double border & changing font color in order to improve contrast.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

![Screenshot 2024-06-27 at 15 33 20](https://github.com/smg-automotive/components-pkg/assets/12614035/4a029aa8-3c9b-4ea4-981f-0ff5807f7bd5)

![Screenshot 2024-06-27 at 15 35 06](https://github.com/smg-automotive/components-pkg/assets/12614035/791db8bc-fe0c-4676-9480-293daf194f40)




## How to test

https://fix-enclosed-tab-variant-components-pkg.branch.autoscout24.dev/?path=/docs/components-navigation-tabs--documentation
