### PR TITLE
feat: migrate two columns layout

### DIFF
--- a/src-v2/components/layout/index.ts
+++ b/src-v2/components/layout/index.ts
@@ -1,4 +1,1 @@
-export { repeatArea } from './BaseGrid';
 export { default as LayoutWithVehicleReference } from './WithVehicleReference';
-export { default as TwoColumnsLayout } from './TwoColumnsLayout';
-export { default as InsertionLayout } from './SingleColumnCentered';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export * from './heading';
 export * from './icons';
 export * from './input';
 export * from './layout';
+export * from './layout/TwoColumnsLayout';
 export * from './link';
 export * from './list';
 export * from './missingImage';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,7 +19,6 @@ export * from './heading';
 export * from './icons';
 export * from './input';
 export * from './layout';
-export * from './layout/TwoColumnsLayout';
 export * from './link';
 export * from './list';
 export * from './missingImage';

--- a/src/components/layout/TwoColumnsLayout.stories.tsx
+++ b/src/components/layout/TwoColumnsLayout.stories.tsx
@@ -2,10 +2,10 @@ import React, { FC } from 'react';
 
 import { Meta, StoryObj } from '@storybook/react';
 
-import Text from '../text';
-import SimpleHeader from '../simpleHeader';
-import Section from '../section';
-import TwoColumnsLayout, { TwoColumnsLayoutProps } from './TwoColumnsLayout';
+import { Text } from '../text';
+import { SimpleHeader } from '../simpleHeader';
+import { Section } from '../section';
+import { TwoColumnsLayout, TwoColumnsLayoutProps } from './TwoColumnsLayout';
 
 type TemplateProps = Omit<TwoColumnsLayoutProps, 'left' | 'right'> & {
   leftContent: TwoColumnsLayoutProps['left']['content'];

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -1,13 +1,12 @@
 import React, { FC, ReactNode } from 'react';
-
 import { GridItem, Heading } from '@chakra-ui/react';
 
-import { sizes } from 'src/themes/shared/sizes';
+import { sizes } from 'src/themes/shared/tokens/sizes';
 
-import Link from '../link';
+import { Link } from '../link';
 import { ArrowLeftIcon } from '../icons';
-import BaseLayout from './BaseLayout';
-import BaseGridLayout, { repeatArea } from './BaseGrid';
+import { BaseLayout } from './BaseLayout';
+import { BaseGridLayout, repeatArea } from './BaseGrid';
 
 export type ColumnSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
@@ -31,7 +30,7 @@ export interface TwoColumnsLayoutProps {
   maxContentWidth?: keyof typeof sizes.container;
 }
 
-const TwoColumnsLayout: FC<TwoColumnsLayoutProps> = (props) => {
+export const TwoColumnsLayout: FC<TwoColumnsLayoutProps> = (props) => {
   const {
     header,
     title,
@@ -67,7 +66,8 @@ const TwoColumnsLayout: FC<TwoColumnsLayoutProps> = (props) => {
         {props.backLink ? (
           <GridItem area="backlink">
             {typeof props.backLink === 'object' && 'url' in props.backLink ? (
-              <Link href={props.backLink.url} leftIcon={<ArrowLeftIcon />}>
+              <Link href={props.backLink.url}>
+                <ArrowLeftIcon />
                 {props.backLink.text}
               </Link>
             ) : (
@@ -96,5 +96,3 @@ const TwoColumnsLayout: FC<TwoColumnsLayoutProps> = (props) => {
     </BaseLayout>
   );
 };
-
-export default TwoColumnsLayout;

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { repeatArea } from './BaseGrid';
 export { PageLayout } from './Page';
 export { SingleColumnCenteredLayout } from './SingleColumnCentered';
+export { TwoColumnsLayout } from './TwoColumnsLayout';


### PR DESCRIPTION
[ST-1385](https://smg-au.atlassian.net/jira/software/projects/ST/boards/1109?jql=assignee%20%3D%20712020%3A7b8fcbea-c829-48f9-ac8e-a01a9c310984&selectedIssue=ST-1385)

## Motivation and context

We want to migrate TwoColumnsLayout component to Chakra UI v3.

## Before

N/A

## After

<img width="1718" height="799" alt="two_columns_layout" src="https://github.com/user-attachments/assets/64edb273-946d-4e33-b2d4-1497fa34e64c" />

## How to test

[Preview link](https://st-1385-migrate-two-columns-layout-components-pkg.branch.autoscout24.dev/?path=/docs/layout-pages-layout-with-two-columns--documentation)

[ST-1385]: https://smg-au.atlassian.net/browse/ST-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ