### PR TITLE
fix: extending popover props

### DIFF
--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -10,10 +10,16 @@ import {
   Portal,
 } from '@chakra-ui/react';
 
+type ContentPadding = '2xl' | 0;
+
+type MaxWidth = '6xl' | '8xl';
+
 export type PopoverProps = PropsWithChildren<
   {
     content: ReactNode;
     showArrow?: boolean;
+    contentPadding?: ContentPadding;
+    maxWidth?: MaxWidth;
   } & Pick<
     ChakraPopoverProps,
     | 'placement'
@@ -39,6 +45,8 @@ const Popover: FC<PopoverProps> = ({
   onClose,
   onOpen,
   isOpen,
+  contentPadding = '2xl',
+  maxWidth = '6xl',
 }) => {
   return (
     <ChakraPopover
@@ -58,10 +66,11 @@ const Popover: FC<PopoverProps> = ({
           <PopoverContent
             borderRadius="sm"
             boxShadow="md"
-            maxW="6xl"
+            maxW={maxWidth}
             // required for arrow to popup above shadow
             zIndex="0"
             backgroundColor="white"
+            padding={contentPadding}
           >
             {showArrow ? <PopoverArrow backgroundColor="white" /> : null}
             <PopoverBody>{content}</PopoverBody>


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Extending popover props in order to support new design for insights.

https://www.figma.com/design/JIg3a2e1WTSGRm0UBF9Hc5/Dealer-Dashboard-2024?node-id=5027-17427&node-type=frame&t=6x9ziUdmYGsfFAF5-0

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
