### PR TITLE
chore: improve storybook setup

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,8 @@
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import type { StorybookConfig } from '@storybook/react-webpack5';
 
+import { autoScout24System } from '../src/themes';
+
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -24,6 +26,34 @@ const config: StorybookConfig = {
   },
   typescript: {
     reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      compilerOptions: {
+        esModuleInterop: false,
+        allowSyntheticDefaultImports: false,
+      },
+      shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
+      propFilter: (prop) => {
+        const isWhitelistedProp = ['variant', 'size'].includes(prop.name);
+
+        // Excludes styling props defined by chakra
+        const isExcludedProp = ['as', 'asChild', 'recipe'].includes(prop.name);
+        const isStyledSystemProp = autoScout24System.isValidProperty(prop.name);
+
+        // Excludes HTML attributes and DOM properties coming (mostly) from react
+        const isHTMLProp = prop.parent?.name?.match(/^(html|dom)/i) ?? false;
+        const isReactProp =
+          prop.parent?.fileName?.includes('node_modules/@types/react') ?? false;
+
+        return (
+          isWhitelistedProp ||
+          (!isExcludedProp &&
+            !isStyledSystemProp &&
+            !isHTMLProp &&
+            !isReactProp)
+        );
+      },
+    },
   },
   staticDirs: [
     {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,4 @@
-import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
+import path from 'path';
 import type { StorybookConfig } from '@storybook/react-webpack5';
 
 import { autoScout24System } from 'src/themes';
@@ -63,8 +63,12 @@ const config: StorybookConfig = {
   ],
   webpackFinal: async (webpack) => {
     webpack.resolve = webpack.resolve || {};
-    webpack.resolve.plugins = webpack.resolve.plugins || [];
-    webpack.resolve.plugins.push(new TsconfigPathsPlugin({}));
+    webpack.resolve.modules = [
+      ...(webpack.resolve.modules || []),
+      path.resolve(__dirname, '..'),
+    ];
+    // webpack.resolve.plugins = webpack.resolve.plugins || [];
+    // webpack.resolve.plugins.push(new TsconfigPathsPlugin({}));
     return webpack;
   },
 };

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import type { StorybookConfig } from '@storybook/react-webpack5';
 
-import { autoScout24System } from '../src/themes';
+import { autoScout24System } from 'src/themes';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import type { StorybookConfig } from '@storybook/react-webpack5';
 
 import { autoScout24System } from 'src/themes';
@@ -63,12 +63,8 @@ const config: StorybookConfig = {
   ],
   webpackFinal: async (webpack) => {
     webpack.resolve = webpack.resolve || {};
-    webpack.resolve.modules = [
-      ...(webpack.resolve.modules || []),
-      path.resolve(__dirname, '..'),
-    ];
-    // webpack.resolve.plugins = webpack.resolve.plugins || [];
-    // webpack.resolve.plugins.push(new TsconfigPathsPlugin({}));
+    webpack.resolve.plugins = webpack.resolve.plugins || [];
+    webpack.resolve.plugins.push(new TsconfigPathsPlugin({}));
     return webpack;
   },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,31 +8,24 @@ import {
   themeSwitcherOptions,
   withThemeDecorator,
 } from './preview/ThemeDecorator';
-import { presetColors } from './colorSwatches';
+import { colorControls } from './preview/controls';
 
-const viewports = Object.entries(breakpoints).reduce((acc, [key, value]) => {
-  acc[key] = {
-    name: key,
-    styles: {
-      width: `${value.em}em`,
-      height: '100%',
-    },
-  };
-  return acc;
-}, {});
-
-const colorControl = (arg: string) => ({
-  [arg]: {
-    control: {
-      type: 'color' as const,
-      presetColors,
-    },
-    if: {
-      arg,
-      exists: true,
-    },
+const viewports = Object.entries(breakpoints).reduce(
+  (acc, [key, value]) => {
+    acc[key] = {
+      name: key,
+      styles: {
+        width: `${value.em}em`,
+        height: '100%',
+      },
+    };
+    return acc;
   },
-});
+  {} as Record<
+    string,
+    { name: string; styles: { width: string; height: string } }
+  >,
+);
 
 const preview: Preview = {
   decorators: [withThemeDecorator],
@@ -75,10 +68,7 @@ const preview: Preview = {
         exists: true,
       },
     },
-    ...['color', 'backgroundColor', 'borderColor'].reduce(
-      (acc, arg) => ({ ...acc, ...colorControl(arg) }),
-      {},
-    ),
+    ...colorControls,
   },
   parameters: {
     docs: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,7 +8,7 @@ import {
   themeSwitcherOptions,
   withThemeDecorator,
 } from './preview/ThemeDecorator';
-import { colorControls } from './preview/controls';
+import { colorControls, tokenControls } from './preview/controls';
 
 const viewports = Object.entries(breakpoints).reduce(
   (acc, [key, value]) => {
@@ -68,6 +68,7 @@ const preview: Preview = {
         exists: true,
       },
     },
+    ...tokenControls,
     ...colorControls,
   },
   parameters: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,24 +1,12 @@
 /* eslint-disable unicorn/filename-case */
-import React from 'react';
-import {
-  ensure as ensureTheme,
-  ThemeProvider as StorybookThemeProvider,
-} from '@storybook/theming';
-import { Decorator, Preview } from '@storybook/react';
-import {
-  Box,
-  ChakraProvider,
-  defaultSystem,
-  SystemContext,
-} from '@chakra-ui/react';
+import { Preview } from '@storybook/react';
 
-import {
-  autoScout24System,
-  breakpoints,
-  motoScout24System,
-} from '../src/themes';
-import Fonts from '../src/fonts/Hosted';
+import { breakpoints } from '../src/themes';
 import storybookTheme from './theme';
+import {
+  themeSwitcherOptions,
+  withThemeDecorator,
+} from './preview/ThemeDecorator';
 import { presetColors } from './colorSwatches';
 
 const viewports = Object.entries(breakpoints).reduce((acc, [key, value]) => {
@@ -31,103 +19,6 @@ const viewports = Object.entries(breakpoints).reduce((acc, [key, value]) => {
   };
   return acc;
 }, {});
-
-const themeOptions = [
-  {
-    value: 'autoScout24',
-    title: 'AutoScout24 theme',
-    chakraThemes: [
-      {
-        name: 'AutoScout24',
-        theme: autoScout24System,
-      },
-    ],
-  },
-  {
-    value: 'motoScout24',
-    title: 'MotoScout24 theme',
-    chakraThemes: [
-      {
-        name: 'MotoScout24',
-        theme: motoScout24System,
-      },
-    ],
-  },
-  {
-    value: 'chakra-ui',
-    title: 'Default chakra-ui theme',
-    chakraThemes: [
-      {
-        name: 'Chakra-ui',
-        theme: defaultSystem,
-      },
-    ],
-  },
-  {
-    value: 'autoScout24-chakra-ui',
-    title: 'AutoScout24 side by side with chakra-ui',
-    chakraThemes: [
-      {
-        name: 'AutoScout24',
-        theme: autoScout24System,
-      },
-      {
-        name: 'Chakra-ui',
-        theme: defaultSystem,
-      },
-    ],
-  },
-  {
-    value: 'motoScout24-chakra-ui',
-    title: 'MotoScout24 side by side with chakra-ui',
-    chakraThemes: [
-      {
-        name: 'MotoScout24',
-        theme: motoScout24System,
-      },
-      {
-        name: 'Chakra-ui',
-        theme: defaultSystem,
-      },
-    ],
-  },
-];
-
-const themesByName: Record<
-  string,
-  Array<{ name: string; theme: SystemContext }>
-> = themeOptions.reduce((acc, { value, chakraThemes }) => {
-  acc[value] = chakraThemes;
-  return acc;
-}, {});
-
-const withThemeDecorator: Decorator = (Story, context) => {
-  const storyTheme = context.globals.theme || 'autoScout24';
-  const chakraThemes = themesByName[storyTheme];
-  const themesToShow = chakraThemes.length;
-
-  return (
-    <StorybookThemeProvider theme={ensureTheme(storybookTheme)}>
-      <Fonts />
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          width: '100%',
-        }}
-      >
-        {chakraThemes.map(({ theme, name }, index) => (
-          <div key={index} style={{ width: `${100 / themesToShow}%` }}>
-            <ChakraProvider value={theme}>
-              <Box display={themesToShow === 1 ? 'none' : 'block'}>{name}</Box>
-              <Story />
-            </ChakraProvider>
-          </div>
-        ))}
-      </div>
-    </StorybookThemeProvider>
-  );
-};
 
 const colorControl = (arg: string) => ({
   [arg]: {
@@ -150,7 +41,7 @@ const preview: Preview = {
       defaultValue: 'autoScout24',
       toolbar: {
         icon: 'photo',
-        items: themeOptions,
+        items: themeSwitcherOptions,
       },
     },
   },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable unicorn/filename-case */
 import { Preview } from '@storybook/react';
 
-import { breakpoints } from '../src/themes';
+import { breakpoints } from 'src/themes';
+
 import storybookTheme from './theme';
 import {
   themeSwitcherOptions,

--- a/.storybook/preview/ThemeDecorator.tsx
+++ b/.storybook/preview/ThemeDecorator.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-imports */
 import React from 'react';
 import {
   ensure as ensureTheme,
@@ -12,9 +11,10 @@ import {
   SystemContext,
 } from '@chakra-ui/react';
 
+import { autoScout24System, motoScout24System } from 'src/themes';
+import Fonts from 'src/fonts/Hosted';
+
 import storybookTheme from '../theme';
-import { autoScout24System, motoScout24System } from '../../src/themes';
-import Fonts from '../../src/fonts/Hosted';
 
 export const themeSwitcherOptions = [
   {
@@ -77,13 +77,13 @@ export const themeSwitcherOptions = [
   },
 ];
 
-const themesByName: Record<
-  string,
-  Array<{ name: string; theme: SystemContext }>
-> = themeSwitcherOptions.reduce((acc, { value, chakraThemes }) => {
-  acc[value] = chakraThemes;
-  return acc;
-}, {});
+const themesByName = themeSwitcherOptions.reduce(
+  (acc, { value, chakraThemes }) => {
+    acc[value] = chakraThemes;
+    return acc;
+  },
+  {} as Record<string, Array<{ name: string; theme: SystemContext }>>,
+);
 
 export const withThemeDecorator: Decorator = (Story, context) => {
   const storyTheme = context.globals.theme || 'autoScout24';

--- a/.storybook/preview/ThemeDecorator.tsx
+++ b/.storybook/preview/ThemeDecorator.tsx
@@ -1,0 +1,114 @@
+/* eslint-disable no-restricted-imports */
+import React from 'react';
+import {
+  ensure as ensureTheme,
+  ThemeProvider as StorybookThemeProvider,
+} from '@storybook/theming';
+import { Decorator } from '@storybook/react';
+import {
+  Box,
+  ChakraProvider,
+  defaultSystem,
+  SystemContext,
+} from '@chakra-ui/react';
+
+import storybookTheme from '../theme';
+import { autoScout24System, motoScout24System } from '../../src/themes';
+import Fonts from '../../src/fonts/Hosted';
+
+export const themeSwitcherOptions = [
+  {
+    value: 'autoScout24',
+    title: 'AutoScout24 theme',
+    chakraThemes: [
+      {
+        name: 'AutoScout24',
+        theme: autoScout24System,
+      },
+    ],
+  },
+  {
+    value: 'motoScout24',
+    title: 'MotoScout24 theme',
+    chakraThemes: [
+      {
+        name: 'MotoScout24',
+        theme: motoScout24System,
+      },
+    ],
+  },
+  {
+    value: 'chakra-ui',
+    title: 'Default chakra-ui theme',
+    chakraThemes: [
+      {
+        name: 'Chakra-ui',
+        theme: defaultSystem,
+      },
+    ],
+  },
+  {
+    value: 'autoScout24-chakra-ui',
+    title: 'AutoScout24 side by side with chakra-ui',
+    chakraThemes: [
+      {
+        name: 'AutoScout24',
+        theme: autoScout24System,
+      },
+      {
+        name: 'Chakra-ui',
+        theme: defaultSystem,
+      },
+    ],
+  },
+  {
+    value: 'motoScout24-chakra-ui',
+    title: 'MotoScout24 side by side with chakra-ui',
+    chakraThemes: [
+      {
+        name: 'MotoScout24',
+        theme: motoScout24System,
+      },
+      {
+        name: 'Chakra-ui',
+        theme: defaultSystem,
+      },
+    ],
+  },
+];
+
+const themesByName: Record<
+  string,
+  Array<{ name: string; theme: SystemContext }>
+> = themeSwitcherOptions.reduce((acc, { value, chakraThemes }) => {
+  acc[value] = chakraThemes;
+  return acc;
+}, {});
+
+export const withThemeDecorator: Decorator = (Story, context) => {
+  const storyTheme = context.globals.theme || 'autoScout24';
+  const chakraThemes = themesByName[storyTheme];
+  const themesToShow = chakraThemes.length;
+
+  return (
+    <StorybookThemeProvider theme={ensureTheme(storybookTheme)}>
+      <Fonts />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          width: '100%',
+        }}
+      >
+        {chakraThemes.map(({ theme, name }, index) => (
+          <div key={index} style={{ width: `${100 / themesToShow}%` }}>
+            <ChakraProvider value={theme}>
+              <Box display={themesToShow === 1 ? 'none' : 'block'}>{name}</Box>
+              <Story />
+            </ChakraProvider>
+          </div>
+        ))}
+      </div>
+    </StorybookThemeProvider>
+  );
+};

--- a/.storybook/preview/controls/color.ts
+++ b/.storybook/preview/controls/color.ts
@@ -1,7 +1,8 @@
-import { sharedConfig } from '../src/themes/shared';
-import { autoScout24System, motoScout24System } from '../src/themes';
+import { getSharedConfig } from 'src/themes/shared';
+import { autoScout24System, motoScout24System } from 'src/themes';
 
-export const presetColors = [
+const sharedConfig = getSharedConfig();
+const presetColors = [
   {
     color: autoScout24System.token('colors.brand.100'),
     title: 'AS24.brand.primary',
@@ -10,7 +11,6 @@ export const presetColors = [
     color: motoScout24System.token('colors.brand.400'),
     title: 'MS24.brand.primary',
   },
-
   ...Object.entries(sharedConfig.theme.tokens.colors).map(
     ([colorName, colorToken]) =>
       'value' in colorToken
@@ -21,3 +21,16 @@ export const presetColors = [
           },
   ),
 ];
+
+export const colorControl = (arg: string) => ({
+  [arg]: {
+    control: {
+      type: 'color' as const,
+      presetColors,
+    },
+    if: {
+      arg,
+      exists: true,
+    },
+  },
+});

--- a/.storybook/preview/controls/index.ts
+++ b/.storybook/preview/controls/index.ts
@@ -1,0 +1,6 @@
+import { colorControl } from './color';
+
+export const colorControls = ['color', 'backgroundColor', 'borderColor'].reduce(
+  (acc, arg) => ({ ...acc, ...colorControl(arg) }),
+  {},
+);

--- a/.storybook/preview/controls/index.ts
+++ b/.storybook/preview/controls/index.ts
@@ -1,6 +1,25 @@
+import { tokenControl } from './token';
 import { colorControl } from './color';
 
 export const colorControls = ['color', 'backgroundColor', 'borderColor'].reduce(
   (acc, arg) => ({ ...acc, ...colorControl(arg) }),
   {},
 );
+
+export const tokenControls = [
+  { name: 'zIndex', token: 'zIndex' as const },
+  { name: 'margin', token: 'spacing' as const },
+  { name: 'padding', token: 'spacing' as const },
+  { name: 'gap', token: 'spacing' as const },
+  { name: 'width', token: 'sizes' as const },
+  { name: 'height', token: 'sizes' as const },
+  { name: 'boxShadow', token: 'shadows' as const },
+  { name: 'borderRadius', token: 'radii' as const },
+  { name: 'opacity', token: 'opacity' as const },
+  { name: 'lineHeight', token: 'lineHeights' as const },
+  { name: 'fontWeight', token: 'fontWeights' as const },
+  { name: 'fontSize', token: 'fontSizes' as const },
+  { name: 'colorPalette', token: 'colors' as const },
+  { name: 'border', token: 'borders' as const },
+  { name: 'aspectRatio', token: 'aspectRatios' as const },
+].reduce((acc, arg) => ({ ...acc, ...tokenControl(arg) }), {});

--- a/.storybook/preview/controls/recipe.ts
+++ b/.storybook/preview/controls/recipe.ts
@@ -1,0 +1,53 @@
+import { InputType } from '@storybook/core/types';
+import type { RecipeDefinition, SlotRecipeDefinition } from '@chakra-ui/react';
+
+import { autoScout24System } from 'src';
+
+const getControlsFromRecipe = (
+  recipe: RecipeDefinition | SlotRecipeDefinition,
+) => {
+  if (!recipe) {
+    return {};
+  }
+
+  return Object.entries(recipe.variants || {}).reduce(
+    (acc, [variantProp, variantDefinitions]) => {
+      const variantNames = Object.keys(variantDefinitions);
+      const isBooleanish = variantNames.every((x) =>
+        ['true', 'false'].includes(x),
+      );
+
+      return {
+        ...acc,
+        [variantProp]: isBooleanish
+          ? { control: { type: 'boolean' } }
+          : {
+              control: { type: 'select' },
+              options: variantNames,
+            },
+      };
+    },
+    {},
+  );
+};
+
+const getControlsFromRecipeName = (recipeName: string) =>
+  getControlsFromRecipe(
+    autoScout24System.getRecipe(recipeName) ||
+      autoScout24System.getSlotRecipe(recipeName),
+  );
+
+export function getRecipeControls(key: string): Record<string, InputType>;
+export function getRecipeControls(
+  recipe: RecipeDefinition | SlotRecipeDefinition,
+): Record<string, InputType>;
+
+export function getRecipeControls(
+  arg: string | RecipeDefinition | SlotRecipeDefinition,
+) {
+  if (typeof arg === 'string') {
+    return getControlsFromRecipeName(arg);
+  }
+
+  return getControlsFromRecipe(arg as RecipeDefinition | SlotRecipeDefinition);
+}

--- a/.storybook/preview/controls/token.ts
+++ b/.storybook/preview/controls/token.ts
@@ -1,0 +1,26 @@
+import { SystemConfig } from '@chakra-ui/react';
+
+import { autoScout24System } from 'src/themes';
+
+type Token = keyof NonNullable<NonNullable<SystemConfig['theme']>['tokens']>;
+
+export const tokenControl = ({
+  name: arg,
+  token,
+}: {
+  name: string;
+  token: Token;
+}) => {
+  return {
+    [arg]: {
+      control: { type: 'select' },
+      options: Object.keys(
+        autoScout24System._config.theme?.tokens?.[token] || {},
+      ),
+      if: {
+        arg,
+        exists: true,
+      },
+    },
+  };
+};

--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -1,4 +1,4 @@
-import { create } from '@storybook/core/theming/create';
+import { create } from '@storybook/theming';
 
 export default create({
   base: 'light',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,5 @@
     "types": ["jest", "node", "@testing-library/jest-dom"]
   },
   "exclude": ["dist", "node_modules"],
-  "include": [
-    "src/**/*",
-    ".storybook/**/*",
-  ]
+  "include": ["src/**/*", ".storybook/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
@@ -21,5 +21,8 @@
     "types": ["jest", "node", "@testing-library/jest-dom"]
   },
   "exclude": ["dist", "node_modules"],
-  "include": ["src"]
+  "include": [
+    "src/**/*",
+    ".storybook/**/*",
+  ]
 }


### PR DESCRIPTION
## Motivation and context

This PR adds some improvements to our storybook setup. Namely:

- storybook setup is now included in tsconfig
- better react-docgen configuration => it will now include the custom props defined and documented in chakra-ui. To not overload the props table style- and dom-related- props are excluded by default.
- default controls for colours with colour swatches preset - to make selecting colours easier
  We are limited to 17 swatches so we only select a `.500` variant of each colour, however colour picker support full rgb input
- default controls for common props that leverage design tokens - think `margin`, `gap`, `width` etc. Props that we likely want to expose but don't want to repeat configuration in every single story
- an easy way to generate variant props from the component recipe
  Because of deep unions and supporting responsive styling, react-docgen cannot unwrap the variant values from component types. I added a simple utility function that takes the component recipe (or key used in the theme) and returns controls for all the variants so that we don't need to repeat that code in every component with variations
