### PR TITLE
fix: hide mobile tenant selection

### DIFF
--- a/src/components/navigation/header/drawer/index.tsx
+++ b/src/components/navigation/header/drawer/index.tsx
@@ -23,7 +23,7 @@ interface NavigationDrawerProps {
   onLogin: () => void;
   onLogout: () => void;
   selectTenant: (sellerId: number | string) => Promise<void>;
-  showTenantSelection?: boolean;
+  showTenantSelection: boolean;
 }
 
 export const NavigationDrawer: FC<NavigationDrawerProps> = ({

--- a/src/components/navigation/header/drawer/index.tsx
+++ b/src/components/navigation/header/drawer/index.tsx
@@ -23,6 +23,7 @@ interface NavigationDrawerProps {
   onLogin: () => void;
   onLogout: () => void;
   selectTenant: (sellerId: number | string) => Promise<void>;
+  showTenantSelection?: boolean;
 }
 
 export const NavigationDrawer: FC<NavigationDrawerProps> = ({
@@ -34,6 +35,7 @@ export const NavigationDrawer: FC<NavigationDrawerProps> = ({
   onLogin,
   onLogout,
   selectTenant,
+  showTenantSelection,
 }) => {
   return (
     <Drawer isOpen={isOpen} placement="top" onClose={onClose}>
@@ -67,7 +69,11 @@ export const NavigationDrawer: FC<NavigationDrawerProps> = ({
             {[DrawerNode.User, DrawerNode.Combined].includes(
               drawer?.current as DrawerNode,
             ) ? (
-              <DrawerUserInfo user={user} selectTenant={selectTenant} />
+              <DrawerUserInfo
+                user={user}
+                selectTenant={selectTenant}
+                showTenantSelection={showTenantSelection}
+              />
             ) : null}
             {drawer?.nodes.map((node, index) => (
               <DrawerMenu key={`node-${index}`} node={node} />

--- a/src/components/navigation/header/drawer/userInfo/index.tsx
+++ b/src/components/navigation/header/drawer/userInfo/index.tsx
@@ -12,9 +12,14 @@ import SelectedTenantInfo from './SelectedTenantInfo';
 type Props = {
   user: EnrichedSessionUser | null;
   selectTenant: (sellerId: number | string) => Promise<void>;
+  showTenantSelection?: boolean;
 };
 
-const DrawerUserInfo: FC<Props> = ({ user, selectTenant }) => {
+const DrawerUserInfo: FC<Props> = ({
+  user,
+  selectTenant,
+  showTenantSelection,
+}) => {
   if (!user) return null;
 
   const selectedTenant = user.managedSellers?.find(
@@ -56,7 +61,7 @@ const DrawerUserInfo: FC<Props> = ({ user, selectTenant }) => {
             ) : null}
           </Stack>
         </Stack>
-        {selectedTenant ? (
+        {selectedTenant && showTenantSelection ? (
           <>
             <Show above="md">
               <SelectedTenantInfo selectedTenant={selectedTenant} />

--- a/src/components/navigation/header/drawer/userInfo/index.tsx
+++ b/src/components/navigation/header/drawer/userInfo/index.tsx
@@ -12,7 +12,7 @@ import SelectedTenantInfo from './SelectedTenantInfo';
 type Props = {
   user: EnrichedSessionUser | null;
   selectTenant: (sellerId: number | string) => Promise<void>;
-  showTenantSelection?: boolean;
+  showTenantSelection: boolean;
 };
 
 const DrawerUserInfo: FC<Props> = ({

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -170,6 +170,7 @@ const Navigation: FC<NavigationProps> = ({
       </Box>
       <NavigationDrawer
         user={user}
+        showTenantSelection={showTenantSelection}
         drawer={drawer}
         isOpen={isOpen}
         onClose={onClose}


### PR DESCRIPTION
References: QA feedback

## Motivation and context

Tenant selection in listings web is still visible on mobile