### PR TITLE
feat: migrate WithVehicleReferenceLayout component

### DIFF
--- a/src-v2/components/layout/index.ts
+++ b/src-v2/components/layout/index.ts
@@ -1,1 +1,0 @@
-export { default as LayoutWithVehicleReference } from './WithVehicleReference';

--- a/src/components/layout/TwoColumnsLayout.tsx
+++ b/src/components/layout/TwoColumnsLayout.tsx
@@ -30,6 +30,17 @@ export interface TwoColumnsLayoutProps {
   maxContentWidth?: keyof typeof sizes.container;
 }
 
+const isRenderable = (value: ReactNode) => {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null ||
+    value === undefined ||
+    React.isValidElement(value)
+  );
+};
+
 export const TwoColumnsLayout: FC<TwoColumnsLayoutProps> = (props) => {
   const {
     header,
@@ -71,7 +82,7 @@ export const TwoColumnsLayout: FC<TwoColumnsLayoutProps> = (props) => {
                 {props.backLink.text}
               </Link>
             ) : (
-              props.backLink
+              isRenderable(props.backLink) && props.backLink
             )}
           </GridItem>
         ) : null}

--- a/src/components/layout/WithVehicleReference.stories.tsx
+++ b/src/components/layout/WithVehicleReference.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 
-import { sizes } from 'src/themes/shared/sizes';
+import { sizes } from 'src/themes/shared/tokens/sizes';
 
-import SimpleHeader from '../simpleHeader';
-import Input from '../input';
-import FormControl from '../formControl';
-import Button from '../button';
-import LayoutWithVehicleReference from './WithVehicleReference';
+import { SimpleHeader } from '../simpleHeader';
+import { Input } from '../input';
+import { Field } from '../field';
+import { Button } from '../button';
+import { LayoutWithVehicleReference } from './WithVehicleReference';
 
 const meta: Meta<typeof LayoutWithVehicleReference> = {
   title: 'Layout/Pages/Layout with vehicle reference',
@@ -36,15 +36,15 @@ const meta: Meta<typeof LayoutWithVehicleReference> = {
 
     children: (
       <>
-        <FormControl id="name" label="Name">
+        <Field id="name" label="Name">
           <Input name="name" size="lg" />
-        </FormControl>
-        <FormControl id="email" label="E-Mail address">
+        </Field>
+        <Field id="email" label="E-Mail address">
           <Input name="email" size="lg" />
-        </FormControl>
-        <FormControl id="phone" label="Phone number">
+        </Field>
+        <Field id="phone" label="Phone number">
           <Input name="phone" size="lg" />
-        </FormControl>
+        </Field>
       </>
     ),
 

--- a/src/components/layout/WithVehicleReference.tsx
+++ b/src/components/layout/WithVehicleReference.tsx
@@ -1,9 +1,10 @@
 import React, { FC, PropsWithChildren } from 'react';
 
-import VehicleReference, { VehicleReferenceProps } from '../vehicleReference';
-import Box from '../box';
-import TwoColumnsLayout, {
+import { VehicleReference, VehicleReferenceProps } from '../vehicleReference';
+import { Box } from '../box';
+import {
   ColumnSize,
+  TwoColumnsLayout,
   TwoColumnsLayoutProps,
 } from './TwoColumnsLayout';
 export interface Props extends Omit<TwoColumnsLayoutProps, 'left' | 'right'> {
@@ -12,7 +13,7 @@ export interface Props extends Omit<TwoColumnsLayoutProps, 'left' | 'right'> {
   rightColumnSize?: ColumnSize;
 }
 
-const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
+export const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
   title,
   backLink,
   vehicle,
@@ -28,9 +29,9 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
     <TwoColumnsLayout
       header={header}
       backLink={backLink}
-      title={title ? <Box marginRight={contentMargin}>{title}</Box> : null}
+      title={title ? <Box css={contentMargin}>{title}</Box> : null}
       left={{
-        content: <Box marginRight={contentMargin}>{children}</Box>,
+        content: <Box css={contentMargin}>{children}</Box>,
         columns: leftColumnSize,
       }}
       right={{
@@ -41,5 +42,3 @@ const LayoutWithVehicleReference: FC<PropsWithChildren<Props>> = ({
     />
   );
 };
-
-export default LayoutWithVehicleReference;

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -2,3 +2,4 @@ export { repeatArea } from './BaseGrid';
 export { PageLayout } from './Page';
 export { SingleColumnCenteredLayout } from './SingleColumnCentered';
 export { TwoColumnsLayout } from './TwoColumnsLayout';
+export { LayoutWithVehicleReference } from './WithVehicleReference';


### PR DESCRIPTION
[ST-1386](https://smg-au.atlassian.net/jira/software/projects/ST/boards/1109?jql=assignee%20%3D%20712020%3A7b8fcbea-c829-48f9-ac8e-a01a9c310984&selectedIssue=ST-1386)

## Motivation and context

We want to migrate WithVehicleReferenceLayout component to Chakra UI v3.

## Before

N/A

## After

<img width="1717" height="947" alt="with_vehicle_reference" src="https://github.com/user-attachments/assets/04e5ca79-b0b1-44eb-8e67-eb5618524e85" />

## How to test

[Preview link](https://st-1386-migrate-with-vehicle-reference-components-pkg.branch.autoscout24.dev/?path=/docs/layout-pages-layout-with-vehicle-reference--documentation)

[ST-1386]: https://smg-au.atlassian.net/browse/ST-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ