### PR TITLE
fix: unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   clearMocks: true,
   collectCoverage: false,
   errorOnDeprecated: true,


### PR DESCRIPTION
Unit tests are failing and we have this error
```
Error: Jest: Failed to parse the TypeScript config file /home/circleci/project/jest.config.ts
  ReferenceError: require is not defined in ES module scope, you can use import instead
    at readConfigFileAndSetRootDir (/home/circleci/project/node_modules/jest-config/build/index.js:2269:13)
    at async readInitialOptions (/home/circleci/project/node_modules/jest-config/build/index.js:1147:13)
    at async readConfig (/home/circleci/project/node_modules/jest-config/build/index.js:918:7)
    at async readConfigs (/home/circleci/project/node_modules/jest-config/build/index.js:1168:26)
    at async runCLI (/home/circleci/project/node_modules/@jest/core/build/index.js:1393:7)
    at async Object.run (/home/circleci/project/node_modules/jest-cli/build/index.js:656:9)

Exited with code exit status 1
```

it looks like we can not use require anymore in our `jest.config.ts`
