### PR TITLE
fix: remove motorcycle make index page from footer

### DIFF
--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -87,18 +87,6 @@ export const footerConfig = (): FooterConfigInterface => ({
           },
         },
         {
-          translationKey: 'footer.sections.brand.makes',
-          visibilitySettings: {
-            brand: { [Brand.AutoScout24]: false, [Brand.MotoScout24]: true },
-          },
-          link: {
-            de: '/de/motorrad-marken',
-            en: '/de/motorrad-marken',
-            fr: '/fr/marques-motos',
-            it: '/it/marche-moto',
-          },
-        },
-        {
           translationKey: 'footer.sections.brand.models',
           visibilitySettings: {
             brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: false },


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-4645

## Motivation and context

There are no new SEO pages for motorcycles and with the shutdown of responsive, this page is no longer existing