### PR TITLE
fix: align digital contract icon to center

### DIFF
--- a/src/components/icons/DigitalContractIcon.tsx
+++ b/src/components/icons/DigitalContractIcon.tsx
@@ -12,7 +12,7 @@ export const DigitalContractIcon: ComponentWithAs<'svg', IconProps> =
         <path
           fill="currentColor"
           fillRule="evenodd"
-          d="m15.965 1.971-1.982.011h-12V18.96h12v-7.98l1.982-2.236v12.199H0V0h15.965zm1.465-.124L8.186 12.56l-.597 2.27 2.157-.92L18.99 3.196zM9.573 16.142H5.902v1.906h3.671z"
+          d="m18.965 3.971-1.982.011h-12V20.96h12v-7.98l1.982-2.236v12.198H3V2h15.965V3.97zm1.465-.124-9.244 10.712-.598 2.27 2.158-.92L21.99 5.195l-1.56-1.349zm-7.857 14.295H8.902v1.906h3.671v-1.906z"
           clipRule="evenodd"
         />
       </>


### PR DESCRIPTION
References [VSST-2829](https://smg-au.atlassian.net/browse/VSST-2829)

## Motivation and context

We need to present a digital contract icon centered within a yellow circle. Currently, the icon is offset to the left so this PR aims to fix the alignment issue.

## Before

<img width="124" alt="Screenshot 2024-10-15 at 11 30 57" src="https://github.com/user-attachments/assets/552bea83-6e6b-4c83-91f6-fcb974ba3b18">
<img width="124" alt="Screenshot 2024-10-15 at 11 34 10" src="https://github.com/user-attachments/assets/2bd76439-92eb-474b-b9a0-eadad9ba297a">

## After

<img width="124" alt="Screenshot 2024-10-15 at 11 31 23" src="https://github.com/user-attachments/assets/bbc31b6d-107f-46df-b734-211c09767bf4">
<img width="124" alt="Screenshot 2024-10-15 at 11 39 47" src="https://github.com/user-attachments/assets/4bf1a120-48ce-4e1c-8457-2dbbdf617d40">


## How to test

Check if the digital contract icon is aligned to center.


[VSST-2829]: https://smg-au.atlassian.net/browse/VSST-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ