### PR TITLE
feat: adjust vehicle reference and article teaser to new success page layout

### DIFF
--- a/src/components/articleTeaser/index.tsx
+++ b/src/components/articleTeaser/index.tsx
@@ -25,14 +25,7 @@ const ArticleTeaser: FC<Props> = ({
   return (
     <article>
       <a href={url} target="_blank" rel="noopener noreferrer">
-        <Stack
-          direction={{
-            '2xs': 'column',
-            sm: 'row',
-          }}
-          spacing="lg"
-          align="center"
-        >
+        <Stack direction="column" spacing="lg" align="center">
           <chakra.img maxW={maxImgW} src={imageUrl} />
           <Stack direction="column" spacing="sm">
             <chakra.h2 __css={styles.title}>{title}</chakra.h2>

--- a/src/components/vehicleReference/index.stories.tsx
+++ b/src/components/vehicleReference/index.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof VehicleReference> = {
   component: VehicleReference,
   decorators: [
     (Story) => (
-      <Box maxW={{ '2xs': '100%', md: '450px' }}>
+      <Box maxW={{ '2xs': '100%', md: '600px' }}>
         <Story />
       </Box>
     ),
@@ -35,7 +35,7 @@ export const VehicleReferenceWithImage: StoryType = {
     sellerName: `Auto-Center Grenchen AG 2540 Grenchen (SO)`,
     sellerAddress: `2540 Grenchen (SO)`,
     image: <img src="https://picsum.photos/400/400" />,
-    direction: { '2xs': 'row', md: 'column' },
+    templateColumns: { base: '96px 1fr', md: '240px 1fr' },
   },
 };
 

--- a/src/components/vehicleReference/index.stories.tsx
+++ b/src/components/vehicleReference/index.stories.tsx
@@ -35,6 +35,7 @@ export const VehicleReferenceWithImage: StoryType = {
     sellerName: `Auto-Center Grenchen AG 2540 Grenchen (SO)`,
     sellerAddress: `2540 Grenchen (SO)`,
     image: <img src="https://picsum.photos/400/400" />,
+    direction: { '2xs': 'row', md: 'column' },
   },
 };
 

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -34,7 +34,7 @@ const VehicleReference: FC<Props> = ({
       <AspectRatio ratio={4 / 3} borderRadius="sm" overflow="hidden">
         {image ? image : <MissingImage />}
       </AspectRatio>
-      <Stack spacing={{ base: 'xs', md: 'md' }} justify="center">
+      <Stack spacing={{ base: 'xs', md: 'md' }} justify="space-between">
         <chakra.h1 __css={styles.carTitle}>{vehicleTitle}</chakra.h1>
         <chakra.span __css={styles.price}>{price}</chakra.span>
         <Box>

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -35,7 +35,7 @@ const VehicleReference: FC<Props> = ({
         {image ? image : <MissingImage />}
       </AspectRatio>
       <Stack spacing={{ base: 'xs', md: 'md' }} justify="space-between">
-        <chakra.h1 __css={styles.carTitle}>{vehicleTitle}</chakra.h1>
+        <chakra.p __css={styles.carTitle}>{vehicleTitle}</chakra.p>
         <chakra.span __css={styles.price}>{price}</chakra.span>
         <Box>
           <chakra.p __css={styles.dealerName}>{sellerName}</chakra.p>

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -5,6 +5,7 @@ import { Box, chakra, useMultiStyleConfig } from '@chakra-ui/react';
 import Stack from '../stack';
 
 import MissingImage from '../missingImage';
+import Grid from '../grid';
 import AspectRatio from '../aspectRatio';
 
 interface Props {
@@ -14,7 +15,7 @@ interface Props {
   sellerName?: string | null;
   sellerAddress?: string | null;
   callToAction?: ReactNode;
-  direction?: ComponentProps<typeof Stack>['direction'];
+  templateColumns?: ComponentProps<typeof Grid>['templateColumns'];
 }
 
 const VehicleReference: FC<Props> = ({
@@ -24,34 +25,27 @@ const VehicleReference: FC<Props> = ({
   sellerName,
   sellerAddress,
   callToAction,
-  direction = { '2xs': 'row', md: 'column' },
+  templateColumns = { base: '96px 1fr', md: '1fr' },
 }) => {
   const styles = useMultiStyleConfig(`VehicleReference`);
 
   return (
-    <article>
-      <Stack direction={direction} spacing="md">
-        <AspectRatio
-          minW="2xl"
-          ratio={4 / 3}
-          borderRadius="sm"
-          overflow="hidden"
-        >
-          {image ? image : <MissingImage />}
-        </AspectRatio>
-        <Stack spacing={{ '2xs': 'xs', md: 'md' }} justify="center">
-          <chakra.h1 __css={styles.carTitle}>{vehicleTitle}</chakra.h1>
-          <chakra.span __css={styles.price}>{price}</chakra.span>
-          <Box>
-            <chakra.p __css={styles.dealerName}>{sellerName}</chakra.p>
-            <chakra.p __css={styles.dealerAddress}>{sellerAddress}</chakra.p>
-          </Box>
-        </Stack>
+    <Grid as="article" templateColumns={templateColumns} gap="md">
+      <AspectRatio ratio={4 / 3} borderRadius="sm" overflow="hidden">
+        {image ? image : <MissingImage />}
+      </AspectRatio>
+      <Stack spacing={{ base: 'xs', md: 'md' }} justify="center">
+        <chakra.h1 __css={styles.carTitle}>{vehicleTitle}</chakra.h1>
+        <chakra.span __css={styles.price}>{price}</chakra.span>
+        <Box>
+          <chakra.p __css={styles.dealerName}>{sellerName}</chakra.p>
+          <chakra.p __css={styles.dealerAddress}>{sellerAddress}</chakra.p>
+        </Box>
       </Stack>
       {callToAction ? (
         <Box marginTop={{ base: 'lg', md: 'sm' }}>{callToAction}</Box>
       ) : null}
-    </article>
+    </Grid>
   );
 };
 

--- a/src/components/vehicleReference/index.tsx
+++ b/src/components/vehicleReference/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { ComponentProps, FC, ReactNode } from 'react';
 
 import { Box, chakra, useMultiStyleConfig } from '@chakra-ui/react';
 
@@ -14,6 +14,7 @@ interface Props {
   sellerName?: string | null;
   sellerAddress?: string | null;
   callToAction?: ReactNode;
+  direction?: ComponentProps<typeof Stack>['direction'];
 }
 
 const VehicleReference: FC<Props> = ({
@@ -23,12 +24,13 @@ const VehicleReference: FC<Props> = ({
   sellerName,
   sellerAddress,
   callToAction,
+  direction = { '2xs': 'row', md: 'column' },
 }) => {
   const styles = useMultiStyleConfig(`VehicleReference`);
 
   return (
     <article>
-      <Stack direction={{ '2xs': 'row', md: 'column' }} spacing="md">
+      <Stack direction={direction} spacing="md">
         <AspectRatio
           minW="2xl"
           ratio={4 / 3}

--- a/src/themes/components/vehicleReference.ts
+++ b/src/themes/components/vehicleReference.ts
@@ -14,7 +14,7 @@ const VehicleReference: ComponentStyleConfig = {
     },
     price: {
       color: 'gray.900',
-      textStyle: { '2xs': 'heading3', md: 'heading1' },
+      textStyle: { '2xs': 'heading3', md: 'heading2' },
     },
     dealerName: {
       color: 'gray.900',


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3436

## Motivation and context

As per design, we can adjust this globally for all the pages

## How to test

see here: https://github.com/smg-automotive/listings-web/pull/2489