### PR TITLE
fix: allow to set fill state on comparison icon

### DIFF
--- a/src/components/icons/CompareIcon.tsx
+++ b/src/components/icons/CompareIcon.tsx
@@ -16,7 +16,7 @@ export const CompareIcon: ComponentWithAs<'svg', IconProps> = createIcon({
   ),
   defaultProps: {
     boxSize: 'sm',
-    fill: 'currentcolor',
+    fill: 'currentColor',
     fillRule: 'evenodd',
     clipRule: 'evenodd',
   },

--- a/src/components/icons/CompareIcon.tsx
+++ b/src/components/icons/CompareIcon.tsx
@@ -8,23 +8,16 @@ export const CompareIcon: ComponentWithAs<'svg', IconProps> = createIcon({
   path: (
     <>
       <title>Compare icon</title>
-      <path
-        fill="currentColor"
-        fillRule="evenodd"
-        d="M2 4h9v8H2zm2 2h5v4H4z"
-        clipRule="evenodd"
-      />
-      <path fill="currentColor" d="M11 14H2v2h9zM2 18h9v2H2z" />
-      <path
-        fill="currentColor"
-        fillRule="evenodd"
-        d="M13 4h9v8h-9zm2 2h5v4h-5z"
-        clipRule="evenodd"
-      />
-      <path fill="currentColor" d="M13 14h9v2h-9zM22 18h-9v2h9z" />
+      <path d="M2 4h9v8H2zm2 2h5v4H4z" />
+      <path d="M11 14H2v2h9zM2 18h9v2H2z" />
+      <path d="M13 4h9v8h-9zm2 2h5v4h-5z" />
+      <path d="M13 14h9v2h-9zM22 18h-9v2h9z" />
     </>
   ),
   defaultProps: {
     boxSize: 'sm',
+    fill: 'currentcolor',
+    fillRule: 'evenodd',
+    clipRule: 'evenodd',
   },
 });


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Allows me to overwrite the filled state with an animation 

https://talamcol-feat-add-comparison-tiem-listings-web.branch.autoscout24.dev/de/s