### PR TITLE
fix(temp): Conditionally hide tenant selection header menu

### DIFF
--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -27,6 +27,7 @@ const renderNavigation = ({
   selectTenant = jest.fn(() => Promise.resolve()),
   useAbsoluteUrls,
   project,
+  showTenantSelection,
 }: Partial<NavigationProps>) =>
   render(
     <Navigation
@@ -40,6 +41,7 @@ const renderNavigation = ({
       selectTenant={selectTenant}
       useAbsoluteUrls={useAbsoluteUrls}
       project={project}
+      showTenantSelection={showTenantSelection}
     />,
   );
 
@@ -146,6 +148,35 @@ describe('Header', () => {
     });
 
     expect(selectTenant).toHaveBeenCalledWith(6002);
+  });
+
+  it('should show tenant selection menu when showTenantSelection is true', () => {
+    renderNavigation({
+      user: multiTenantUser(),
+      showTenantSelection: true,
+    });
+
+    const tenantSelectionMenu = screen.getByText('Garage Amir Zurich');
+    expect(tenantSelectionMenu).toBeInTheDocument();
+  });
+
+  it('should hide tenant selection menu when showTenantSelection is false', () => {
+    renderNavigation({
+      user: multiTenantUser(),
+      showTenantSelection: false,
+    });
+
+    const tenantSelectionMenu = screen.queryByText('Garage Amir Zurich');
+    expect(tenantSelectionMenu).not.toBeInTheDocument();
+  });
+
+  it('should show tenant selection menu by default when showTenantSelection is not provided', () => {
+    renderNavigation({
+      user: multiTenantUser(),
+    });
+
+    const tenantSelectionMenu = screen.getByText('Garage Amir Zurich');
+    expect(tenantSelectionMenu).toBeInTheDocument();
   });
 
   it('does not display user name in the search drawer', async () => {

--- a/src/components/navigation/header/index.stories.tsx
+++ b/src/components/navigation/header/index.stories.tsx
@@ -77,6 +77,7 @@ const meta: Meta<typeof Navigation> = {
     trackEvent: action('track navigation item click'),
     comparisonItemIds: [1, 2, 3],
     selectTenant: async (id) => action('select tenant')(id),
+    showTenantSelection: true,
     experiments: {
       leasing: 'on',
     },
@@ -153,6 +154,26 @@ export const ProfessionalWithMultiTenancy: StoryType = {
 export const Private: StoryType = {
   args: {
     user: privateUser(),
+    experiments: {
+      leasing: 'on',
+    },
+  },
+};
+
+export const ProfessionalWithTenantSelectionHidden: StoryType = {
+  args: {
+    user: multiTenantUser({
+      managedSellers: new Array(100).fill(null).map((_, index) => ({
+        id: 6000 + index,
+        billingAddress: null,
+        billingCity: 'Zurich',
+        billingCountryCode: null,
+        billingName: `Garage Amir ${index}`,
+        billingPostOfficeBox: null,
+        billingZipCode: (8000 + index).toString(),
+      })),
+    }),
+    showTenantSelection: false,
     experiments: {
       leasing: 'on',
     },

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -40,6 +40,7 @@ export interface NavigationProps {
   project?: Project;
   user: EnrichedSessionUser | null;
   selectTenant: (sellerId: number | string) => Promise<void>;
+  showTenantSelection?: boolean;
 }
 
 const Navigation: FC<NavigationProps> = ({
@@ -55,6 +56,7 @@ const Navigation: FC<NavigationProps> = ({
   project,
   user,
   selectTenant,
+  showTenantSelection = true,
   experiments = {},
 }) => {
   const config = useMemo(() => {
@@ -155,7 +157,9 @@ const Navigation: FC<NavigationProps> = ({
               hasNotification={hasNotification}
               onLogin={onLogin}
             />
-            <NavigationTenantMenu user={user} selectTenant={selectTenant} />
+            {showTenantSelection ? (
+              <NavigationTenantMenu user={user} selectTenant={selectTenant} />
+            ) : null}
             <NavigationLanguageMenu activeLanguage={language} />
             <MobileHeaderMenuToggle
               isOpen={isOpen}


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/FED-781

## Motivation and context

Adds a boolean prop to conditionally hide the tenant selection menu in the project. It's a temporary fix until we develop a mechanism to synchronise selected tenant between the projects