### PR TITLE
Cetralize variants

### DIFF
--- a/src/components/alert/Bare.tsx
+++ b/src/components/alert/Bare.tsx
@@ -12,7 +12,7 @@ import { ColourVariant } from 'src/types/colourVariants';
 
 import Link from '../link';
 
-type BareAlertVariant = Extract<
+type BareAlertType = Extract<
   ColourVariant,
   'info' | 'success' | 'warning' | 'error'
 >;
@@ -27,7 +27,7 @@ export interface BareAlertProps {
     isExternal?: boolean;
     onClick?: () => void;
   };
-  type?: BareAlertVariant;
+  type?: BareAlertType;
   icon?: ReactNode;
   onClose?: () => void;
 }

--- a/src/components/alert/Bare.tsx
+++ b/src/components/alert/Bare.tsx
@@ -8,7 +8,14 @@ import {
   Flex,
 } from '@chakra-ui/react';
 
+import { ColourVariant } from 'src/types/colourVariants';
+
 import Link from '../link';
+
+type BareAlertVariant = Extract<
+  ColourVariant,
+  'info' | 'success' | 'warning' | 'error'
+>;
 
 export interface BareAlertProps {
   title?: string;
@@ -20,7 +27,7 @@ export interface BareAlertProps {
     isExternal?: boolean;
     onClick?: () => void;
   };
-  type?: 'error' | 'warning' | 'info' | 'success';
+  type?: BareAlertVariant;
   icon?: ReactNode;
   onClose?: () => void;
 }

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -5,6 +5,8 @@ import {
   ResponsiveValue,
 } from '@chakra-ui/react';
 
+import { ColourVariant } from 'src/types/colourVariants';
+
 type Overwrite<T, NewT> = Omit<T, keyof NewT> & NewT;
 type Never<Source> = { [P in keyof Source]?: never };
 
@@ -21,9 +23,14 @@ type IconButton = {
 
 type ButtonSize = 'md' | 'lg';
 
+type ButtonVariant = Extract<
+  ColourVariant,
+  'primary' | 'secondary' | 'success' | 'transparent'
+>;
+
 type SharedProps = {
   as?: 'button';
-  variant?: 'primary' | 'secondary' | 'success' | 'transparent';
+  variant?: ButtonVariant;
   size?: ButtonSize | ResponsiveValue<ButtonSize>;
   children: ReactNode;
   leftIcon?: ReactElement;

--- a/src/components/count/index.tsx
+++ b/src/components/count/index.tsx
@@ -1,20 +1,19 @@
 import React, { FC } from 'react';
 import { chakra } from '@chakra-ui/react';
 
-type Variant =
-  | 'primary'
-  | 'inverted'
-  | 'info'
-  | 'success'
-  | 'warning'
-  | 'error';
+import { ColourVariant } from 'src/types/colourVariants';
+
+export type CountVariant = Extract<
+  ColourVariant,
+  'primary' | 'inverted' | 'info' | 'success' | 'warning' | 'error'
+>;
 
 type ColorConfig = {
   bg: string;
   text: string;
 };
 
-const color: Record<Variant, ColorConfig> = {
+const color: Record<CountVariant, ColorConfig> = {
   primary: {
     bg: 'brand.primary',
     text: 'black',
@@ -42,7 +41,7 @@ const color: Record<Variant, ColorConfig> = {
 };
 
 export interface Props {
-  variant?: Variant;
+  variant?: CountVariant;
   count: number;
   ariaLabel?: string;
 }

--- a/src/components/count/index.tsx
+++ b/src/components/count/index.tsx
@@ -3,6 +3,7 @@ import { chakra } from '@chakra-ui/react';
 
 import { ColourVariant } from 'src/types/colourVariants';
 
+// TOFIX: refactor "inverted" variant into "transparent" (used in listings-web)
 export type CountVariant = Extract<
   ColourVariant,
   'primary' | 'inverted' | 'info' | 'success' | 'warning' | 'error'

--- a/src/types/colourVariants.ts
+++ b/src/types/colourVariants.ts
@@ -1,0 +1,9 @@
+export type ColourVariant =
+  | 'primary'
+  | 'secondary'
+  | 'inverted'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'transparent';


### PR DESCRIPTION
References [JIRA](https://smg-au.atlassian.net/browse/IN-2049)

## Motivation and context

As a part of Vehicle Pool (VP) implementation of Completeness Score, we need to display average score with a summary. 

Within [its PR](https://github.com/smg-automotive/seller-web/pull/2293#discussion_r1741624777) there was a request to unify coloured variants, and re-use them with Alert and Count components. In that manner, I added a common type and adjusted all components to use it.

Also, `CountVariant` type was exported, so it can be used in VP.

## Before

Components that are using the same colour variant names (e.g. success, warning, error, etc.) do not have a common type.

## After

Components that are using the same colour variant names (e.g. success, warning, error, etc.) have a common type.

## How to test

- https://cetralize-variants-components-pkg.branch.autoscout24.dev/?path=/docs/components-data-display-count--documentation
- https://cetralize-variants-components-pkg.branch.autoscout24.dev/?path=/docs/components-button--documentation
- https://cetralize-variants-components-pkg.branch.autoscout24.dev/?path=/docs/components-feedback-toast--documentation