### PR TITLE
fix: adding download icon

### DIFF
--- a/src/components/icons/DownloadIcon.tsx
+++ b/src/components/icons/DownloadIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const DownloadIcon: ComponentWithAs<'svg', IconProps> = createIcon({
+  displayName: 'Download',
+  viewBox: '0 0 24 24',
+  path: (
+    <>
+      <title>Download icon</title>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M16.58 8.59L18 10.01L12 16.01L6 10.01L7.42 8.6L11 12.18V3L13 2V12.18L16.58 8.59ZM19 19V14L21 12V21H3V12H5V19H19Z"
+        fill="currentColor"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -144,3 +144,4 @@ export { DoubleChevronUpIcon } from './DoubleChevronUpIcon';
 export { DoubleChevronDownIcon } from './DoubleChevronDownIcon';
 export { DoubleLineIcon } from './DoubleLineIcon';
 export { NotAvailableSquareIcon } from './NotAvailableSquareIcon';
+export { DownloadIcon } from './DownloadIcon';


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Adding download icon.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

<img width="176" alt="Screenshot 2025-01-14 at 13 59 23" src="https://github.com/user-attachments/assets/1c474792-5903-4bec-a805-030a6f343652" />

## How to test

https://adding-download-icon-components-pkg.branch.autoscout24.dev/?path=/docs/foundations-icons--documentation
