### PR TITLE
fix: Bookmark icon size and path fix.

### DIFF
--- a/src/components/icons/BookmarkIcon.tsx
+++ b/src/components/icons/BookmarkIcon.tsx
@@ -4,15 +4,15 @@ import { createIcon, IconProps } from '@chakra-ui/react';
 
 export const BookmarkIcon: ComponentWithAs<'svg', IconProps> = createIcon({
   displayName: 'Bookmark',
-  viewBox: '0 0 12 20',
+  viewBox: '0 0 24 24',
   path: (
     <>
       <title>Bookmark icon</title>
       <path
         fill="currentColor"
-        d="m10 14.99-4-4-4 4v-13h10v-2H0v20l6-6 6 6v-17l-2 1z"
+        d="m16 17-4-4-4 4V4h10V2H6v20l6-6 6 6V5l-2 1z"
       />
-      <path d="M12-.01H0v20l6-6 6 6z" />
+      <path d="M18 1.99H6v20l6-6 6 6z" />
     </>
   ),
   defaultProps: {


### PR DESCRIPTION
## Motivation and context

Change in size of bookmark icon.

## Before

<img width="156" height="85" alt="Screenshot 2025-08-18 at 17 11 19" src="https://github.com/user-attachments/assets/3c883890-418d-46c3-bd31-c6b4cad55c08" />

## After

<img width="156" height="85" alt="Screenshot 2025-08-18 at 17 11 25" src="https://github.com/user-attachments/assets/48d23612-9be1-43ad-8d80-6105d0dfa35f" />

## How to test

- Bookmark icon still renders correctly.