### PR TITLE
feat: export separator component

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export * from './heading';
 export * from './icons';
 export * from './link';
 export * from './missingImage';
+export * from './separator';
 export * from './stack';
 export * from './table';
 export * from './themeProvider';


### PR DESCRIPTION
## Motivation and context

Export of the component was missed in: [pull/1263](https://github.com/smg-automotive/components-pkg/pull/1263)
