### PR TITLE
fix: change imports for layout/baseGrid to avoid circular dependencies

### DIFF
--- a/src/components/layout/BaseGrid.tsx
+++ b/src/components/layout/BaseGrid.tsx
@@ -1,6 +1,6 @@
 import React, { FC, PropsWithChildren } from 'react';
 
-import { Grid, type GridProps } from 'src';
+import { Grid, type GridProps } from '../grid';
 
 export const repeatArea = (count: number, area: string) => {
   return new Array(count).fill(area).join(' ');


### PR DESCRIPTION
## Motivation and context

BaseLayout is used in various other layouts and importing must not reference src or any index file to avoid circular dependency issue in the build process.

## Before

Component's dependencies are referencing 'src' in imports.

## After

Component's dependencies are referencing files directly in imports.

## How to test

Run build process or use github's tooling to confirm the build.
