### PR TITLE
fix: change optimizer link in header

### DIFF
--- a/src/components/navigation/header/config/Optimizer.tsx
+++ b/src/components/navigation/header/config/Optimizer.tsx
@@ -8,10 +8,10 @@ import { NavigationLinkConfigProps } from './headerLinks';
 export const optimizerLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.optimizer',
   link: {
-    de: '/de/member/optimizer',
-    en: '/de/member/optimizer',
-    fr: '/fr/member/optimizer',
-    it: '/it/member/optimizer',
+    de: '/de/vehicle-management?origin=legacy-optimizer',
+    en: '/de/vehicle-management?origin=legacy-optimizer',
+    fr: '/fr/vehicle-management?origin=legacy-optimizer',
+    it: '/it/vehicle-management?origin=legacy-optimizer',
   },
   visibilitySettings: {
     userType: {
@@ -39,10 +39,10 @@ export const optimizerLinkConfig: NavigationLinkConfigProps = {
 export const optimizerProLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.optimizerPro',
   link: {
-    de: '/de/member/optimizerpro',
-    en: '/de/member/optimizerpro',
-    fr: '/fr/member/optimizerpro',
-    it: '/it/member/optimizerpro',
+    de: '/de/vehicle-management?origin=legacy-optimizer',
+    en: '/de/vehicle-management?origin=legacy-optimizer',
+    fr: '/fr/vehicle-management?origin=legacy-optimizer',
+    it: '/it/vehicle-management?origin=legacy-optimizer',
   },
   visibilitySettings: {
     userType: {


### PR DESCRIPTION
[ST-1065](https://smg-au.atlassian.net/browse/ST-1065)

## Motivation and context

Replace optimizer legacy link with the vehicle pool one (we need a query param to display a banner explaining why we land here)

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]


[ST-1065]: https://smg-au.atlassian.net/browse/ST-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ