### PR TITLE
feat: constrain menu content max width

### DIFF
--- a/src/themes/components/menu.ts
+++ b/src/themes/components/menu.ts
@@ -15,6 +15,7 @@ const baseStyleList = defineStyle({
   boxShadow: 'sm',
   color: 'inherit',
   minW: '3xs',
+  maxW: '100vw',
   py: '2',
   zIndex: 'dropdown',
   borderRadius: 'sm',

--- a/src/themes/components/menu.ts
+++ b/src/themes/components/menu.ts
@@ -10,12 +10,14 @@ import { opacity } from '../shared/opacity';
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(parts.keys);
 
+const maximumScrollbarWidth = 20;
+
 const baseStyleList = defineStyle({
   bg: 'white',
   boxShadow: 'sm',
   color: 'inherit',
   minW: '3xs',
-  maxW: '100vw',
+  maxW: `calc(100vw - ${maximumScrollbarWidth}px)`,
   py: '2',
   zIndex: 'dropdown',
   borderRadius: 'sm',


### PR DESCRIPTION
References [VSST-3226](https://smg-au.atlassian.net/browse/VSST-3226)

## Motivation and context

Due to no width constraint of the menu content, it was possible for menu to grow beyond the width of the screen (eg. when a menu item text was wider than the page), resulting in the page layout being broken - it was possible to horizontally scroll the page as seen in the ticket.

## Before

Page layout broken and is horizontally scrollable.

## After

Page layout is not broken and is not horizontally scrollable.

## How to test

- https://fix-320px-layout-overflow-seller-web.branch.autoscout24.dev/fr/features/top-list/manage
- https://fix-320px-layout-overflow-seller-web.branch.autoscout24.dev/fr/features/top-vehicle/manage
- https://fix-320px-layout-overflow-seller-web.branch.autoscout24.dev/fr/vehicle-management
- login with a professional seller
- visit linked pages and set window width to 320px
- ensure the layout is not broken (the page must not be horizontally scrollable even if the sort menu is open)

[VSST-3226]: https://smg-au.atlassian.net/browse/VSST-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ