### PR TITLE
chore: fix fonts hosting in storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -31,5 +31,11 @@ const config: StorybookConfig = {
     webpack.resolve.plugins.push(new TsconfigPathsPlugin({}));
     return webpack;
   },
+  staticDirs: [
+    {
+      from: '../src/assets',
+      to: 'assets',
+    },
+  ],
 };
 export default config;


### PR DESCRIPTION
Correctly maps static dirs to host static assets and fonts in storybook

### Before
![Screenshot 2025-02-26 at 16 27 47](https://github.com/user-attachments/assets/a6273d76-f5d8-48c9-ba18-6664989d81ec)

### After
<img width="1420" alt="Screenshot 2025-02-26 at 16 28 15" src="https://github.com/user-attachments/assets/ad5a4b18-687a-462c-b9b2-277e4ffe94e1" />
