### PR TITLE
fix: remove old vehicle pool link from user menu

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -352,25 +352,6 @@ export const drawerNodeItems = ({
           },
         },
         {
-          translationKey: 'header.userMenu.myVehcilesOld',
-          link: {
-            de: '/de/member/vehiclepool',
-            en: '/de/member/vehiclepool',
-            fr: '/fr/member/vehiclepool',
-            it: '/it/member/vehiclepool',
-          },
-          visibilitySettings: {
-            userType: {
-              private: false,
-              professional: true,
-            },
-            brand: {
-              autoscout24: true,
-              motoscout24: false,
-            },
-          },
-        },
-        {
           translationKey: 'header.userMenu.myMotorcycles',
           isInternal: true,
           link: {

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -328,7 +328,7 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: true,
-              professional: true,
+              professional: false,
             },
             brand: {
               autoscout24: true,
@@ -336,6 +336,46 @@ export const drawerNodeItems = ({
             },
           },
           projectIdentifier: 'seller-web',
+        },
+        {
+          translationKey: 'header.userMenu.myVehicles',
+          isInternal: true,
+          link: {
+            de: '/de/vehicles',
+            en: '/de/vehicles',
+            fr: '/fr/vehicles',
+            it: '/it/vehicles',
+          },
+          visibilitySettings: {
+            userType: {
+              private: false,
+              professional: true,
+            },
+            brand: {
+              autoscout24: true,
+              motoscout24: false,
+            },
+          },
+        },
+        {
+          translationKey: 'header.userMenu.myMotorcycles',
+          isInternal: true,
+          link: {
+            de: '/de/vehicles',
+            en: '/de/vehicles',
+            fr: '/fr/vehicles',
+            it: '/it/vehicles',
+          },
+          visibilitySettings: {
+            userType: {
+              private: false,
+              professional: true,
+            },
+            brand: {
+              autoscout24: false,
+              motoscout24: true,
+            },
+          },
         },
         {
           translationKey: 'header.userMenu.myMotorcycles',
@@ -348,7 +388,7 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: true,
-              professional: true,
+              professional: false,
             },
             brand: {
               autoscout24: false,

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -328,7 +328,7 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: true,
-              professional: false,
+              professional: true,
             },
             brand: {
               autoscout24: true,
@@ -336,46 +336,6 @@ export const drawerNodeItems = ({
             },
           },
           projectIdentifier: 'seller-web',
-        },
-        {
-          translationKey: 'header.userMenu.myVehicles',
-          isInternal: true,
-          link: {
-            de: '/de/vehicles',
-            en: '/de/vehicles',
-            fr: '/fr/vehicles',
-            it: '/it/vehicles',
-          },
-          visibilitySettings: {
-            userType: {
-              private: false,
-              professional: true,
-            },
-            brand: {
-              autoscout24: true,
-              motoscout24: false,
-            },
-          },
-        },
-        {
-          translationKey: 'header.userMenu.myMotorcycles',
-          isInternal: true,
-          link: {
-            de: '/de/vehicles',
-            en: '/de/vehicles',
-            fr: '/fr/vehicles',
-            it: '/it/vehicles',
-          },
-          visibilitySettings: {
-            userType: {
-              private: false,
-              professional: true,
-            },
-            brand: {
-              autoscout24: false,
-              motoscout24: true,
-            },
-          },
         },
         {
           translationKey: 'header.userMenu.myMotorcycles',
@@ -388,7 +348,7 @@ export const drawerNodeItems = ({
           visibilitySettings: {
             userType: {
               private: true,
-              professional: false,
+              professional: true,
             },
             brand: {
               autoscout24: false,

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -181,7 +181,6 @@
       "marketPriceCheck": "MarketPriceCheck",
       "motorcyclePark": "Zum Motorradpark",
       "myMotorcycles": "Meine Motorräder",
-      "myMotorcyclesOld": "Meine Motorräder (alt)",
       "myVehicles": "Meine Fahrzeuge",
       "onlineAdvertising": "Online Werbung",
       "openingHours": "Öffnungszeiten",

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -182,7 +182,6 @@
       "motorcyclePark": "Zum Motorradpark",
       "myMotorcycles": "Meine Motorräder",
       "myMotorcyclesOld": "Meine Motorräder (alt)",
-      "myVehcilesOld": "Meine Fahrzeuge (alt)",
       "myVehicles": "Meine Fahrzeuge",
       "onlineAdvertising": "Online Werbung",
       "openingHours": "Öffnungszeiten",

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -182,7 +182,6 @@
       "motorcyclePark": "Motorcycle park",
       "myMotorcycles": "My Motorcycles",
       "myMotorcyclesOld": "My Motorcycle (old)",
-      "myVehcilesOld": "My Vehicles (old)",
       "myVehicles": "My Vehicles",
       "onlineAdvertising": "Online Advertising",
       "openingHours": "Opening hours",

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -181,7 +181,6 @@
       "marketPriceCheck": "MarketPriceCheck",
       "motorcyclePark": "Motorcycle park",
       "myMotorcycles": "My Motorcycles",
-      "myMotorcyclesOld": "My Motorcycle (old)",
       "myVehicles": "My Vehicles",
       "onlineAdvertising": "Online Advertising",
       "openingHours": "Opening hours",

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -182,7 +182,6 @@
       "motorcyclePark": "Parc de motos",
       "myMotorcycles": "Mes motos",
       "myMotorcyclesOld": "Mes motos (anc. vue)",
-      "myVehcilesOld": "Mes véhicules (anc. vue)",
       "myVehicles": "Mes véhicules",
       "onlineAdvertising": "Publicité online",
       "openingHours": "Heures d'ouverture",

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -181,7 +181,6 @@
       "marketPriceCheck": "MarketPriceCheck",
       "motorcyclePark": "Parc de motos",
       "myMotorcycles": "Mes motos",
-      "myMotorcyclesOld": "Mes motos (anc. vue)",
       "myVehicles": "Mes véhicules",
       "onlineAdvertising": "Publicité online",
       "openingHours": "Heures d'ouverture",

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -181,7 +181,6 @@
       "marketPriceCheck": "MarketPriceCheck",
       "motorcyclePark": "Parco moto",
       "myMotorcycles": "le mie moto",
-      "myMotorcyclesOld": "le mie moto (lay-out prec.)",
       "myVehicles": "I miei veicoli",
       "onlineAdvertising": "Pubblicità online",
       "openingHours": "Orari di apertura",

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -182,7 +182,6 @@
       "motorcyclePark": "Parco moto",
       "myMotorcycles": "le mie moto",
       "myMotorcyclesOld": "le mie moto (lay-out prec.)",
-      "myVehcilesOld": "I miei veicoli (lay-out prec.)",
       "myVehicles": "I miei veicoli",
       "onlineAdvertising": "Pubblicità online",
       "openingHours": "Orari di apertura",


### PR DESCRIPTION
References:
- [IN-2432](https://smg-au.atlassian.net/browse/IN-2432)
- seller-web [PR](https://github.com/smg-automotive/seller-web/pull/2752)

## Motivation and context

We want to remove old Vehicle Pool link from user menu.

## Before

![Screenshot 2025-01-10 at 14 54 35](https://github.com/user-attachments/assets/4317e809-efee-440b-880f-2bdac06f33d7)

## After

![Screenshot 2025-01-10 at 14 54 20](https://github.com/user-attachments/assets/00a814ec-0302-40bc-950c-77055ad535c3)

## How to test

- Start the project
- Open Navigation -> Header -> Professional
- Old link doesn't exist in user menu (check languages)

[IN-2432]: https://smg-au.atlassian.net/browse/IN-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ