### PR TITLE
fix: update header info management link

### DIFF
--- a/src/components/navigation/header/config/Presence.tsx
+++ b/src/components/navigation/header/config/Presence.tsx
@@ -7,11 +7,12 @@ import { NavigationLinkConfigProps } from './headerLinks';
 
 export const infoPageLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.infoPage',
+  projectIdentifier: 'seller-web',
   link: {
-    de: '/de/member/dealerpageadmin',
-    en: '/de/member/dealerpageadmin',
-    fr: '/fr/member/dealerpageadmin',
-    it: '/it/member/dealerpageadmin',
+    de: '/de/info-management/hero-image',
+    en: '/en/info-management/hero-image',
+    fr: '/fr/info-management/hero-image',
+    it: '/it/info-management/hero-image',
   },
   visibilitySettings: {
     userType: {


### PR DESCRIPTION
References [VSST-3624](https://smg-au.atlassian.net/browse/VSST-3624)

## Motivation and context

Updated header info management link

## Before

old link -> [cloudflare redirect](https://github.com/smg-automotive/terraform-cloudflare/tree/8cd7f04451f0cee7729b19d2174d0c5f1a1ed082/workers/redirect-legacy-dealer-admin-page) -> new link

## After

new link

## How to test

- https://update-header-info-management-link-components-pkg.branch.autoscout24.dev/?path=/docs/patterns-navigation-header--documentation#professional
- ensure the `InfoPage` header link (under profile drawer) matches cloudflare redirect worker behaviour


[VSST-3624]: https://smg-au.atlassian.net/browse/VSST-3624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ