### PR TITLE
feat: added Forward icon

### DIFF
--- a/src/components/icons/ForwardIcon.tsx
+++ b/src/components/icons/ForwardIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentWithAs } from '@chakra-ui/system';
+import { createIcon, IconProps } from '@chakra-ui/react';
+
+export const ForwardIcon: ComponentWithAs<'svg', IconProps> = createIcon({
+  displayName: 'ForwardIcon',
+  viewBox: '0 0 24 24',
+  path: (
+    <>
+      <title>Forward icon</title>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M2 9.54L10 14L14.44 22L22 2L2 9.54ZM14.12 17.31L12 13.42L14.41 11L13 9.59L10.58 12L6.69 9.88L18.58 5.42L14.12 17.31Z"
+        fill="currentColor"
+      />
+    </>
+  ),
+  defaultProps: {
+    boxSize: 'sm',
+  },
+});

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -162,3 +162,4 @@ export { ScreenIcon } from './ScreenIcon';
 export { QualitySealIcon } from './QualitySealIcon';
 export { ExpandIcon } from './ExpandIcon';
 export { CollapseIcon } from './CollapseIcon';
+export { ForwardIcon } from './ForwardIcon';


### PR DESCRIPTION
[ST-1279](https://smg-au.atlassian.net/jira/software/projects/ST/boards/1109?jql=assignee%20%3D%20712020%3A7b8fcbea-c829-48f9-ac8e-a01a9c310984&selectedIssue=ST-1279)

## Motivation and context

For the purpose of creating UI for lead message basic info, we need to add Forward icon to the list.

## Before

N/A

## After

<img width="161" height="88" alt="forward_icon" src="https://github.com/user-attachments/assets/18b8c879-10bf-44b9-aaa9-e9e18bd28bf6" />

## How to test

[Preview link](https://feat-st-1279-leads-message-basic-info-ui-components-pkg.branch.autoscout24.dev/?path=/docs/foundations-icons--documentation)

[ST-1279]: https://smg-au.atlassian.net/browse/ST-1279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ