### PR TITLE
fix: description type in Alert

### DIFF
--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -13,7 +13,9 @@ import {
 import AlertLink from './Link';
 import { BareAlertProps } from './Bare';
 
-type SharedProps = Omit<BareAlertProps, 'onClose'>;
+type SharedProps = Omit<BareAlertProps, 'onClose' | 'description'> & {
+  description: React.ReactNode | string;
+};
 
 export type DismissibleProps = SharedProps & {
   onDismiss?: () => void;


### PR DESCRIPTION
[ST-1340](https://smg-au.atlassian.net/browse/ST-1340)

## Motivation and context

To achieve [this ticket](https://github.com/smg-automotive/seller-web/pull/3718), we need the description within the Alert component to be more flexible and accept both a string or an element

## Before

Accepts string only

## After

Accept both string and element

## How to test

[Add a deep link and instructions how to verify the new behavior]


[ST-1340]: https://smg-au.atlassian.net/browse/ST-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ