### PR TITLE
feat: sparkling car & minus icons

### DIFF
--- a/src/components/icons/MinusIcon.tsx
+++ b/src/components/icons/MinusIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const MinusIcon: ComponentWithAs<'svg', IconProps> = createIcon({
+  displayName: 'Minus',
+  viewBox: '0 0 24 24',
+  path: (
+    <>
+      <title>Minus icon</title>
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M6.444 20.315a10 10 0 1 0 11.112-16.63 10 10 0 0 0-11.112 16.63M7.555 5.348a8 8 0 1 1 8.89 13.304 8 8 0 0 1-8.89-13.304M7 13h9l1-2H7z"
+        clipRule="evenodd"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/SparklingCarIcon.tsx
+++ b/src/components/icons/SparklingCarIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const SparklingCarIcon: ComponentWithAs<'svg', IconProps> = createIcon({
+  displayName: 'Sparkling Car',
+  viewBox: '0 0 24 24',
+  path: (
+    <>
+      <title>Sparkling Car icon</title>
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M19 9h-1.5L15 4H4L1 9h2.34l1.8-3h8.62l2.51 5H19a2 2 0 0 1 2 2v3h-1.18a3 3 0 0 0-5.63 0H13l-2 2h3.19a3 3 0 0 0 5.63 0H23v-5a4 4 0 0 0-4-4m-2 9a1 1 0 1 1 0-2 1 1 0 0 1 0 2M6 9l1.697 4.303L12 15l-4.303 1.697L6 21l-1.697-4.303L0 15l4.303-1.697zm5-1h2v2l-2 1z"
+        clipRule="evenodd"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -138,3 +138,5 @@ export { BulbIcon } from './BulbIcon';
 export { NoPhotoIcon } from './NoPhotoIcon';
 export { ThumbsUpIcon } from './ThumbsUpIcon';
 export { ThumbsDownIcon } from './ThumbsDownIcon';
+export { SparklingCarIcon } from './SparklingCarIcon';
+export { MinusIcon } from './MinusIcon';


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Adding sparkling car and minus icons.

https://www.figma.com/design/JIg3a2e1WTSGRm0UBF9Hc5/Dealer-Dashboard-2024?node-id=5027-17427&node-type=frame&t=aBU4bj7AbfhjEHwN-0

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After
![Screenshot 2024-11-13 at 14 28 34](https://github.com/user-attachments/assets/bd61e0f7-496f-48b0-b779-39514ac96e6d)
![Screenshot 2024-11-13 at 14 28 21](https://github.com/user-attachments/assets/9624de7a-f553-4c47-9774-e15414b32a53)


## How to test

https://sparkling-car-and-minus-icons-components-pkg.branch.autoscout24.dev/?path=/docs/foundations-icons--documentation
