### PR TITLE
fix: mark auth v7 as peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "whatwg-fetch": "3.6.20"
       },
       "peerDependencies": {
-        "@smg-automotive/auth": "^6.0.0",
+        "@smg-automotive/auth": "^7.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@smg-automotive/auth": "^6.0.0"
+    "@smg-automotive/auth": "^7.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "7.28.3",


### PR DESCRIPTION
References https://github.com/smg-automotive/components-pkg/pull/1518

## Motivation and context

Missed to udpate the auth version in peer deps
