### PR TITLE
chore: remove slide transition component import and export

### DIFF
--- a/src-v2/components/slide/index.tsx
+++ b/src-v2/components/slide/index.tsx
@@ -1,2 +1,0 @@
-import { Slide } from '@chakra-ui/react';
-export default Slide;

--- a/src-v2/themes/components/index.ts
+++ b/src-v2/themes/components/index.ts
@@ -7,7 +7,6 @@ import Tabs from './tabs';
 import Table from './table';
 import Switch from './switch';
 import Spinner from './spinner';
-import Slider from './slider';
 import Skeleton from './skeleton';
 import SimpleHeader from './simpleHeader';
 import Radio from './radio';
@@ -69,6 +68,5 @@ export const components: Record<string, ComponentStyleConfig> = {
   Textarea,
   Tooltip,
   VehicleReference,
-  Slider,
   Popover,
 };


### PR DESCRIPTION
References [https://smg-au.atlassian.net/browse/PS-924](url)

## Motivation and context

I couldn't find any references or imports of Slide component in our repositories so I removed it. 
Additionally, based on the docs it seems like Chakra moved away from transition components and started using transition style properties in v3. 
More details here: 
v2: https://v2.chakra-ui.com/docs/components/transitions/usage
v3: https://chakra-ui.com/docs/styling/style-props/transitions