### PR TITLE
feat: implement color picker component

### DIFF
--- a/src/components/colorPicker/__tests__/ColorPicker.Test.tsx
+++ b/src/components/colorPicker/__tests__/ColorPicker.Test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '.jest/utils';
+
+import ColorPicker from '..';
+
+const renderWrapper = ({
+  onBlur = jest.fn(),
+  onFocus = jest.fn(),
+  onChange = jest.fn(),
+  value = '#FF0000',
+}: Partial<React.ComponentProps<typeof ColorPicker>> = {}) =>
+  render(
+    <ColorPicker
+      onBlur={onBlur}
+      onFocus={onFocus}
+      onChange={onChange}
+      value={value}
+      data-testid="test-colorpicker"
+    />,
+  );
+
+describe('<ColorPicker />', () => {
+  it('renders with given color value', () => {
+    renderWrapper({ value: '#FF0000' });
+
+    const input = screen.getByTestId('test-colorpicker');
+    expect(input).toHaveValue('#ff0000');
+  });
+
+  describe('onFocus', () => {
+    it('is called when focusing the input', () => {
+      const onFocus = jest.fn();
+      renderWrapper({ onFocus });
+
+      const input = screen.getByTestId('test-colorpicker');
+      input.focus();
+
+      expect(onFocus).toHaveBeenCalled();
+    });
+  });
+
+  describe('onBlur', () => {
+    it('is called when de-focusing the input', () => {
+      const onBlur = jest.fn();
+      renderWrapper({ onBlur });
+
+      const input = screen.getByTestId('test-colorpicker');
+      input.focus();
+      input.blur();
+
+      expect(onBlur).toHaveBeenCalled();
+    });
+  });
+
+  describe('onChange', () => {
+    it('is called when the input value changes', () => {
+      const onChange = jest.fn();
+      renderWrapper({ onChange });
+
+      const input = screen.getByTestId('test-colorpicker');
+      fireEvent.change(input, { target: { value: '#00FF00' } });
+
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/colorPicker/index.stories.tsx
+++ b/src/components/colorPicker/index.stories.tsx
@@ -43,6 +43,8 @@ const meta: Meta<typeof ColorPickerComponent> = {
     isDisabled: false,
     border: '1px solid #CBD5E0',
     borderRadius: '4px',
+    width: '36px',
+    padding: '0',
   },
 
   argTypes: {
@@ -59,6 +61,12 @@ const meta: Meta<typeof ColorPickerComponent> = {
       control: 'text',
     },
     borderRadius: {
+      control: 'text',
+    },
+    width: {
+      control: 'text',
+    },
+    padding: {
       control: 'text',
     },
   },

--- a/src/components/colorPicker/index.stories.tsx
+++ b/src/components/colorPicker/index.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { useArgs } from '@storybook/preview-api';
+import { action } from '@storybook/addon-actions';
+import { Box } from '@chakra-ui/react';
+
+import ColorPickerComponent from './index';
+
+const Template = (props: React.ComponentProps<typeof ColorPickerComponent>) => {
+  const [args, updateArgs] = useArgs<typeof props>();
+
+  return (
+    <ColorPickerComponent
+      {...props}
+      {...args}
+      onChange={(e) => {
+        args.onChange?.(e);
+        updateArgs({ value: e.target.value });
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof ColorPickerComponent> = {
+  title: 'Components/Forms/Color Picker',
+  component: ColorPickerComponent,
+  render: Template.bind({}),
+
+  decorators: [
+    (Story) => (
+      <Box w="100%" maxW="250px">
+        <Story />
+      </Box>
+    ),
+  ],
+
+  args: {
+    onBlur: action('onBlur'),
+    onChange: action('onChange'),
+    onFocus: action('onFocus'),
+    value: '#B3D3F3',
+    isInvalid: false,
+    isDisabled: false,
+    border: '1px solid #CBD5E0',
+    borderRadius: '4px',
+  },
+
+  argTypes: {
+    value: {
+      control: 'color',
+    },
+    isInvalid: {
+      control: 'boolean',
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
+    border: {
+      control: 'text',
+    },
+    borderRadius: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+
+export const Overview: StoryObj<typeof ColorPickerComponent> = {};

--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef } from 'react';
+import { Input, InputProps } from '@chakra-ui/react';
+
+const ColorPicker = forwardRef<
+  HTMLInputElement,
+  Pick<
+    InputProps,
+    | 'onFocus'
+    | 'onBlur'
+    | 'onChange'
+    | 'name'
+    | 'value'
+    | 'isInvalid'
+    | 'isDisabled'
+    | 'border'
+    | 'borderRadius'
+  >
+>((props, ref) => {
+  return (
+    <Input
+      {...props}
+      ref={ref}
+      type="color"
+      width="36px"
+      padding="0"
+      cursor="pointer"
+    />
+  );
+});
+
+ColorPicker.displayName = 'ColorPicker';
+
+export default ColorPicker;

--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -6,8 +6,8 @@ const ColorPicker = forwardRef<HTMLInputElement, InputProps>(
     return (
       <Input
         {...props}
-        ref={ref}
         type="color"
+        ref={ref}
         width={width}
         padding={padding}
         cursor="pointer"

--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -1,32 +1,20 @@
 import React, { forwardRef } from 'react';
 import { Input, InputProps } from '@chakra-ui/react';
 
-const ColorPicker = forwardRef<
-  HTMLInputElement,
-  Pick<
-    InputProps,
-    | 'onFocus'
-    | 'onBlur'
-    | 'onChange'
-    | 'name'
-    | 'value'
-    | 'isInvalid'
-    | 'isDisabled'
-    | 'border'
-    | 'borderRadius'
-  >
->((props, ref) => {
-  return (
-    <Input
-      {...props}
-      ref={ref}
-      type="color"
-      width="36px"
-      padding="0"
-      cursor="pointer"
-    />
-  );
-});
+const ColorPicker = forwardRef<HTMLInputElement, InputProps>(
+  ({ width = '36px', padding = '0', ...props }, ref) => {
+    return (
+      <Input
+        {...props}
+        ref={ref}
+        type="color"
+        width={width}
+        padding={padding}
+        cursor="pointer"
+      />
+    );
+  },
+);
 
 ColorPicker.displayName = 'ColorPicker';
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -39,6 +39,7 @@ export { default as GridItem } from './grid/GridItem';
 export { default as Hide } from './hide';
 export { default as Input } from './input';
 export { default as Link } from './link';
+export { default as ColorPicker } from './colorPicker';
 export {
   LinkBox,
   LinkOverlay,


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/VSST-3657

## Motivation and context

We needed a color picker input on the Create Photobar form in the Seller Info Management page.
Since no such component existed in the design system, this PR introduces a minimal, reusable ColorPicker component as a first version — implemented as a wrapper around the native .

## Before

It was not implemented.

## After

<img width="1134" alt="Screenshot 2025-05-28 at 15 11 04" src="https://github.com/user-attachments/assets/0f4c2fab-0c2c-4dbe-bea7-1492649c77e2" />



## How to test

[Add a deep link and instructions how to verify the new behavior]
