### PR TITLE
fix: change message-manager link

### DIFF
--- a/src/components/navigation/header/__tests__/index.Test.tsx
+++ b/src/components/navigation/header/__tests__/index.Test.tsx
@@ -288,7 +288,7 @@ describe('Header', () => {
     };
     const legacyWebLink = {
       name: 'Kontaktanfragen',
-      pathname: '/de/member/messagemanager',
+      pathname: '/de/message-manager',
     };
 
     it('should use relative URLs for pages inside listings-web and keep the others absolute', async () => {

--- a/src/components/navigation/header/config/leadsManagement.ts
+++ b/src/components/navigation/header/config/leadsManagement.ts
@@ -3,10 +3,10 @@ import { NavigationLinkConfigProps } from './headerLinks';
 export const leadsManagementLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.contactRequests',
   link: {
-    de: '/de/member/messagemanager',
-    en: '/de/member/messagemanager',
-    fr: '/fr/member/messagemanager',
-    it: '/it/member/messagemanager',
+    de: '/de/message-manager',
+    en: '/de/message-manager',
+    fr: '/fr/message-manager',
+    it: '/it/message-manager',
   },
   visibilitySettings: {
     userType: {


### PR DESCRIPTION
[ST-1330](https://smg-au.atlassian.net/browse/ST-1330)

## Motivation and context

Since we released the new message manager page, we can now replace the legacy links with the new one. 

<img width="714" height="396" alt="Screenshot 2025-09-15 at 08 19 38" src="https://github.com/user-attachments/assets/ce021d1b-a3c5-421f-95e3-a2477db39275" />

## How to test

You can test here: https://smg-au.atlassian.net/browse/ST-1330

Thank you 🌺 


[ST-1330]: https://smg-au.atlassian.net/browse/ST-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ