### PR TITLE
feat: remove change-email link

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -10,7 +10,6 @@ import {
 import { carParkLinkConfig, motorcycleParkLinkConfig } from './vehiclePool';
 import {
   accountSettingsLinkConfig,
-  changeEmailLinkConfig,
   changeLanguageLinkConfig,
   editUsersLinkConfig,
   favoritesLinkConfig,
@@ -170,7 +169,6 @@ const getUserNodeItems = ({
   {
     translationKey: 'header.userMenu.accountSettings',
     items: [
-      changeEmailLinkConfig,
       editUsersLinkConfig,
       accountSettingsLinkConfig,
       changeLanguageLinkConfig,

--- a/src/components/navigation/header/config/user.ts
+++ b/src/components/navigation/header/config/user.ts
@@ -42,26 +42,6 @@ export const favoritesLinkConfig: NavigationLinkConfigProps = {
   projectIdentifier: 'listings-web',
 };
 
-export const changeEmailLinkConfig: NavigationLinkConfigProps = {
-  translationKey: 'header.userMenu.emailAddress',
-  link: {
-    de: '/de/account/change-email',
-    en: '/en/account/change-email',
-    fr: '/fr/account/change-email',
-    it: '/it/account/change-email',
-  },
-  visibilitySettings: {
-    userType: {
-      private: true,
-      professional: true,
-    },
-    brand: {
-      autoscout24: true,
-      motoscout24: true,
-    },
-  },
-};
-
 export const editUsersLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.editUser',
   link: {


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/FED-686

## Motivation and context

Removes the link to the change email feature, feature will be sun set.

## Before

![Screenshot 2025-06-23 at 12 59 02](https://github.com/user-attachments/assets/8b75bc29-599c-4e13-a68b-97e18c53a052)

## After

![Screenshot 2025-06-23 at 13 03 11](https://github.com/user-attachments/assets/bb730a73-ee9b-44c4-8357-8d871706ef36)

## How to test

Ensure link is not present any more
