### PR TITLE
feat: full width tabs

### DIFF
--- a/src/components/tab/index.stories.tsx
+++ b/src/components/tab/index.stories.tsx
@@ -43,7 +43,13 @@ const meta: Meta<typeof Tabs> = {
 
   argTypes: {
     variant: {
-      options: ['spaceBetween', 'spaceAround', 'enclosed', 'default'],
+      options: [
+        'spaceBetween',
+        'spaceAround',
+        'enclosed',
+        'fullWidth',
+        'default',
+      ],
       control: 'select',
     },
     children: {
@@ -79,6 +85,14 @@ export const VariantEnclosed: StoryType = {
 
   args: {
     variant: 'enclosed',
+  },
+};
+
+export const VariantFullWidth: StoryType = {
+  name: 'Variant > Full Width',
+
+  args: {
+    variant: 'fullWidth',
   },
 };
 

--- a/src/components/tab/index.tsx
+++ b/src/components/tab/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, PropsWithChildren } from 'react';
 import { Tabs as ChakraTabs, TabsProps } from '@chakra-ui/react';
 
 export type Props = {
-  variant?: 'spaceBetween' | 'spaceAround' | 'enclosed';
+  variant?: 'spaceBetween' | 'spaceAround' | 'enclosed' | 'fullWidth';
 } & Pick<TabsProps, 'defaultIndex' | 'isLazy' | 'onChange' | 'index'>;
 
 const Tabs: FC<PropsWithChildren<Props>> = (props) => {

--- a/src/themes/components/tabs.ts
+++ b/src/themes/components/tabs.ts
@@ -79,7 +79,7 @@ const variants = {
     tabpanel: { ...baseStyleTabpanel, margin: '0' },
   },
   fullWidth: {
-    tab: { ...baseStyleTab, flexGrow: 1 },
+    tab: { ...baseStyleTab, flex: 1 },
     tablist: baseStyleTablist,
     tabpanel: baseStyleTabpanel,
   },

--- a/src/themes/components/tabs.ts
+++ b/src/themes/components/tabs.ts
@@ -78,6 +78,11 @@ const variants = {
     },
     tabpanel: { ...baseStyleTabpanel, margin: '0' },
   },
+  fullWidth: {
+    tab: { ...baseStyleTab, flexGrow: 1 },
+    tablist: baseStyleTablist,
+    tabpanel: baseStyleTabpanel,
+  },
 };
 
 export default {


### PR DESCRIPTION
References [VSST-2932](https://smg-au.atlassian.net/browse/VSST-2932)

## Motivation and context

The new professional seller profile page has full width tabs:

<img width="837" alt="Screenshot 2024-10-30 at 16 29 20" src="https://github.com/user-attachments/assets/9d59ef0b-8c04-4bde-85cb-b3d3d4ca0981">

This PR adds a new `fullWidth` variant to the existing tabs component.

## Before

No full width variant of tabs component.

## After

<img width="1046" alt="Screenshot 2024-10-30 at 16 30 07" src="https://github.com/user-attachments/assets/d57af8ef-a72a-44ef-aa81-e22f76210ce8">

## How to test

- https://full-width-tabs-components-pkg.branch.autoscout24.dev/?path=/docs/components-navigation-tabs--documentation#variant%20%3E%20full%20width

[VSST-2932]: https://smg-au.atlassian.net/browse/VSST-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ