### PR TITLE
fix: add professional packages link in footer

### DIFF
--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -228,6 +228,18 @@ export const footerConfig = ({
             it: '/it/products-and-prices',
           },
         },
+        {
+          translationKey: 'footer.sections.list.professionalPackages',
+          visibilitySettings: {
+            brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: false },
+          },
+          link: {
+            de: 'https://b2b.autoscout24.ch/abos/',
+            en: 'https://b2b.autoscout24.ch/abos/',
+            fr: 'https://b2b.autoscout24.ch/fr/abos/',
+            it: 'https://b2b.autoscout24.ch/it/abos/',
+          },
+        },
       ],
     },
     {

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -109,6 +109,7 @@
       "list": {
         "direct": "AutoScout24 Direct",
         "productsAndPrices": "Produkte und Preise",
+        "professionalPackages": "Abos für Händler",
         "title": "Inserieren",
         "vehicles": "Fahrzeuge"
       },

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -109,6 +109,7 @@
       "list": {
         "direct": "AutoScout24 Direct",
         "productsAndPrices": "Products and Prices",
+        "professionalPackages": "Professional packages",
         "title": "Advertise",
         "vehicles": "Vehicles"
       },

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -109,6 +109,7 @@
       "list": {
         "direct": "AutoScout24 Direct",
         "productsAndPrices": "Produits et prix",
+        "professionalPackages": "Packs pour garagistes",
         "title": "Insérer",
         "vehicles": "Véhicules"
       },

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -109,6 +109,7 @@
       "list": {
         "direct": "AutoScout24 Direct",
         "productsAndPrices": "Prodotti e prezzi",
+        "professionalPackages": "Pacchetti per garagisti",
         "title": "Inserire",
         "vehicles": "Veicoli"
       },


### PR DESCRIPTION
[ST-760](https://smg-au.atlassian.net/browse/ST-760?atlOrigin=eyJpIjoiMDU0N2QwMzE2NTZlNDkzY2E5NzRjYTc3MDcxMWY4ZDciLCJwIjoiaiJ9)

## Motivation and context

We would like that dealers who are not yet working with us can find information about working with us. Therefore a link to the professional abos should be visible in the footer

## Before

<img width="181" alt="Screenshot 2025-03-24 at 15 38 24" src="https://github.com/user-attachments/assets/ee7d3009-4df3-4e03-bd19-56c3f57d342e" />

## After

<img width="165" alt="Screenshot 2025-03-24 at 15 37 51" src="https://github.com/user-attachments/assets/9161a7e1-3088-41cb-989f-efa8d8cf8911" />

## How to test

[Add a deep link and instructions how to verify the new behavior]


[ST-760]: https://smg-au.atlassian.net/browse/ST-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ