### PR TITLE
fix: price estimator link

### DIFF
--- a/src/components/navigation/header/config/estimate.ts
+++ b/src/components/navigation/header/config/estimate.ts
@@ -10,10 +10,10 @@ export const estimateLinkConfig = ({
   return {
     translationKey: 'header.estimate',
     link: {
-      de: 'https://my.autoscout24.ch/de/fahrzeugbewertung',
-      en: 'https://my.autoscout24.ch/de/fahrzeugbewertung',
-      fr: 'https://my.autoscout24.ch/fr/evaluation-vehicules',
-      it: 'https://my.autoscout24.ch/it/valuazione-vehicoli',
+      de: '/de/price-estimate',
+      en: '/de/price-estimate',
+      fr: '/fr/price-estimate',
+      it: '/it/price-estimate',
     },
     showUnderMoreLinkBelow: 'sm',
     visibilitySettings: {


### PR DESCRIPTION
[ST-1207](https://smg-au.atlassian.net/browse/ST-1207)

## Motivation and context

We released the new price estimate page, we can then change the link

## Before

Legacy link

## After

New one 

<img width="629" height="140" alt="Screenshot 2025-07-17 at 16 07 00" src="https://github.com/user-attachments/assets/f57b00dc-0f54-4c83-9cb5-4a2a03edbfec" />


[ST-1207]: https://smg-au.atlassian.net/browse/ST-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
