### PR TITLE
chore: Replaced private profile link in navigation header

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1178,7 +1178,7 @@ export const drawerNodeItems = ({
           translationKey: 'header.userMenu.contactDetails',
           link: {
             de: '/de/profile',
-            en: '/de/profile',
+            en: '/en/profile',
             fr: '/fr/profile',
             it: '/it/profile',
           },
@@ -1197,7 +1197,7 @@ export const drawerNodeItems = ({
           translationKey: 'header.userMenu.contactDetails',
           link: {
             de: '/de/member/masterdata/addressedit',
-            en: '/en/member/masterdata/addressedit',
+            en: '/de/member/masterdata/addressedit',
             fr: '/fr/member/masterdata/addressedit',
             it: '/it/member/masterdata/addressedit',
           },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -961,7 +961,7 @@ export const drawerNodeItems = ({
             de: 'http://bi.scout24.ch',
             en: 'http://bi.scout24.ch',
             fr: 'http://bi.scout24.ch',
-            it: 'http://bi. scout24.ch',
+            it: 'http://bi.scout24.ch',
           },
           visibilitySettings: {
             userType: {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1178,7 +1178,7 @@ export const drawerNodeItems = ({
           translationKey: 'header.userMenu.contactDetails',
           link: {
             de: '/de/profile',
-            en: '/de/profile',
+            en: '/de/profcile',
             fr: '/fr/profile',
             it: '/it/profile',
           },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1178,7 +1178,7 @@ export const drawerNodeItems = ({
           translationKey: 'header.userMenu.contactDetails',
           link: {
             de: '/de/profile',
-            en: '/de/profcile',
+            en: '/de/profile',
             fr: '/fr/profile',
             it: '/it/profile',
           },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -961,7 +961,7 @@ export const drawerNodeItems = ({
             de: 'http://bi.scout24.ch',
             en: 'http://bi.scout24.ch',
             fr: 'http://bi.scout24.ch',
-            it: 'http://bi.scout24.ch',
+            it: 'http://bi. scout24.ch',
           },
           visibilitySettings: {
             userType: {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1177,10 +1177,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.userMenu.contactDetails',
           link: {
-            de: '/de/member/masterdata/addressedit',
-            en: '/de/member/masterdata/addressedit',
-            fr: '/fr/member/masterdata/addressedit',
-            it: '/it/member/masterdata/addressedit',
+            de: '/de/profile',
+            en: '/de/profile',
+            fr: '/fr/profile',
+            it: '/it/profile',
           },
           visibilitySettings: {
             userType: {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -1185,6 +1185,25 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: true,
+              professional: false,
+            },
+            brand: {
+              autoscout24: true,
+              motoscout24: true,
+            },
+          },
+        },
+        {
+          translationKey: 'header.userMenu.contactDetails',
+          link: {
+            de: '/de/member/masterdata/addressedit',
+            en: '/en/member/masterdata/addressedit',
+            fr: '/fr/member/masterdata/addressedit',
+            it: '/it/member/masterdata/addressedit',
+          },
+          visibilitySettings: {
+            userType: {
+              private: false,
               professional: true,
             },
             brand: {


### PR DESCRIPTION
References [ticket](https://smg-au.atlassian.net/browse/VSST-2517?atlOrigin=eyJpIjoiYTJkZTU2YmExZTkwNDhiM2IzNDk5ZjU3N2ZjMTU1MTciLCJwIjoiaiJ9)

## Motivation and context

Instead of legacy link to private profile /{language}/member/masterdata/addressedit replace with new link /{language}/profile in navigation headers

## Before

By hovering over the Link (Contact details) in the menu bar, it shows /{language}/member/masterdata/addressedit for private seller but redirects to /{language}/profile. Private and Professional sellers both shared the same Link.

## After

By hovering over the Link now, it shows the right address /{language}/profile when using a private account and shows {language}/member/masterdata/addressedit when using a private account.

## How to test

[deployment](https://replace-link-navigator-header-components-pkg.branch.autoscout24.dev)
