### PR TITLE
feat: extend popover component to fit the cockpit needs

### DIFF
--- a/src/components/popover/index.stories.tsx
+++ b/src/components/popover/index.stories.tsx
@@ -41,12 +41,6 @@ const meta: Meta<typeof PopoverComponent> = {
       control: 'select',
       defaultValue: 'hover',
     },
-    contentWidth: {
-      control: 'text',
-    },
-    contentPadding: {
-      control: 'text',
-    },
     closeOnBlur: {
       control: 'boolean',
     },

--- a/src/components/popover/index.stories.tsx
+++ b/src/components/popover/index.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof PopoverComponent> = {
     content: 'I am popover content',
     placement: 'auto',
     children: <TooltipIcon />,
+    size: 'md',
   },
 
   argTypes: {
@@ -30,7 +31,10 @@ const meta: Meta<typeof PopoverComponent> = {
         'bottom-start',
         'bottom-end',
       ],
-
+      control: 'select',
+    },
+    size: {
+      options: ['md', 'xl'],
       control: 'select',
     },
     showArrow: {

--- a/src/components/popover/index.stories.tsx
+++ b/src/components/popover/index.stories.tsx
@@ -34,9 +34,24 @@ const meta: Meta<typeof PopoverComponent> = {
       control: 'select',
     },
     showArrow: {
-      options: [true, false],
+      control: 'boolean',
+    },
+    trigger: {
+      options: ['hover', 'click'],
       control: 'select',
-      defaultValue: true,
+      defaultValue: 'hover',
+    },
+    contentWidth: {
+      control: 'text',
+    },
+    contentPadding: {
+      control: 'text',
+    },
+    closeOnBlur: {
+      control: 'boolean',
+    },
+    gutter: {
+      control: 'number',
     },
   },
 };
@@ -50,5 +65,12 @@ export const NoArrow: StoryType = {
   name: 'No arrow',
   args: {
     showArrow: false,
+  },
+};
+
+export const OpenOnClick: StoryType = {
+  name: 'Open on click',
+  args: {
+    trigger: 'click',
   },
 };

--- a/src/components/popover/index.stories.tsx
+++ b/src/components/popover/index.stories.tsx
@@ -1,19 +1,56 @@
 import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
+import { useDisclosure } from '@chakra-ui/react';
 
 import { TooltipIcon } from '../icons';
 
-import PopoverComponent from './index';
+import PopoverComponent, { PopoverProps } from './index';
 
-const meta: Meta<typeof PopoverComponent> = {
+const Template = ({
+  hasCloseButton,
+  size,
+  showArrow,
+  placement,
+  closeOnBlur,
+  gutter,
+  trigger,
+  content,
+}: PopoverProps & { hasCloseButton: boolean }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  return (
+    <PopoverComponent
+      onClose={onClose}
+      content={
+        hasCloseButton ? (
+          <button onClick={() => onClose()}>Close</button>
+        ) : (
+          content
+        )
+      }
+      size={size}
+      showArrow={showArrow}
+      placement={placement}
+      closeOnBlur={closeOnBlur}
+      gutter={gutter}
+      trigger={trigger}
+      onOpen={onOpen}
+      isOpen={isOpen}
+    >
+      <TooltipIcon />
+    </PopoverComponent>
+  );
+};
+
+const meta: Meta<typeof Template> = {
   title: 'Components/Overlay/Popover',
   component: PopoverComponent,
+  render: Template.bind({}),
 
   args: {
     content: 'I am popover content',
     placement: 'auto',
-    children: <TooltipIcon />,
     size: 'md',
+    hasCloseButton: false,
   },
 
   argTypes: {
@@ -55,7 +92,7 @@ const meta: Meta<typeof PopoverComponent> = {
 };
 
 export default meta;
-type StoryType = StoryObj<typeof PopoverComponent>;
+type StoryType = StoryObj<typeof Template>;
 
 export const Overview: StoryObj<typeof PopoverComponent> = {};
 
@@ -70,5 +107,13 @@ export const OpenOnClick: StoryType = {
   name: 'Open on click',
   args: {
     trigger: 'click',
+  },
+};
+
+export const CloseOnClickOnButton: StoryType = {
+  name: 'Close on click on button',
+  args: {
+    trigger: 'click',
+    hasCloseButton: true,
   },
 };

--- a/src/components/popover/index.stories.tsx
+++ b/src/components/popover/index.stories.tsx
@@ -33,9 +33,22 @@ const meta: Meta<typeof PopoverComponent> = {
 
       control: 'select',
     },
+    showArrow: {
+      options: [true, false],
+      control: 'select',
+      defaultValue: true,
+    },
   },
 };
 
 export default meta;
+type StoryType = StoryObj<typeof PopoverComponent>;
 
 export const Overview: StoryObj<typeof PopoverComponent> = {};
+
+export const NoArrow: StoryType = {
+  name: 'No arrow',
+  args: {
+    showArrow: false,
+  },
+};

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -16,6 +16,7 @@ type PopoverProps = PropsWithChildren<
     trigger?: 'hover' | 'click';
     contentWidth?: string;
     contentPadding?: string;
+    showArrow?: boolean;
   } & Pick<ChakraPopoverProps, 'placement'>
 >;
 
@@ -26,6 +27,7 @@ const Popover: FC<PopoverProps> = ({
   trigger = 'hover',
   contentWidth,
   contentPadding = '2xl',
+  showArrow = true,
 }) => {
   return (
     <ChakraPopover
@@ -48,7 +50,7 @@ const Popover: FC<PopoverProps> = ({
             backgroundColor="white"
             width={contentWidth ? contentWidth : 'auto'}
           >
-            <PopoverArrow backgroundColor="white" />
+            {showArrow ? <PopoverArrow backgroundColor="white" /> : null}
             <PopoverBody>{content}</PopoverBody>
           </PopoverContent>
         </Box>

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -13,15 +13,16 @@ import {
 type PopoverProps = PropsWithChildren<
   {
     content: ReactNode;
+    trigger?: 'hover' | 'click';
   } & Pick<ChakraPopoverProps, 'placement'>
 >;
 
-const Popover: FC<PopoverProps> = ({ content, children, placement }) => {
+const Popover: FC<PopoverProps> = ({ content, children, placement, trigger = 'hover' }) => {
   return (
     <ChakraPopover
       placement={placement}
       closeOnBlur={false}
-      trigger="hover"
+      trigger={trigger}
       arrowSize={12}
       gutter={12}
     >

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -14,12 +14,8 @@ type PopoverProps = PropsWithChildren<
   {
     content: ReactNode;
     trigger?: 'hover' | 'click';
-    contentWidth?: string;
-    contentPadding?: string;
     showArrow?: boolean;
-    closeOnBlur?: boolean;
-    gutter?: number;
-  } & Pick<ChakraPopoverProps, 'placement'>
+  } & Pick<ChakraPopoverProps, 'placement' | 'closeOnBlur' | 'gutter' | 'size'>
 >;
 
 const Popover: FC<PopoverProps> = ({
@@ -27,11 +23,10 @@ const Popover: FC<PopoverProps> = ({
   children,
   placement,
   trigger = 'hover',
-  contentWidth,
-  contentPadding = '2xl',
   showArrow = true,
   closeOnBlur = false,
   gutter = 12,
+  size = 'md',
 }) => {
   return (
     <ChakraPopover
@@ -40,6 +35,7 @@ const Popover: FC<PopoverProps> = ({
       trigger={trigger}
       arrowSize={12}
       gutter={gutter}
+      size={size}
     >
       <PopoverTrigger>{children}</PopoverTrigger>
       <Portal>
@@ -48,11 +44,9 @@ const Popover: FC<PopoverProps> = ({
             borderRadius="sm"
             boxShadow="md"
             maxW="6xl"
-            p={contentPadding}
             // required for arrow to popup above shadow
             zIndex="0"
             backgroundColor="white"
-            width={contentWidth ? contentWidth : 'auto'}
           >
             {showArrow ? <PopoverArrow backgroundColor="white" /> : null}
             <PopoverBody>{content}</PopoverBody>

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -13,9 +13,11 @@ import {
 type PopoverProps = PropsWithChildren<
   {
     content: ReactNode;
-    trigger?: 'hover' | 'click';
     showArrow?: boolean;
-  } & Pick<ChakraPopoverProps, 'placement' | 'closeOnBlur' | 'gutter' | 'size'>
+  } & Pick<
+    ChakraPopoverProps,
+    'placement' | 'closeOnBlur' | 'gutter' | 'size' | 'trigger'
+  >
 >;
 
 const Popover: FC<PopoverProps> = ({

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -17,6 +17,8 @@ type PopoverProps = PropsWithChildren<
     contentWidth?: string;
     contentPadding?: string;
     showArrow?: boolean;
+    closeOnBlur?: boolean;
+    gutter?: number;
   } & Pick<ChakraPopoverProps, 'placement'>
 >;
 
@@ -28,14 +30,16 @@ const Popover: FC<PopoverProps> = ({
   contentWidth,
   contentPadding = '2xl',
   showArrow = true,
+  closeOnBlur = false,
+  gutter = 12,
 }) => {
   return (
     <ChakraPopover
       placement={placement}
-      closeOnBlur={false}
+      closeOnBlur={closeOnBlur}
       trigger={trigger}
       arrowSize={12}
-      gutter={12}
+      gutter={gutter}
     >
       <PopoverTrigger>{children}</PopoverTrigger>
       <Portal>

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -17,7 +17,12 @@ type PopoverProps = PropsWithChildren<
   } & Pick<ChakraPopoverProps, 'placement'>
 >;
 
-const Popover: FC<PopoverProps> = ({ content, children, placement, trigger = 'hover' }) => {
+const Popover: FC<PopoverProps> = ({
+  content,
+  children,
+  placement,
+  trigger = 'hover',
+}) => {
   return (
     <ChakraPopover
       placement={placement}

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -14,6 +14,8 @@ type PopoverProps = PropsWithChildren<
   {
     content: ReactNode;
     trigger?: 'hover' | 'click';
+    contentWidth?: string;
+    contentPadding?: string;
   } & Pick<ChakraPopoverProps, 'placement'>
 >;
 
@@ -22,6 +24,8 @@ const Popover: FC<PopoverProps> = ({
   children,
   placement,
   trigger = 'hover',
+  contentWidth,
+  contentPadding = '2xl',
 }) => {
   return (
     <ChakraPopover
@@ -38,10 +42,11 @@ const Popover: FC<PopoverProps> = ({
             borderRadius="sm"
             boxShadow="md"
             maxW="6xl"
-            p="2xl"
+            p={contentPadding}
             // required for arrow to popup above shadow
             zIndex="0"
             backgroundColor="white"
+            width={contentWidth ? contentWidth : 'auto'}
           >
             <PopoverArrow backgroundColor="white" />
             <PopoverBody>{content}</PopoverBody>

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -10,13 +10,20 @@ import {
   Portal,
 } from '@chakra-ui/react';
 
-type PopoverProps = PropsWithChildren<
+export type PopoverProps = PropsWithChildren<
   {
     content: ReactNode;
     showArrow?: boolean;
   } & Pick<
     ChakraPopoverProps,
-    'placement' | 'closeOnBlur' | 'gutter' | 'size' | 'trigger'
+    | 'placement'
+    | 'closeOnBlur'
+    | 'gutter'
+    | 'size'
+    | 'trigger'
+    | 'onClose'
+    | 'onOpen'
+    | 'isOpen'
   >
 >;
 
@@ -29,6 +36,9 @@ const Popover: FC<PopoverProps> = ({
   closeOnBlur = false,
   gutter = 12,
   size = 'md',
+  onClose,
+  onOpen,
+  isOpen,
 }) => {
   return (
     <ChakraPopover
@@ -38,6 +48,9 @@ const Popover: FC<PopoverProps> = ({
       arrowSize={12}
       gutter={gutter}
       size={size}
+      onClose={onClose}
+      onOpen={onOpen}
+      isOpen={isOpen}
     >
       <PopoverTrigger>{children}</PopoverTrigger>
       <Portal>

--- a/src/themes/components/index.ts
+++ b/src/themes/components/index.ts
@@ -13,6 +13,7 @@ import SimpleHeader from './simpleHeader';
 import Select from './select';
 import Section from './section';
 import Radio from './radio';
+import Popover from './popover';
 import Pagination from './pagination';
 import NumberInput from './numberInput';
 import Modal from './modal';
@@ -76,4 +77,5 @@ export const components: Record<string, ComponentStyleConfig> = {
   Tooltip,
   VehicleReference,
   Slider,
+  Popover,
 };

--- a/src/themes/components/popover.ts
+++ b/src/themes/components/popover.ts
@@ -1,0 +1,19 @@
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
+import { popoverAnatomy as parts } from '@chakra-ui/anatomy';
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys);
+const sizes = {
+  xl: definePartsStyle({
+    content: {
+      width: '326px',
+      p: 'md',
+    },
+  }),
+  md: definePartsStyle({
+    content: {
+      width: 'auto',
+      p: '2xl',
+    },
+  }),
+};
+export default defineMultiStyleConfig({ sizes });

--- a/src/themes/components/popover.ts
+++ b/src/themes/components/popover.ts
@@ -5,7 +5,7 @@ const { definePartsStyle, defineMultiStyleConfig } =
 const sizes = {
   xl: definePartsStyle({
     content: {
-      width: '326px',
+      width: '6xl',
       p: 'md',
     },
   }),


### PR DESCRIPTION
[ST-137](https://smg-au.atlassian.net/browse/ST-137?atlOrigin=eyJpIjoiZGEyMmNkNzllZmI5NDZkMjg1Y2RhMTg3MjZjNGNlYjkiLCJwIjoiaiJ9)

## Motivation and context

We need to use the popover to display KPI's metrics filters in the cockpit like the design below. 
To achieve that, we need additional props

<img width="202" alt="Screenshot 2024-07-22 at 15 37 53" src="https://github.com/user-attachments/assets/5a74b7aa-89b9-4852-81e4-b89b5de2554d">

## Before

n/a

## After

New props: trigger, contentWidth, contentPadding, showArrow, closeOnBlur, gutter


