### PR TITLE
fix: change rating stars color

### DIFF
--- a/src/components/rating/index.tsx
+++ b/src/components/rating/index.tsx
@@ -13,7 +13,7 @@ const Rating: FC<Props> = ({ rating, size }) => {
       sx={{
         '--rating': rating.toString(),
         '--percent': 'calc((var(--rating) - 0.16) / 5 * 100%)',
-        '--star-color': 'var(--chakra-colors-gray-900)',
+        '--star-color': 'var(--chakra-colors-orange-300)',
       }}
       display="inline-block"
       fontSize={size === 'large' ? 'md' : 'sm'}


### PR DESCRIPTION
References [JIRA](https://smg-au.atlassian.net/browse/DM-3655)

## Motivation and context

To bring more color and align as well with Google rating stars we want to change the colors of the stars from #gray-900 to #orange-300

## Before

<img width="1040" alt="Screenshot 2025-01-16 at 16 13 29" src="https://github.com/user-attachments/assets/894009d8-7c5a-4d03-9d71-eb8bc679204c" />

## After

<img width="1039" alt="Screenshot 2025-01-16 at 16 13 48" src="https://github.com/user-attachments/assets/9253b1a2-fb8e-45b9-8c54-bf471d785721" />

## How to test

Once PR is merged and version is bumped on dependent projects, make sure that rating stars color is changed.
