### PR TITLE
feat(tokens): Add auth0 sepecific tokens and allow them in modal

### DIFF
--- a/src/components/modal/index.stories.tsx
+++ b/src/components/modal/index.stories.tsx
@@ -75,7 +75,7 @@ const meta: Meta<typeof Template> = {
 
   argTypes: {
     size: {
-      options: ['md', 'lg'],
+      options: ['md', 'lg', 'full', 'auth0'],
 
       control: {
         type: 'select',

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -26,7 +26,7 @@ export interface Props
   primaryActionButton?: ActionButton;
   secondaryActionButton?: ActionButton;
   variant?: 'fullScreen' | 'base' | 'topScroll';
-  size?: 'md' | 'lg' | 'full';
+  size?: 'md' | 'lg' | 'full' | 'auth0';
   disableBodyPadding?: boolean;
   overlayColor?: 'default' | 'gray';
 }

--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -132,6 +132,7 @@ function getSize(value: string) {
 const sizes = {
   md: getSize('7xl'),
   lg: getSize('8xl'),
+  auth0: getSize('auth0-width'),
   full: getSize('full'),
 };
 

--- a/src/themes/shared/sizes.ts
+++ b/src/themes/shared/sizes.ts
@@ -19,6 +19,8 @@ export const sizes = {
     xl: '1280px',
     '2xl': '1604px',
   },
+  'auth0-width': '25rem',
+  'auth0-height': '33.75rem',
 };
 
 export type Sizes = Exclude<keyof typeof sizes, 'container'>;

--- a/src/themes/shared/space.ts
+++ b/src/themes/shared/space.ts
@@ -11,6 +11,7 @@ export const space = {
   '5xl': '4rem',
   '6xl': '6rem',
   '7xl': '8rem',
+  'auth0-spacing': '2.5rem',
 };
 
 export type Space = Exclude<keyof typeof space, undefined>;


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/SST-1010

## Motivation and context

We discussed with the UX team to align our pages to match the auth0 modals as they are limited in configuration options. Therefore we are going to add some auth0-specific tokens to our components package so we use them within the custom pages

## Before

n/A

## After

auth0 specific tokens added and modal extended

![Screenshot 2024-10-16 at 09 45 24](https://github.com/user-attachments/assets/4d38c539-6bd5-4761-9fcf-59b62bd649be)


## How to test

Check the modal and token docs
