### PR TITLE
fix: adjusted seller search link with new url

### DIFF
--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -82,10 +82,10 @@ export const footerConfig = ({
             brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: false },
           },
           link: {
-            de: '/de/auto-haendler-garage/suche',
-            en: '/de/auto-haendler-garage/suche',
-            fr: '/fr/voiture-concessionaires-garages/recherche',
-            it: '/it/auto-concessionari-garage/ricerca',
+            de: '/de/sellers',
+            en: '/de/sellers',
+            fr: '/fr/sellers',
+            it: '/it/sellers',
           },
         },
         {
@@ -94,10 +94,10 @@ export const footerConfig = ({
             brand: { [Brand.AutoScout24]: false, [Brand.MotoScout24]: true },
           },
           link: {
-            de: '/de/moto-haendler-garage/suche',
-            en: '/de/moto-haendler-garage/suche',
-            fr: '/fr/moto-concessionaires-garage/recherche',
-            it: '/it/moto-concessionari-garage/ricerca',
+            de: '/de/sellers',
+            en: '/de/sellers',
+            fr: '/fr/sellers',
+            it: '/it/sellers',
           },
         },
         {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -134,10 +134,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.searchMerchant',
           link: {
-            de: '/de/auto-haendler-garage/suche',
-            en: '/de/auto-haendler-garage/suche',
-            fr: '/fr/voiture-concessionaires-garages/recherche',
-            it: '/it/auto-concessionari-garage/ricerca',
+            de: '/de/sellers',
+            en: '/de/sellers',
+            fr: '/fr/sellers',
+            it: '/it/sellers',
           },
           visibilitySettings: {
             userType: {
@@ -153,10 +153,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.searchMerchant',
           link: {
-            de: '/de/moto-haendler-garage/suche',
-            en: '/de/moto-haendler-garage/suche',
-            fr: '/fr/moto-concessionaires-garage/recherche',
-            it: '/it/moto-concessionari-garage/ricerca',
+            de: '/de/sellers',
+            en: '/de/sellers',
+            fr: '/fr/sellers',
+            it: '/it/sellers',
           },
           visibilitySettings: {
             userType: {


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3245

## Motivation and context

After the seller search page release, we can adjust the seller search page link with the new one on header and footer

## How to test

Please check the header and footer

## Thank you 🐈 🩵  🧝🏽‍♀️  🇧🇷 
