### PR TITLE
fix: only show user info in the user drawer

### DIFF
--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -74,7 +74,7 @@ describe('Header', () => {
     drawerBody = screen.queryByTestId('drawer-body');
     expect(drawerBody).toBeInTheDocument();
   });
-  it('displays user info in the drawer', async () => {
+  it('displays user info in the user drawer', async () => {
     render(
       <Navigation
         environment="preprod"
@@ -103,7 +103,37 @@ describe('Header', () => {
     expect(within(drawerBody).getByText('john.doe@me.com')).toBeInTheDocument();
     expect(within(drawerBody).getByText('(John Doe)')).toBeInTheDocument();
   });
-  it("doesn't displays user name if it's same as email", async () => {
+  it('does not display user name in the search drawer', async () => {
+    render(
+      <Navigation
+        environment="preprod"
+        user={{
+          id: '1',
+          userName: 'john.doe@me.com',
+          userType: MappedUserType.Private,
+          sellerId: '5',
+          sellerIds: ['5'],
+          isImpersonated: false,
+          email: 'john.doe@me.com',
+          exp: 123,
+        }}
+        brand={Brand.AutoScout24}
+        language="en"
+        hasNotification={false}
+        onLogin={jest.fn}
+        onLogout={jest.fn}
+      />,
+    );
+
+    const searchItem = screen.getByText('Search');
+    fireEvent.click(searchItem);
+
+    const drawerBody = screen.getByTestId('drawer-body');
+    expect(
+      within(drawerBody).queryByText('john.doe@me.com', { exact: false }),
+    ).not.toBeInTheDocument();
+  });
+  it("doesn't display user name if it's same as email", async () => {
     render(
       <Navigation
         environment="preprod"

--- a/src/components/navigation/header/drawer/index.tsx
+++ b/src/components/navigation/header/drawer/index.tsx
@@ -44,7 +44,7 @@ export const NavigationDrawer: FC<NavigationDrawerProps> = ({
             templateColumns={{ '2xs': '1fr', md: 'repeat(5, 1fr)' }}
             gridGap={{ md: '3xl' }}
           >
-            <DrawerUserInfo user={user} />
+            {drawer?.current === 'user' ? <DrawerUserInfo user={user} /> : null}
             {drawer?.nodes.map((node, index) => (
               <DrawerMenu key={`node-${index}`} node={node} />
             ))}


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/FED-555

## Motivation and context

When adding user info to the header drawer, we intended to only show it in the user menu. Accidentally it got added to every drawer, this PR fixes the issue.

## Before

<img width="1432" alt="Screenshot 2025-02-14 at 09 48 35" src="https://github.com/user-attachments/assets/e917d224-d0bb-4f1c-a697-e82f7af05a4d" />

## After

<img width="1430" alt="Screenshot 2025-02-14 at 09 48 20" src="https://github.com/user-attachments/assets/36d9ca6e-3ee1-4eec-a3c0-20acf35c5407" />

