### PR TITLE
fix: update link for sellers search

### DIFF
--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -82,10 +82,10 @@ export const footerConfig = ({
             brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: false },
           },
           link: {
-            de: '/de/sellers',
-            en: '/de/sellers',
-            fr: '/fr/sellers',
-            it: '/it/sellers',
+            de: '/de/sellers/search',
+            en: '/de/sellers/search',
+            fr: '/fr/sellers/search',
+            it: '/it/sellers/search',
           },
         },
         {
@@ -94,10 +94,10 @@ export const footerConfig = ({
             brand: { [Brand.AutoScout24]: false, [Brand.MotoScout24]: true },
           },
           link: {
-            de: '/de/sellers',
-            en: '/de/sellers',
-            fr: '/fr/sellers',
-            it: '/it/sellers',
+            de: '/de/sellers/search',
+            en: '/de/sellers/search',
+            fr: '/fr/sellers/search',
+            it: '/it/sellers/search',
           },
         },
         {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -136,10 +136,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.searchMerchant',
           link: {
-            de: '/de/sellers',
-            en: '/de/sellers',
-            fr: '/fr/sellers',
-            it: '/it/sellers',
+            de: '/de/sellers/search',
+            en: '/de/sellers/search',
+            fr: '/fr/sellers/search',
+            it: '/it/sellers/search',
           },
           visibilitySettings: {
             userType: {
@@ -155,10 +155,10 @@ export const drawerNodeItems = ({
         {
           translationKey: 'header.searchMenu.searchMerchant',
           link: {
-            de: '/de/sellers',
-            en: '/de/sellers',
-            fr: '/fr/sellers',
-            it: '/it/sellers',
+            de: '/de/sellers/search',
+            en: '/de/sellers/search',
+            fr: '/fr/sellers/search',
+            it: '/it/sellers/search',
           },
           visibilitySettings: {
             userType: {


### PR DESCRIPTION
References [VSST-3089](https://smg-au.atlassian.net/browse/VSST-3089)

## How to test

- Go to: https://fix-link-sellers-search-listings-web.branch.autoscout24.dev/de
- Header: click on `suchen` and hover on `handler suchen` -> /sellers/search link should be visible 
- Footer: hover on `garagen und handler suchen` -> /sellers/search link should be visible 


[VSST-3089]: https://smg-au.atlassian.net/browse/VSST-3089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ