### PR TITLE
fix: update HCI link in navigation header

### DIFF
--- a/src/components/navigation/header/config/hci.ts
+++ b/src/components/navigation/header/config/hci.ts
@@ -18,4 +18,5 @@ export const hciLinkConfig: NavigationLinkConfigProps = {
       motoscout24: true,
     },
   },
+  projectIdentifier: 'seller-web',
 };

--- a/src/components/navigation/header/config/hci.ts
+++ b/src/components/navigation/header/config/hci.ts
@@ -3,10 +3,10 @@ import { NavigationLinkConfigProps } from './headerLinks';
 export const hciLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.hci',
   link: {
-    de: '/de/member/hci',
-    en: '/de/member/hci',
-    fr: '/fr/member/hci',
-    it: '/it/member/hci',
+    de: '/de/hci-management',
+    en: '/en/hci-management',
+    fr: '/fr/hci-management',
+    it: '/it/hci-management',
   },
   visibilitySettings: {
     userType: {


### PR DESCRIPTION
[DM-3564](https://smg-au.atlassian.net/browse/DM-3564)

## Motivation and context

We already have rewrite worker for '/hci-management' implemented in [terraform-cloudflare](https://github.com/smg-automotive/terraform-cloudflare/blob/ff48c96555c65098349566d61d4397fd7703a104/workers/rewrite-hci-management/src/rewrite-hci-management.ts#L4), and also [redirect](https://github.com/smg-automotive/terraform-cloudflare/blob/ff48c96555c65098349566d61d4397fd7703a104/workers/redirect-hci-management/src/redirect-hci-management.ts) from old url ('member/hci') to the new one. We can keep it for now, because there might be bookmarks in users browsers pointing to the old url.

## Before

HCI link ('member/hci')  redirects to new HCI Seller Page route in seller-web ('/hci-management/')

## After

HCI link pointing directly to '/hci-management'


[DM-3564]: https://smg-au.atlassian.net/browse/DM-3564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ