### PR TITLE
fix: remove c2b feature flag

### DIFF
--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -30,11 +30,7 @@ export interface FooterConfigInterface {
   companies: LinkConfig[];
 }
 
-export const footerConfig = ({
-  experiments = {},
-}: {
-  experiments?: Record<string, string>;
-} = {}): FooterConfigInterface => ({
+export const footerConfig = (): FooterConfigInterface => ({
   sections: [
     {
       title: [
@@ -152,58 +148,19 @@ export const footerConfig = ({
         },
       ],
       items: [
-        ...(experiments?.c2b === 'on'
-          ? [
-              {
-                translationKey: 'footer.sections.list.vehicles',
-                visibilitySettings: {
-                  brand: {
-                    [Brand.AutoScout24]: true,
-                    [Brand.MotoScout24]: false,
-                  },
-                },
-                link: {
-                  de: '/de/sell',
-                  en: '/en/sell',
-                  fr: '/fr/sell',
-                  it: '/it/sell',
-                },
-                projectIdentifier: 'seller-web' as const,
-              },
-              {
-                translationKey: 'footer.sections.list.direct',
-                visibilitySettings: {
-                  brand: {
-                    [Brand.AutoScout24]: true,
-                    [Brand.MotoScout24]: false,
-                  },
-                },
-                link: {
-                  de: '/de/direct',
-                  en: '/en/direct',
-                  fr: '/fr/direct',
-                  it: '/it/direct',
-                },
-                projectIdentifier: 'seller-web' as const,
-              },
-            ]
-          : [
-              {
-                translationKey: 'footer.sections.list.vehicles',
-                visibilitySettings: {
-                  brand: {
-                    [Brand.AutoScout24]: true,
-                    [Brand.MotoScout24]: false,
-                  },
-                },
-                link: {
-                  de: '/de/auto-verkaufen',
-                  en: '/de/auto-verkaufen',
-                  fr: '/fr/vendre-voiture',
-                  it: '/it/vendere-auto',
-                },
-              },
-            ]),
+        {
+          translationKey: 'footer.sections.list.vehicles',
+          visibilitySettings: {
+            brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: false },
+          },
+          link: {
+            de: '/de/sell',
+            en: '/en/sell',
+            fr: '/fr/sell',
+            it: '/it/sell',
+          },
+          projectIdentifier: 'seller-web' as const,
+        },
         {
           translationKey: 'footer.sections.list.vehicles',
           visibilitySettings: {
@@ -215,6 +172,19 @@ export const footerConfig = ({
             fr: '/fr/insertion/identify',
             it: '/it/insertion/identify',
           },
+        },
+        {
+          translationKey: 'footer.sections.list.direct',
+          visibilitySettings: {
+            brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: false },
+          },
+          link: {
+            de: '/de/direct',
+            en: '/en/direct',
+            fr: '/fr/direct',
+            it: '/it/direct',
+          },
+          projectIdentifier: 'seller-web' as const,
         },
         {
           translationKey: 'footer.sections.list.productsAndPrices',

--- a/src/components/navigation/footer/index.tsx
+++ b/src/components/navigation/footer/index.tsx
@@ -27,7 +27,6 @@ interface FooterProps {
   environment?: Environment;
   useAbsoluteUrls?: boolean;
   project?: Project;
-  experiments?: Record<string, string>;
 }
 
 const Footer: FC<FooterProps> = ({
@@ -36,18 +35,17 @@ const Footer: FC<FooterProps> = ({
   environment,
   useAbsoluteUrls,
   project,
-  experiments = {},
 }) => {
   const config = useMemo(() => {
     const footerConfigInstance = new FooterConfig({
-      config: footerConfig({ experiments }),
+      config: footerConfig(),
       brand,
       environment,
       useAbsoluteUrls,
       project,
     });
     return footerConfigInstance.getMappedConfig();
-  }, [brand, environment, useAbsoluteUrls, project, experiments]);
+  }, [brand, environment, useAbsoluteUrls, project]);
 
   return (
     <TranslationProvider language={language} scopes={['footer']}>


### PR DESCRIPTION
References [PS-628](https://smg-au.atlassian.net/browse/PS-628)

## Motivation and context

There is no need to keep the featureFlag c2b in splitIO and code. 100% users sees the c2b.

## Before

Feature flag is in the code.

## After

Feature flag is removed from the code.

## Note

Merging this in branch 23.x.

## How to test

[Add a deep link and instructions how to verify the new behavior]


[PS-628]: https://smg-au.atlassian.net/browse/PS-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ