### PR TITLE
fix: radio list item

### DIFF
--- a/src/components/radio/RadioListItem.tsx
+++ b/src/components/radio/RadioListItem.tsx
@@ -15,12 +15,35 @@ export const RadioListItem = forwardRef<HTMLInputElement, Props>(
   ({ children, value, ...rest }, ref) => {
     const recipe = useRecipe({ key: 'radioListItem' });
     const styles = recipe();
+    // This item is rendered as a label, so clicks inside children can bubble up
+    // and toggle/select the radio item instead of interacting with nested controls.
+    // We explicitly treat common form/interactive elements as "safe zones".
+    const interactiveSelector =
+      'input, textarea, select, button, a, [contenteditable="true"], [data-radiolist-interactive]';
+
+    // Stop propagation only for nested interactive controls so:
+    // 1) typing/focus in child inputs works on first click, and
+    // 2) clicking non-interactive parts of the row still selects the radio item.
+    const stopIfInteractiveTarget = (
+      event: React.PointerEvent<HTMLElement> | React.MouseEvent<HTMLElement>,
+    ) => {
+      const target = event.target;
+
+      if (target instanceof Element && target.closest(interactiveSelector)) {
+        event.stopPropagation();
+      }
+    };
 
     return (
       <RadioGroup.Item value={value} asChild {...rest}>
         <Box as="label" css={styles}>
           <RadioGroup.ItemHiddenInput ref={ref} />
-          {children}
+          <Box
+            onPointerDownCapture={stopIfInteractiveTarget}
+            onClickCapture={stopIfInteractiveTarget}
+          >
+            {children}
+          </Box>
         </Box>
       </RadioGroup.Item>
     );


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/ST-1755

## Motivation and context

- Fixes an interaction bug in RadioListItem where nested inputs inside children could not be typed into immediately after selecting a radio option.
- Adds guarded event handling for nested interactive elements (input, textarea, select, button, a, contenteditable, and opt-in [data-radiolist-interactive]) to prevent bubbling from hijacking focus/typing.
- Preserves expected radio behavior: clicking non-interactive parts of the row still selects the radio item.
- Adds inline comments explaining why the interactive selector and propagation guard are required.

## Before

When RadioListItem is rendered as a label-based radio item, click/pointer events from nested controls can bubble to the radio container.
This caused users to need an extra click before they could type into an input passed via children.

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
