### PR TITLE
feat: remove full width tab panel margin

### DIFF
--- a/src/themes/components/tabs.ts
+++ b/src/themes/components/tabs.ts
@@ -81,7 +81,7 @@ const variants = {
   fullWidth: {
     tab: { ...baseStyleTab, flex: 1 },
     tablist: baseStyleTablist,
-    tabpanel: baseStyleTabpanel,
+    tabpanel: { ...baseStyleTabpanel, margin: '0' },
   },
 };
 


### PR DESCRIPTION
References [VSST-3240](https://smg-au.atlassian.net/browse/VSST-3240)

## Motivation and context

The new professional seller info management page information section renders tab panels without any margin. Since the `fullWidth` variant is only used for the professional seller profile page (where we stack margin + padding to achieve the final spacing), I've opted into removing the margin from the variant which will:
1. allow implementing info management page according to design
2. simplify profile page spacing implementation

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]


[VSST-3240]: https://smg-au.atlassian.net/browse/VSST-3240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ