### PR TITLE
feat: add favorites link icon to navigation header

### DIFF
--- a/src/components/navigation/header/FavoritesItem.tsx
+++ b/src/components/navigation/header/FavoritesItem.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+import { useI18n } from '@smg-automotive/i18n-pkg';
+import { chakra } from '@chakra-ui/react';
+
+import { HeartIcon } from 'src/components/icons';
+import { Link } from '../link';
+
+type Props = {
+  link: Link;
+};
+
+const FavoritesItem: FC<Props> = ({ link }) => {
+  const { t, language } = useI18n();
+
+  return (
+    <chakra.a
+      position="relative"
+      href={link.link?.[language]}
+      onClick={link.onClick}
+      aria-label={t(link.translationKey ?? '')}
+      mr="15px"
+    >
+      <HeartIcon color="gray.900" />
+    </chakra.a>
+  );
+};
+
+export default FavoritesItem;

--- a/src/components/navigation/header/FavoritesItem.tsx
+++ b/src/components/navigation/header/FavoritesItem.tsx
@@ -19,7 +19,6 @@ const FavoritesItem: FC<Props> = ({ link }) => {
       href={link.link?.[language]}
       onClick={link.onClick}
       aria-label={t(link.translationKey ?? '')}
-      mr="15px"
     >
       <HeartIcon color="gray.900" />
     </chakra.a>

--- a/src/components/navigation/header/FavoritesItem.tsx
+++ b/src/components/navigation/header/FavoritesItem.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '@smg-automotive/i18n-pkg';
 import { chakra } from '@chakra-ui/react';
 
 import { HeartIcon } from 'src/components/icons';
+
 import { Link } from '../link';
 
 type Props = {

--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -214,6 +214,21 @@ describe('Header', () => {
     expect(notification).toBeInTheDocument();
   });
 
+  it('should not display favorites icon if there is no user', async () => {
+    renderNavigation({ user: null });
+
+    const favorites = screen.queryByText('Heart icon');
+    expect(favorites).not.toBeInTheDocument();
+  });
+
+  it('should display favorites icon if there is a user', async () => {
+    const email = 'john.doe@me.com';
+    renderNavigation({ user: privateUser({ email }) });
+
+    const favorites = screen.getByText('Heart icon');
+    expect(favorites).toBeInTheDocument();
+  });
+
   describe('getMappedConfig', () => {
     it('returns a mapped instance', () => {
       const headerConfigInstance = new HeaderNavigationConfig({
@@ -235,7 +250,7 @@ describe('Header', () => {
       expect(config).toEqual({
         drawerItems: expect.any(Object),
         headerItems: expect.any(Object),
-        iconItems: { comparison: null },
+        iconItems: { comparison: null, favorites: null },
         homeUrl: expect.any(String),
         menuHeight: expect.any(String),
         user: expect.any(Object),

--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -11,6 +11,7 @@ import { Brand } from 'src/types/brand';
 import { act, fireEvent, render, screen, within } from '.jest/utils';
 
 import { iconItems } from '../config/iconItems';
+import { HeaderNavigationLink } from '../config/headerNavigationLink';
 import { HeaderNavigationConfig } from '../config/HeaderNavigationConfig';
 import { headerLinks } from '../config/headerLinks';
 import { drawerNodeItems } from '../config/DrawerNodeItems';
@@ -250,7 +251,10 @@ describe('Header', () => {
       expect(config).toEqual({
         drawerItems: expect.any(Object),
         headerItems: expect.any(Object),
-        iconItems: { comparison: null, favorites: null },
+        iconItems: {
+          comparison: null,
+          favorites: expect.any(HeaderNavigationLink),
+        },
         homeUrl: expect.any(String),
         menuHeight: expect.any(String),
         user: expect.any(Object),

--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -11,7 +11,7 @@ import { carParkLinkConfig, motorcycleParkLinkConfig } from './vehiclePool';
 import {
   changeLanguageLinkConfig,
   editUsersLinkConfig,
-  favoritesLinkConfig,
+  getFavoritesLinkConfig,
   getLogoutLinkConfig,
   savedSearchesLinkConfig,
 } from './user';
@@ -156,7 +156,10 @@ const getUserNodeItems = ({
     translationKey: 'header.userMenu.toolsForPurchasing',
     items: [
       savedSearchesLinkConfig,
-      favoritesLinkConfig,
+      getFavoritesLinkConfig({
+        trackEvent,
+        eventLabel: 'drawer-user',
+      }),
       ...getComparisonNodeItem({
         comparisonItemIds,
         trackEvent,

--- a/src/components/navigation/header/config/iconItems.ts
+++ b/src/components/navigation/header/config/iconItems.ts
@@ -3,8 +3,8 @@ import { CustomEvent, navigationEventCategory } from 'src/types/tracking';
 import { Link, LinkConfig } from 'src/components/navigation/link';
 
 import { shouldShowComparisonLink } from '../ComparisonItem';
-import { comparisonLinkConfig } from './comparison';
 import { favoritesLinkConfig } from './user';
+import { comparisonLinkConfig } from './comparison';
 
 export type IconItems = 'comparison' | 'favorites';
 export type IconItemsConfig = Record<IconItems, LinkConfig | null>;

--- a/src/components/navigation/header/config/iconItems.ts
+++ b/src/components/navigation/header/config/iconItems.ts
@@ -3,7 +3,7 @@ import { CustomEvent, navigationEventCategory } from 'src/types/tracking';
 import { Link, LinkConfig } from 'src/components/navigation/link';
 
 import { shouldShowComparisonLink } from '../ComparisonItem';
-import { favoritesLinkConfig } from './user';
+import { getFavoritesLinkConfig } from './user';
 import { comparisonLinkConfig } from './comparison';
 
 export type IconItems = 'comparison' | 'favorites';
@@ -12,11 +12,9 @@ export type IconItemsLinks = Record<IconItems, Link | null>;
 
 export const iconItems = ({
   comparisonItemIds,
-  isLoggedIn,
   trackEvent,
 }: {
   comparisonItemIds?: number[] | null;
-  isLoggedIn?: boolean;
   trackEvent?: (event: CustomEvent) => void;
 }): IconItemsConfig => ({
   comparison: shouldShowComparisonLink(comparisonItemIds)
@@ -30,15 +28,8 @@ export const iconItems = ({
           }),
       }
     : null,
-  favorites: isLoggedIn
-    ? {
-        ...favoritesLinkConfig,
-        onClick: () =>
-          trackEvent?.({
-            eventCategory: navigationEventCategory,
-            eventAction: 'open_favorites',
-            eventLabel: 'icon',
-          }),
-      }
-    : null,
+  favorites: getFavoritesLinkConfig({
+    trackEvent,
+    eventLabel: 'icon',
+  }),
 });

--- a/src/components/navigation/header/config/iconItems.ts
+++ b/src/components/navigation/header/config/iconItems.ts
@@ -4,16 +4,19 @@ import { Link, LinkConfig } from 'src/components/navigation/link';
 
 import { shouldShowComparisonLink } from '../ComparisonItem';
 import { comparisonLinkConfig } from './comparison';
+import { favoritesLinkConfig } from './user';
 
-export type IconItems = 'comparison';
+export type IconItems = 'comparison' | 'favorites';
 export type IconItemsConfig = Record<IconItems, LinkConfig | null>;
 export type IconItemsLinks = Record<IconItems, Link | null>;
 
 export const iconItems = ({
   comparisonItemIds,
+  isLoggedIn,
   trackEvent,
 }: {
   comparisonItemIds?: number[] | null;
+  isLoggedIn?: boolean;
   trackEvent?: (event: CustomEvent) => void;
 }): IconItemsConfig => ({
   comparison: shouldShowComparisonLink(comparisonItemIds)
@@ -23,6 +26,17 @@ export const iconItems = ({
           trackEvent?.({
             eventCategory: navigationEventCategory,
             eventAction: 'open_comparison_tool',
+            eventLabel: 'icon',
+          }),
+      }
+    : null,
+  favorites: isLoggedIn
+    ? {
+        ...favoritesLinkConfig,
+        onClick: () =>
+          trackEvent?.({
+            eventCategory: navigationEventCategory,
+            eventAction: 'open_favorites',
             eventLabel: 'icon',
           }),
       }

--- a/src/components/navigation/header/config/user.ts
+++ b/src/components/navigation/header/config/user.ts
@@ -1,4 +1,5 @@
 import { CustomEvent, navigationEventCategory } from 'src/types/tracking';
+
 import { NavigationLinkConfigProps } from './headerLinks';
 
 export const savedSearchesLinkConfig: NavigationLinkConfigProps = {

--- a/src/components/navigation/header/config/user.ts
+++ b/src/components/navigation/header/config/user.ts
@@ -1,3 +1,4 @@
+import { CustomEvent, navigationEventCategory } from 'src/types/tracking';
 import { NavigationLinkConfigProps } from './headerLinks';
 
 export const savedSearchesLinkConfig: NavigationLinkConfigProps = {
@@ -7,27 +8,6 @@ export const savedSearchesLinkConfig: NavigationLinkConfigProps = {
     en: '/de/me/saved-searches',
     fr: '/fr/me/saved-searches',
     it: '/it/me/saved-searches',
-  },
-  visibilitySettings: {
-    userType: {
-      private: true,
-      professional: true,
-    },
-    brand: {
-      autoscout24: true,
-      motoscout24: true,
-    },
-  },
-  projectIdentifier: 'listings-web',
-};
-
-export const favoritesLinkConfig: NavigationLinkConfigProps = {
-  translationKey: 'header.userMenu.bookmarks',
-  link: {
-    de: '/de/me/favorites',
-    en: '/de/me/favorites',
-    fr: '/fr/me/favorites',
-    it: '/it/me/favorites',
   },
   visibilitySettings: {
     userType: {
@@ -81,6 +61,40 @@ export const changeLanguageLinkConfig: NavigationLinkConfigProps = {
     },
   },
 };
+
+export const getFavoritesLinkConfig = ({
+  trackEvent,
+  eventLabel,
+}: {
+  trackEvent?: (event: CustomEvent) => void;
+  eventLabel?: string;
+}): NavigationLinkConfigProps => ({
+  translationKey: 'header.userMenu.bookmarks',
+  link: {
+    de: '/de/me/favorites',
+    en: '/de/me/favorites',
+    fr: '/fr/me/favorites',
+    it: '/it/me/favorites',
+  },
+  visibilitySettings: {
+    userType: {
+      private: true,
+      professional: true,
+      guest: false,
+    },
+    brand: {
+      autoscout24: true,
+      motoscout24: true,
+    },
+  },
+  projectIdentifier: 'listings-web',
+  onClick: () =>
+    trackEvent?.({
+      eventCategory: navigationEventCategory,
+      eventAction: 'open_favorites',
+      eventLabel,
+    }),
+});
 
 export const getLogoutLinkConfig = ({
   onLogout,

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -144,7 +144,7 @@ const Navigation: FC<NavigationProps> = ({
             language={language}
           />
           <Stack direction="row" spacing="2xl" align="center">
-            {config.iconItems.favorites ? (
+            {config.iconItems.favorites?.isVisible ? (
               <FavoritesItem link={config.iconItems.favorites} />
             ) : null}
             {config.iconItems.comparison ? (

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -18,13 +18,13 @@ import { NavigationItems } from './NavigationItems';
 import { NavigationAvatar } from './NavigationAvatar';
 import MobileHeaderMenuToggle from './MobileMenuToggle';
 import { useNavigationDrawer } from './hooks/useNavigationDrawer';
+import FavoritesItem from './FavoritesItem';
 import { NavigationDrawer } from './drawer';
 import { iconItems } from './config/iconItems';
 import { HeaderNavigationConfig } from './config/HeaderNavigationConfig';
 import { headerLinks } from './config/headerLinks';
 import { drawerNodeItems } from './config/DrawerNodeItems';
 import ComparisonItem from './ComparisonItem';
-import FavoritesItem from './FavoritesItem';
 
 export interface NavigationProps {
   brand: Brand;

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -80,7 +80,6 @@ const Navigation: FC<NavigationProps> = ({
         }),
         iconItems: iconItems({
           trackEvent,
-          isLoggedIn: !!user,
           comparisonItemIds,
         }),
       },

--- a/src/components/navigation/header/index.tsx
+++ b/src/components/navigation/header/index.tsx
@@ -24,6 +24,7 @@ import { HeaderNavigationConfig } from './config/HeaderNavigationConfig';
 import { headerLinks } from './config/headerLinks';
 import { drawerNodeItems } from './config/DrawerNodeItems';
 import ComparisonItem from './ComparisonItem';
+import FavoritesItem from './FavoritesItem';
 
 export interface NavigationProps {
   brand: Brand;
@@ -77,7 +78,11 @@ const Navigation: FC<NavigationProps> = ({
           currentLanguage: language,
           isLoggedIn: !!user,
         }),
-        iconItems: iconItems({ trackEvent, comparisonItemIds }),
+        iconItems: iconItems({
+          trackEvent,
+          isLoggedIn: !!user,
+          comparisonItemIds,
+        }),
       },
       user,
       urlPathParams,
@@ -140,6 +145,9 @@ const Navigation: FC<NavigationProps> = ({
             language={language}
           />
           <Stack direction="row" spacing="2xl" align="center">
+            {config.iconItems.favorites ? (
+              <FavoritesItem link={config.iconItems.favorites} />
+            ) : null}
             {config.iconItems.comparison ? (
               <ComparisonItem
                 link={config.iconItems.comparison}


### PR DESCRIPTION
Reference: [DM-4669](https://smg-au.atlassian.net/browse/DM-4669)

## Motivation and context

Add favorites link icon inside the navigation header (only for logged in user).

## Before

<img width="1634" height="390" alt="Screenshot 2025-08-20 at 13 26 16" src="https://github.com/user-attachments/assets/561ad385-d0b2-46d0-b748-e6a78a963d6b" />
<img width="1237" height="300" alt="Screenshot 2025-08-20 at 13 26 28" src="https://github.com/user-attachments/assets/c78034b9-0aad-4fe2-9bde-670a773390ae" />
<img width="432" height="247" alt="Screenshot 2025-08-20 at 13 26 38" src="https://github.com/user-attachments/assets/8405faf7-dd6a-434e-86eb-7d41a2bef480" />


## After

<img width="1636" height="390" alt="Screenshot 2025-08-20 at 13 27 43" src="https://github.com/user-attachments/assets/69b5fb16-688c-46b8-86b9-f585e09f7113" />
<img width="1239" height="306" alt="Screenshot 2025-08-20 at 13 27 25" src="https://github.com/user-attachments/assets/e56c23c3-208f-4de7-b390-8ae2b37a41f5" />
<img width="434" height="250" alt="Screenshot 2025-08-20 at 13 26 59" src="https://github.com/user-attachments/assets/c3fd5ce5-d7db-43d8-9dd6-a3074ccc5f7e" />


## How to test

Test listings-web and seller-web with [this prerelease](https://www.npmjs.com/package/@smg-automotive/components/v/24.9.0-DM-4669-add-favorites-to-nav-header-5987f86e1bf03adca55ca6260941a1e87aea9d71.1).


[DM-4669]: https://smg-au.atlassian.net/browse/DM-4669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ