### PR TITLE
feat: show and hide cockpit link

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -70,21 +70,14 @@ const getComparisonNodeItem = ({
     : [];
 };
 
-const isCockpitBetaGroupUser = ({ id }: { id?: string }) => {
-  const betaGroupTesterList = ['61627', '60601'];
-  return id && betaGroupTesterList.includes(id);
-};
-
 export const drawerNodeItems = ({
   comparisonItemIds,
   trackEvent,
   onLogout,
-  sellerId,
 }: {
   comparisonItemIds?: number[] | null;
   trackEvent?: (event: CustomEvent) => void;
   onLogout: () => void;
-  sellerId?: string;
 }): DrawerNodeItemsConfig => ({
   search: [
     {
@@ -426,14 +419,16 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: false,
-              professional: isCockpitBetaGroupUser({ id: sellerId })
-                ? false
-                : true,
+              professional: true,
             },
             brand: {
               autoscout24: true,
               motoscout24: false,
             },
+          },
+          entitlementConfig: {
+            hideIfEntitlementIsPresent: Entitlement.CockpitFrontend,
+            singleRequiredEntitlement: [Entitlement.CockpitFrontend],
           },
         },
         {
@@ -520,14 +515,16 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: false,
-              professional: isCockpitBetaGroupUser({ id: sellerId })
-                ? true
-                : false,
+              professional: true,
             },
             brand: {
               autoscout24: true,
               motoscout24: false,
             },
+          },
+          entitlementConfig: {
+            hideIfRequiredEntitlementIsMissing: true,
+            singleRequiredEntitlement: [Entitlement.CockpitFrontend],
           },
         },
         {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -70,14 +70,21 @@ const getComparisonNodeItem = ({
     : [];
 };
 
+const isCockpitBetaGroupUser = ({ id }: { id?: string }) => {
+  const betaGroupTesterList = ['61627', '60601'];
+  return id && betaGroupTesterList.includes(id);
+};
+
 export const drawerNodeItems = ({
   comparisonItemIds,
   trackEvent,
   onLogout,
+  sellerId,
 }: {
   comparisonItemIds?: number[] | null;
   trackEvent?: (event: CustomEvent) => void;
   onLogout: () => void;
+  sellerId?: string;
 }): DrawerNodeItemsConfig => ({
   search: [
     {
@@ -503,19 +510,21 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.userMenu.cockpit',
           link: {
-            de: '/de/member/cockpit',
-            en: '/de/member/cockpit',
-            fr: '/fr/member/cockpit',
-            it: '/it/member/cockpit',
+            de: '/de/cockpit',
+            en: '/de/cockpit',
+            fr: '/fr/cockpit',
+            it: '/it/cockpit',
           },
           visibilitySettings: {
             userType: {
               private: false,
-              professional: false,
+              professional: isCockpitBetaGroupUser({ id: sellerId })
+                ? true
+                : false,
             },
             brand: {
               autoscout24: true,
-              motoscout24: true,
+              motoscout24: false,
             },
           },
         },

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -426,7 +426,9 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: false,
-              professional: true,
+              professional: isCockpitBetaGroupUser({ id: sellerId })
+                ? false
+                : true,
             },
             brand: {
               autoscout24: true,

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -519,7 +519,7 @@ export const drawerNodeItems = ({
             },
             brand: {
               autoscout24: true,
-              motoscout24: false,
+              motoscout24: true,
             },
           },
           entitlementConfig: {

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -65,7 +65,6 @@ const Navigation: FC<NavigationProps> = ({
           trackEvent,
           onLogout,
           comparisonItemIds,
-          sellerId: user?.sellerId,
         }),
         iconItems: iconItems({ trackEvent, comparisonItemIds }),
       },

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -65,6 +65,7 @@ const Navigation: FC<NavigationProps> = ({
           trackEvent,
           onLogout,
           comparisonItemIds,
+          sellerId: user?.sellerId,
         }),
         iconItems: iconItems({ trackEvent, comparisonItemIds }),
       },

--- a/src/types/entitlements.ts
+++ b/src/types/entitlements.ts
@@ -6,4 +6,5 @@ export enum Entitlement {
   AutoRadarFast = 'auto-radar-fast',
   ListingVisibilityStandard = 'listing-visibility-standard',
   ListingVisibilityPremium = 'listing-visibility-premium',
+  CockpitFrontend = 'cockpit-frontend',
 }


### PR DESCRIPTION
[ST-372](https://smg-au.atlassian.net/browse/ST-372)

## Motivation and context

For the cockpit release to come, in case the user is part of beta testing group we show cockpit link and hide dealer dashboard link. If the user is not part of the beta group we hide cockpit link and show dealer dashboard. 

## Before

Cockpit was hidden for everyone
Dealer dashboard is visible for everyone

## After

We show cockpit link and hide dealer dashboard link if the user is part of beta group 
If the user is not part of the beta group we hide cockpit link and show dealer dashboard. 

## How to test

You can test seller web [here](https://st-372-seller-web.branch.autoscout24.dev/de) and listings [here](https://st-372-listings-web.branch.autoscout24.dev/de). 

Currently only user 60601 is part of the group, so if you login with this account, you will see the cockpit link but not the dealer dashboard link. 
Try to impersonate a different dealer (225 for example), you will see the dealer dashboard link and not the cockpit. 

Thank you 🍓 


[ST-372]: https://smg-au.atlassian.net/browse/ST-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
