### PR TITLE
fix: enable showing tooltip with the button

### DIFF
--- a/src/components/formControl/index.stories.tsx
+++ b/src/components/formControl/index.stories.tsx
@@ -101,6 +101,17 @@ export const WithButton: StoryType = {
   },
 };
 
+export const WithTooltipAndButton: StoryType = {
+  name: 'With tooltip and button',
+
+  args: {
+    label: 'Label',
+    tooltip: 'I am a tooltip text',
+    labelButtonText: 'button',
+    labelButtonOnClick: action('label button clicked'),
+  },
+};
+
 export const Invalid: StoryType = {
   args: {
     label: 'Label',

--- a/src/components/formControl/index.tsx
+++ b/src/components/formControl/index.tsx
@@ -71,6 +71,21 @@ const FormControl: FC<PropsWithChildren<Props>> = ({
     </Stack>
   );
 
+  const formLabelWithTooltipAndButton = (
+    <Stack direction="row" justify="space-between">
+      {formLabelWithTooltip}
+      <Link
+        as={Button}
+        onClick={labelButtonOnClick}
+        textStyle="body-small"
+        color="blue.700"
+        padding="0"
+      >
+        {labelButtonText}
+      </Link>
+    </Stack>
+  );
+
   return (
     <ChakraFormControl
       isDisabled={isDisabled}
@@ -79,8 +94,11 @@ const FormControl: FC<PropsWithChildren<Props>> = ({
       id={id}
     >
       {label && !tooltip && !labelButtonText ? formLabel : null}
-      {label && tooltip ? formLabelWithTooltip : null}
-      {label && labelButtonText ? formLabelWithButton : null}
+      {label && tooltip && !labelButtonText ? formLabelWithTooltip : null}
+      {label && !tooltip && labelButtonText ? formLabelWithButton : null}
+      {label && tooltip && labelButtonText
+        ? formLabelWithTooltipAndButton
+        : null}
       {children}
       <FormErrorMessage>{errorMessage}</FormErrorMessage>
       {hint ? <FormHelperText>{hint}</FormHelperText> : null}

--- a/src/components/formControl/index.tsx
+++ b/src/components/formControl/index.tsx
@@ -86,6 +86,20 @@ const FormControl: FC<PropsWithChildren<Props>> = ({
     </Stack>
   );
 
+  let labelComponent = null;
+
+  if (label) {
+    if (tooltip && labelButtonText) {
+      labelComponent = formLabelWithTooltipAndButton;
+    } else if (tooltip) {
+      labelComponent = formLabelWithTooltip;
+    } else if (labelButtonText) {
+      labelComponent = formLabelWithButton;
+    } else {
+      labelComponent = formLabel;
+    }
+  }
+
   return (
     <ChakraFormControl
       isDisabled={isDisabled}
@@ -93,12 +107,7 @@ const FormControl: FC<PropsWithChildren<Props>> = ({
       isRequired={isRequired}
       id={id}
     >
-      {label && !tooltip && !labelButtonText ? formLabel : null}
-      {label && tooltip && !labelButtonText ? formLabelWithTooltip : null}
-      {label && !tooltip && labelButtonText ? formLabelWithButton : null}
-      {label && tooltip && labelButtonText
-        ? formLabelWithTooltipAndButton
-        : null}
+      {labelComponent}
       {children}
       <FormErrorMessage>{errorMessage}</FormErrorMessage>
       {hint ? <FormHelperText>{hint}</FormHelperText> : null}


### PR DESCRIPTION
References:
- [IN-1793](https://smg-au.atlassian.net/browse/IN-1793)
- [Seller web PR](https://github.com/smg-automotive/seller-web/pull/2248)

## Motivation and context

We want to display label, tooltip and button in the same row.

## Before

n/a

## After

![image](https://github.com/user-attachments/assets/72fe2bc5-81e9-43fc-81e3-63f6af1f5926)

## How to test

https://in-1973-version-input-tooltip-components-pkg.branch.autoscout24.dev/?path=/story/components-forms-form-control--with-tooltip-and-button

[IN-1793]: https://smg-au.atlassian.net/browse/IN-1793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ