### PR TITLE
fix: useToken hook return values

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,6 +19,7 @@ const external = [
 const onwarn = (warning, warn) => {
   if (warning.code === 'CIRCULAR_DEPENDENCY') {
     if (warning.message.includes('node_modules/yargs')) return;
+    if (warning.message.includes('node_modules/@internationalized')) return;
     throw new Error(warning.message);
   }
   warn(warning);

--- a/src/hooks/__tests__/useToken.Test.ts
+++ b/src/hooks/__tests__/useToken.Test.ts
@@ -1,20 +1,15 @@
+import { renderHook } from 'jest-utils';
+
 import useToken from '../useToken';
 
 describe('useToken', () => {
-  const mockGetCategoryValues = jest.fn().mockImplementation((scale) => {
-    if (scale === 'colors') {
-      return {
-        'brand.100': '#F5F200',
-        'brand.500': '#908800',
-        'brand.700': '#665E00',
-      };
-    }
-    return null;
-  });
-
   const mockContext = {
     tokens: {
-      getCategoryValues: mockGetCategoryValues,
+      tokenMap: new Map([
+        ['colors.brand.100', { originalValue: '#F5F200' }],
+        ['colors.brand.500', { originalValue: '#908800' }],
+        ['colors.brand.700', { originalValue: '#665E00' }],
+      ]),
     },
   };
 
@@ -27,7 +22,7 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(undefined);
 
-    expect(() => useToken('colors', ['brand.100'])).toThrow(
+    expect(() => renderHook(() => useToken('colors', ['brand.100']))).toThrow(
       'useToken must be used within a ChakraProvider',
     );
   });
@@ -37,8 +32,10 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(mockContext);
 
-    const result = useToken('colors', ['brand.100', 'brand.500', 'brand.700']);
-    expect(result).toEqual(['#F5F200', '#908800', '#665E00']);
+    const { result } = renderHook(() =>
+      useToken('colors', ['brand.100', 'brand.500', 'brand.700']),
+    );
+    expect(result.current).toEqual(['#F5F200', '#908800', '#665E00']);
   });
 
   it('should return the token itself if not found and no fallback is provided', () => {
@@ -46,8 +43,10 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(mockContext);
 
-    const result = useToken('colors', ['nonexistent.token']);
-    expect(result).toEqual(['nonexistent.token']);
+    const { result } = renderHook(() =>
+      useToken('colors', ['nonexistent.token']),
+    );
+    expect(result.current).toEqual(['nonexistent.token']);
   });
 
   it('should return fallback values if tokens are not found in the theme', () => {
@@ -55,8 +54,10 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(mockContext);
 
-    const result = useToken('colors', ['nonexistent.token'], ['#000']);
-    expect(result).toEqual(['#000']);
+    const { result } = renderHook(() =>
+      useToken('colors', ['nonexistent.token'], ['#000']),
+    );
+    expect(result.current).toEqual(['#000']);
   });
 
   it('should handle mixed cases with some tokens found and some not, without fallbacks', () => {
@@ -64,8 +65,10 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(mockContext);
 
-    const result = useToken('colors', ['nonexistent.token', 'brand.700']);
-    expect(result).toEqual(['nonexistent.token', '#665E00']);
+    const { result } = renderHook(() =>
+      useToken('colors', ['nonexistent.token', 'brand.700']),
+    );
+    expect(result.current).toEqual(['nonexistent.token', '#665E00']);
   });
 
   it('should handle mixed cases with some tokens found and some not, with fallbacks', () => {
@@ -73,12 +76,10 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(mockContext);
 
-    const result = useToken(
-      'colors',
-      ['nonexistent.token', 'brand.100'],
-      ['#000', '#666'],
+    const { result } = renderHook(() =>
+      useToken('colors', ['nonexistent.token', 'brand.100'], ['#000', '#666']),
     );
-    expect(result).toEqual(['#000', '#F5F200']);
+    expect(result.current).toEqual(['#000', '#F5F200']);
   });
 
   it('should return token itself when scale does not exist in the theme and no fallback is provided', () => {
@@ -86,8 +87,10 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(mockContext);
 
-    const result = useToken('nonexistent.scale', ['nonexistent.token']);
-    expect(result).toEqual(['nonexistent.token']);
+    const { result } = renderHook(() =>
+      useToken('nonexistent.scale', ['nonexistent.token']),
+    );
+    expect(result.current).toEqual(['nonexistent.token']);
   });
 
   it('should return fallback values when scale does not exist in the theme', () => {
@@ -95,11 +98,9 @@ describe('useToken', () => {
       .spyOn(require('@chakra-ui/react'), 'useChakraContext')
       .mockReturnValue(mockContext);
 
-    const result = useToken(
-      'nonexistent.scale',
-      ['nonexistent.token'],
-      ['#000'],
+    const { result } = renderHook(() =>
+      useToken('nonexistent.scale', ['nonexistent.token'], ['#000']),
     );
-    expect(result).toEqual(['#000']);
+    expect(result.current).toEqual(['#000']);
   });
 });

--- a/src/hooks/useToken/index.ts
+++ b/src/hooks/useToken/index.ts
@@ -11,11 +11,12 @@ const useToken = (
     throw new Error('useToken must be used within a ChakraProvider');
   }
 
-  const category = context.tokens.getCategoryValues(scale);
+  const { tokenMap } = context.tokens;
 
   const value = token.map((t, i) => {
-    if (category?.[t] !== undefined) {
-      return category[t];
+    const tokenValue = tokenMap.get(`${scale}.${t}`);
+    if (tokenValue !== undefined) {
+      return tokenValue['originalValue'];
     }
     if (fallback?.[i] !== undefined) {
       return fallback[i];


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

We noticed an invalid format in the values returned by this custom hook.

## Before

<img width="710" height="267" alt="Screenshot 2026-02-10 at 17 06 13" src="https://github.com/user-attachments/assets/b39c8fb1-ee8c-40f2-b29e-971ab07e46eb" />

## After

<img width="319" height="263" alt="Screenshot 2026-02-10 at 17 04 08" src="https://github.com/user-attachments/assets/b372447d-bf4f-419d-8f21-25a1b01683f4" />

## How to test

[Preview link](https://fix-use-token-hook-components-pkg.branch.autoscout24.dev/?path=/docs/hooks-usetoken--documentation)
