### PR TITLE
fix: modal scroll

### DIFF
--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -23,8 +23,8 @@ const baseStyleDialogContainer = defineStyle({
   display: 'flex',
   zIndex: 'modal',
   justifyContent: 'center',
-  alignItems: 'center',
-  overflow: 'hidden',
+  alignItems: 'flex-start',
+  overflow: 'auto',
   overscrollBehaviorY: 'none',
 });
 
@@ -81,8 +81,8 @@ const variants = {
     dialogContainer: {
       ...baseStyle.dialogContainer,
       alignItems: 'flex-start',
-      overflow: 'auto',
       marginTop: '5xl',
+      maxH: 'calc(100vh - var(--chakra-sizes-xl))',
     },
   },
   fullScreen: {
@@ -101,6 +101,7 @@ const variants = {
     body: {
       p: '0',
       flex: '1',
+      overflow: 'auto',
     },
     footer: baseStyleFooter,
     dialog: {


### PR DESCRIPTION
References [link the ticket here]()

## Motivation and context

If content is larger, modal does not show all content.
The API of modal is strange, there is variant prop (fullSize, base, topScroll).
FullSize and base variant does not support content scrolling at all.
TopScroll supports but the end of content is not visible.
This PR is just a fix so user can see entire content (check EquipmetnOverview modal).

I suggest as follow-up ticket to re-define modal API.
In chakra-ui there is option(prop `scrollBehavior`) to scroll conetent outside or inside modal.


[Describe the problem we're solving and lay out the solution]

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
