### PR TITLE
fix: remove paddingTop for small devices

### DIFF
--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -82,6 +82,10 @@ const variants = {
       ...baseStyle.dialogContainer,
       alignItems: 'flex-start',
       overflow: 'auto',
+      paddingTop: defineStyle({
+        base: '',
+        md: '5xl',
+      }),
     },
   },
   fullScreen: {

--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -82,7 +82,6 @@ const variants = {
       ...baseStyle.dialogContainer,
       alignItems: 'flex-start',
       overflow: 'auto',
-      paddingTop: '5xl',
     },
   },
   fullScreen: {

--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -82,7 +82,7 @@ const variants = {
       ...baseStyle.dialogContainer,
       alignItems: 'flex-start',
       overflow: 'auto',
-      marginTop: '5xl',
+      paddingTop: '5xl',
     },
   },
   fullScreen: {

--- a/src/themes/components/modal.ts
+++ b/src/themes/components/modal.ts
@@ -84,7 +84,7 @@ const variants = {
       overflow: 'auto',
       paddingTop: defineStyle({
         base: '',
-        md: '5xl',
+        sm: '5xl',
       }),
     },
   },


### PR DESCRIPTION
References [Tiecket](https://smg-au.atlassian.net/browse/VSST-3879?atlOrigin=eyJpIjoiNTM5OWU1YmYwM2U1NGJhMzk5YWNhNmZiOWJmNTA2YzgiLCJwIjoiaiJ9)

## Motivation and context

The modal on mobile view should be full page, with no margins at the top.

## Before

Modal variant 'topScroll' is not aligned with design, mobile version needs changes
<img width="410" height="699" alt="image" src="https://github.com/user-attachments/assets/510fa423-b228-4e07-a5b2-c4685e3645ae" />


## After

TopScoll variant, has now no topPadding for mobile version

<img width="748" height="1162" alt="image" src="https://github.com/user-attachments/assets/09d4b55b-c94d-4f2b-bfb6-8c4a5edd9191" />

## How to test
Got to the following link and choose as variant 'topScroll'
[deployment](https://removing-toppadding-mobile-modal-components-pkg.branch.autoscout24.dev/?path=/docs/components-data-display-modal--documentation)