### PR TITLE
fix: Fix Discrete slider mark word break on space.

### DIFF
--- a/src/themes/components/slider.ts
+++ b/src/themes/components/slider.ts
@@ -101,6 +101,7 @@ const baseStyleMark = defineStyle(() => {
     mt: '2xl',
     fontSize: 'sm',
     transform: 'translateX(-50%)',
+    whiteSpace: 'nowrap',
   };
 });
 


### PR DESCRIPTION
## Motivation and context

On last step of Discrete slider, if there is space in mark step label it breaks in two lines.

## Before

Overflow wrap set to break-word.

## After

Apply white-space:nowrap.

## How to test

[Storybook](https://fix-discreteslider-mark-components-pkg.branch.autoscout24.dev/?__cf_chl_tk=eGCB1WpVO.UJYn5YnAPMqWHfZkuNpOEjeTvPGVFrkEw-1725463612-0.0.1.1-6996)