### PR TITLE
fix: seller management links

### DIFF
--- a/src/components/navigation/header/config/Presence.tsx
+++ b/src/components/navigation/header/config/Presence.tsx
@@ -1,3 +1,8 @@
+import React from 'react';
+
+import { Entitlement } from 'src/types/entitlements';
+import { CartIcon } from 'src/components/icons';
+
 import { NavigationLinkConfigProps } from './headerLinks';
 
 export const infoPageLinkConfig: NavigationLinkConfigProps = {
@@ -79,6 +84,16 @@ export const businessImageLinkConfig: NavigationLinkConfigProps = {
       autoscout24: true,
       motoscout24: true,
     },
+  },
+  entitlementConfig: {
+    singleRequiredEntitlement: [Entitlement.BusinessImage],
+    missingEntitlementFallbackLink: {
+      de: '/de/info-management/business-image',
+      en: '/de/info-management/business-image',
+      fr: '/fr/info-management/business-image',
+      it: '/it/info-management/business-image',
+    },
+    missingEntitlementLinkIcon: <CartIcon />,
   },
 };
 

--- a/src/components/navigation/header/config/Presence.tsx
+++ b/src/components/navigation/header/config/Presence.tsx
@@ -51,7 +51,7 @@ export const openingHoursLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.openingHours',
   link: {
     de: '/de/info-management/opening-hours',
-    en: '/de/info-management/opening-hours',
+    en: '/en/info-management/opening-hours',
     fr: '/fr/info-management/opening-hours',
     it: '/it/info-management/opening-hours',
   },
@@ -71,7 +71,7 @@ export const businessImageLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.businessImage',
   link: {
     de: '/de/info-management/business-image',
-    en: '/de/info-management/business-image',
+    en: '/en/info-management/business-image',
     fr: '/fr/info-management/business-image',
     it: '/it/info-management/business-image',
   },
@@ -89,7 +89,7 @@ export const businessImageLinkConfig: NavigationLinkConfigProps = {
     singleRequiredEntitlement: [Entitlement.BusinessImage],
     missingEntitlementFallbackLink: {
       de: '/de/info-management/business-image',
-      en: '/de/info-management/business-image',
+      en: '/en/info-management/business-image',
       fr: '/fr/info-management/business-image',
       it: '/it/info-management/business-image',
     },
@@ -101,7 +101,7 @@ export const photoBarLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.editPhotobar',
   link: {
     de: '/de/info-management/photo-bar',
-    en: '/de/info-management/photo-bar',
+    en: '/en/info-management/photo-bar',
     fr: '/fr/info-management/photo-bar',
     it: '/it/info-management/photo-bar',
   },
@@ -121,7 +121,7 @@ export const qualilogoLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.qualityLogo',
   link: {
     de: '/de/info-management/quali-logo',
-    en: '/de/info-management/quali-logo',
+    en: '/en/info-management/quali-logo',
     fr: '/fr/info-management/quali-logo',
     it: '/it/info-management/quali-logo',
   },

--- a/src/components/navigation/header/config/Presence.tsx
+++ b/src/components/navigation/header/config/Presence.tsx
@@ -1,8 +1,3 @@
-import React from 'react';
-
-import { Entitlement } from 'src/types/entitlements';
-import { CartIcon } from 'src/components/icons';
-
 import { NavigationLinkConfigProps } from './headerLinks';
 
 export const infoPageLinkConfig: NavigationLinkConfigProps = {
@@ -50,10 +45,10 @@ export const contactDetailsLinkConfig: NavigationLinkConfigProps = {
 export const openingHoursLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.openingHours',
   link: {
-    de: '/de/member/businesshours',
-    en: '/de/member/businesshours',
-    fr: '/fr/member/businesshours',
-    it: '/it/member/businesshours',
+    de: '/de/info-management/opening-hours',
+    en: '/de/info-management/opening-hours',
+    fr: '/fr/info-management/opening-hours',
+    it: '/it/info-management/opening-hours',
   },
   visibilitySettings: {
     userType: {
@@ -70,10 +65,10 @@ export const openingHoursLinkConfig: NavigationLinkConfigProps = {
 export const businessImageLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.businessImage',
   link: {
-    de: '/de/member/businessimage',
-    en: '/de/member/businessimage',
-    fr: '/de/member/businessimage',
-    it: '/it/member/businessimage',
+    de: '/de/info-management/business-image',
+    en: '/de/info-management/business-image',
+    fr: '/fr/info-management/business-image',
+    it: '/it/info-management/business-image',
   },
   visibilitySettings: {
     userType: {
@@ -85,25 +80,15 @@ export const businessImageLinkConfig: NavigationLinkConfigProps = {
       motoscout24: true,
     },
   },
-  entitlementConfig: {
-    singleRequiredEntitlement: [Entitlement.BusinessImage],
-    missingEntitlementFallbackLink: {
-      de: '/de/productdescription/as24_businessimage',
-      en: '/de/productdescription/as24_businessimage',
-      fr: '/fr/productdescription/as24_businessimage',
-      it: '/it/productdescription/as24_businessimage',
-    },
-    missingEntitlementLinkIcon: <CartIcon />,
-  },
 };
 
 export const photoBarLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.editPhotobar',
   link: {
-    de: '/de/member/templates/photobar',
-    en: '/de/member/templates/photobar',
-    fr: '/it/member/templates/photobar',
-    it: '/it/member/templates/photobar',
+    de: '/de/info-management/photo-bar',
+    en: '/de/info-management/photo-bar',
+    fr: '/fr/info-management/photo-bar',
+    it: '/it/info-management/photo-bar',
   },
   visibilitySettings: {
     userType: {
@@ -120,10 +105,10 @@ export const photoBarLinkConfig: NavigationLinkConfigProps = {
 export const qualilogoLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.qualityLogo',
   link: {
-    de: '/de/member/qualilogo',
-    en: '/de/member/qualilogo',
-    fr: '/fr/member/qualilogo',
-    it: '/it/member/qualilogo',
+    de: '/de/info-management/quali-logo',
+    en: '/de/info-management/quali-logo',
+    fr: '/fr/info-management/quali-logo',
+    it: '/it/info-management/quali-logo',
   },
   visibilitySettings: {
     userType: {


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/VSST-3728 https://smg-au.atlassian.net/browse/VSST-3630

## Motivation and context

Will check with Bojana do we need bucket icon in case seller does not have business image feature.
<img width="408" height="271" alt="Screenshot 2025-07-16 at 17 06 27" src="https://github.com/user-attachments/assets/6779bdc3-8638-49d7-a6ad-612f2168623d" />
As far as I remember an idea is to have only one link related to seller management in future (e.g. seller management) instead of current info page, business image, photobar, working hours, etc. 
## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
