### PR TITLE
Private INSERTION RELEASE - Fix: remove shoppingCard link for all users 

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -517,25 +517,6 @@ export const drawerNodeItems = ({
           },
         },
         {
-          translationKey: 'header.userMenu.shoppingCard',
-          link: {
-            de: '/de/member/insertion/checkout/?steps=40-47',
-            en: '/de/member/insertion/checkout/?steps=40-47',
-            fr: '/fr/member/insertion/checkout/?steps=40-47',
-            it: '/it/member/insertion/checkout/?steps=40-47',
-          },
-          visibilitySettings: {
-            userType: {
-              private: true,
-              professional: true,
-            },
-            brand: {
-              autoscout24: true,
-              motoscout24: false,
-            },
-          },
-        },
-        {
           translationKey: 'header.userMenu.motorcyclePark',
           forceMotoscoutLink: true,
           link: {

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -166,7 +166,6 @@
       "requisitions": "Suchaufträge",
       "reviews": "Bewertungen",
       "settings": "Einstellungen",
-      "shoppingCard": "Warenkorb",
       "statistics": "Statistiken",
       "toolsForPurchasing": "Tools für den Einkauf",
       "toolsForSelling": "Tools für den Verkauf",

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -166,7 +166,6 @@
       "requisitions": "Requisitions",
       "reviews": "Reviews",
       "settings": "Ideas",
-      "shoppingCard": "Shopping card",
       "statistics": "The statistics",
       "toolsForPurchasing": "Tools for purchasing",
       "toolsForSelling": "Tools for Selling",

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -166,7 +166,6 @@
       "requisitions": "Profil de recherche",
       "reviews": "Évaluations",
       "settings": "Préférences",
-      "shoppingCard": "Panier",
       "statistics": "Statistiques",
       "toolsForPurchasing": "Outils pour l'achat",
       "toolsForSelling": "Outils pour la vente",

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -166,7 +166,6 @@
       "requisitions": "Ordini di ricerca",
       "reviews": "Valutazioni",
       "settings": "Preferenze",
-      "shoppingCard": "Carrello",
       "statistics": "Statistiche",
       "toolsForPurchasing": "Strumenti per l'acquisto",
       "toolsForSelling": "Gestire veicoli",


### PR DESCRIPTION
References [VSST-2512](https://smg-au.atlassian.net/browse/VSST-2512)

## Motivation and context

We need this link until we release private supply (on 15th of the August). After we release new insertion, VP, profile page for privates, we need to remove this link from header (we don't support shopping card anymore).
For professional, it can be removed now - (we forgot to remove when professional was released).

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
