### PR TITLE
fix: omit gap prop in flex component

### DIFF
--- a/src/components/flex/index.tsx
+++ b/src/components/flex/index.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { Flex as ChakraFlex, FlexProps } from '@chakra-ui/react';
 
-const Flex: FC<Omit<FlexProps, 'columnGap' | 'rowGap'>> = ({
+const Flex: FC<Omit<FlexProps, 'gap' | 'columnGap' | 'rowGap'>> = ({
   children,
   ...rest
 }) => <ChakraFlex {...rest}>{children}</ChakraFlex>;


### PR DESCRIPTION
Revert this https://github.com/smg-automotive/components-pkg/pull/1152 because `gap` is not supported by all browsers
