### PR TITLE
fix: popover white space

### DIFF
--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -20,7 +20,7 @@ export type PopoverProps = PropsWithChildren<
     showArrow?: boolean;
     contentPadding?: ContentPadding;
     maxWidth?: MaxWidth;
-    contentPosition?: 'relative';
+    contentPosition?: 'relative' | 'absolute';
   } & Pick<
     ChakraPopoverProps,
     | 'placement'
@@ -65,7 +65,7 @@ const Popover: FC<PopoverProps> = ({
     >
       <PopoverTrigger>{children}</PopoverTrigger>
       <Portal>
-        <Box zIndex="popover" w="full" h="full" position={contentPosition}>
+        <Box zIndex="popover" position={contentPosition} top="0" left="0">
           <PopoverContent
             borderRadius="sm"
             boxShadow="md"

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -20,7 +20,7 @@ export type PopoverProps = PropsWithChildren<
     showArrow?: boolean;
     contentPadding?: ContentPadding;
     maxWidth?: MaxWidth;
-    contentPosition?: 'relative';
+    contentPosition?: 'relative' | 'absolute';
   } & Pick<
     ChakraPopoverProps,
     | 'placement'

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -20,7 +20,7 @@ export type PopoverProps = PropsWithChildren<
     showArrow?: boolean;
     contentPadding?: ContentPadding;
     maxWidth?: MaxWidth;
-    contentPosition?: 'relative' | 'absolute';
+    contentPosition?: 'relative';
   } & Pick<
     ChakraPopoverProps,
     | 'placement'


### PR DESCRIPTION
[ST-1149](https://smg-au.atlassian.net/browse/ST-1149)

## Motivation and context

We have a white space at the bottom of the Optimizer page.
This is due to the Popover having 'relative' as position. Combined with the use of Portal and `w="full" h="full"`, we have this overlay at the bottom 

## Before

<img width="1489" alt="Screenshot 2025-06-25 at 09 13 49" src="https://github.com/user-attachments/assets/d8cd0d02-aa5f-42ea-b164-4d25faa49f74" />

## After

<img width="1277" alt="Screenshot 2025-06-26 at 09 44 32" src="https://github.com/user-attachments/assets/a6976c12-781e-42a4-b818-7c83bbeba995" />

## How to test

You can test seller web here: https://st-1149-bug-seller-web.branch.autoscout24.dev/de/optimizer/11321654
I tested that all Popover still works as usual. Same with listings-web

Thank you 


[ST-1149]: https://smg-au.atlassian.net/browse/ST-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ