### PR TITLE
chore: change Assure link href in Header

### DIFF
--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -186,10 +186,6 @@ describe('Header', () => {
       name: 'Meine Fahrzeuge',
       pathname: '/de/vehicle-management',
     };
-    const legacyWebLink = {
-      name: 'Versichern',
-      pathname: '/de/autoversicherung',
-    };
 
     it('should use relative URLs for pages inside listings-web and keep the others absolute', async () => {
       renderNavigation({
@@ -219,16 +215,6 @@ describe('Header', () => {
       expect(isAbsoluteUrl(sellerLink!)).toBe(true);
       expect(sellerLink!).toEqual(
         transformToAbsoluteUrl(sellerWebLink.pathname),
-      );
-      const legacyLink = screen
-        .getAllByRole('link', {
-          name: legacyWebLink.name,
-          hidden: true,
-        })[0]
-        .getAttribute('href');
-      expect(isAbsoluteUrl(legacyLink!)).toBe(true);
-      expect(legacyLink!).toEqual(
-        transformToAbsoluteUrl(legacyWebLink.pathname),
       );
     });
 
@@ -261,16 +247,6 @@ describe('Header', () => {
         .getAttribute('href');
       expect(isAbsoluteUrl(sellerLink!)).toBe(false);
       expect(sellerLink!).toEqual(sellerWebLink.pathname);
-      const legacyLink = screen
-        .getAllByRole('link', {
-          name: legacyWebLink.name,
-          hidden: true,
-        })[0]
-        .getAttribute('href');
-      expect(isAbsoluteUrl(legacyLink!)).toBe(true);
-      expect(legacyLink!).toEqual(
-        transformToAbsoluteUrl(legacyWebLink.pathname),
-      );
     });
   });
 });

--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -186,6 +186,10 @@ describe('Header', () => {
       name: 'Meine Fahrzeuge',
       pathname: '/de/vehicle-management',
     };
+    const legacyWebLink = {
+      name: 'Kontaktanfragen',
+      pathname: '/de/member/messagemanager',
+    };
 
     it('should use relative URLs for pages inside listings-web and keep the others absolute', async () => {
       renderNavigation({
@@ -215,6 +219,16 @@ describe('Header', () => {
       expect(isAbsoluteUrl(sellerLink!)).toBe(true);
       expect(sellerLink!).toEqual(
         transformToAbsoluteUrl(sellerWebLink.pathname),
+      );
+      const legacyLink = screen
+        .getAllByRole('link', {
+          name: legacyWebLink.name,
+          hidden: true,
+        })[0]
+        .getAttribute('href');
+      expect(isAbsoluteUrl(legacyLink!)).toBe(true);
+      expect(legacyLink!).toEqual(
+        transformToAbsoluteUrl(legacyWebLink.pathname),
       );
     });
 
@@ -247,6 +261,16 @@ describe('Header', () => {
         .getAttribute('href');
       expect(isAbsoluteUrl(sellerLink!)).toBe(false);
       expect(sellerLink!).toEqual(sellerWebLink.pathname);
+      const legacyLink = screen
+        .getAllByRole('link', {
+          name: legacyWebLink.name,
+          hidden: true,
+        })[0]
+        .getAttribute('href');
+      expect(isAbsoluteUrl(legacyLink!)).toBe(true);
+      expect(legacyLink!).toEqual(
+        transformToAbsoluteUrl(legacyWebLink.pathname),
+      );
     });
   });
 });

--- a/src/components/navigation/header/config/assure.ts
+++ b/src/components/navigation/header/config/assure.ts
@@ -10,10 +10,10 @@ export const autoScoutAssureLinkConfig = ({
   return {
     translationKey: 'header.assure',
     link: {
-      de: '/de/autoversicherung',
-      en: '/de/autoversicherung',
-      fr: '/fr/assurance-auto',
-      it: '/it/assicurazione-auto',
+      de: 'https://www.financescout24.ch/de/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=insurance_hub_car_',
+      en: 'https://www.financescout24.ch/de/autoversicherung-finden?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=insurance_hub_car_',
+      fr: 'https://www.financescout24.ch/fr/trouver-assurance-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=insurance_hub_car_',
+      it: 'https://www.financescout24.ch/it/trova-assicurazione-auto?utm_source=autoscout24.ch&utm_medium=web&utm_campaign=insurance_hub_car_',
     },
     showUnderMoreLinkBelow: 'lg',
     visibilitySettings: {


### PR DESCRIPTION
Reference: [DM-4455](https://smg-au.atlassian.net/browse/DM-4455) [DM-4480](https://smg-au.atlassian.net/browse/DM-4480)

## Motivation and context

We need to change the url for "Assure" in the Header navigation.

## Before

"Assure" link leads to legacy page on `/autoversicherung `path.

## After

"Assure" link leads to the FinanceScout URLs listed in the [ticket](https://smg-au.atlassian.net/browse/DM-4455) description.

## How to test

Check if the "Assure" link in Header points to the correct FinanceScout URLs.


[DM-4455]: https://smg-au.atlassian.net/browse/DM-4455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DM-4480]: https://smg-au.atlassian.net/browse/DM-4480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ