### PR TITLE
fix: switch label font size

### DIFF
--- a/src/themes/shared/slotRecipes/switch.ts
+++ b/src/themes/shared/slotRecipes/switch.ts
@@ -72,7 +72,7 @@ export const switchRecipe = defineSlotRecipe({
     },
     label: {
       userSelect: 'none',
-      fontSize: 'sm',
+      fontSize: 'base',
       _disabled: {
         opacity: '60',
       },


### PR DESCRIPTION
References [VSST-4652](https://smg-au.atlassian.net/browse/VSST-4652)

## Motivation and context

Fixed invalid switch label font size.

[Pre-migration font size is 16px](https://main-components-pkg.branch.autoscout24.dev/?path=/docs/components-forms-switch--documentation)

## Before

[Post-migration font size is 14px - chakra v3 root pr](https://chakra-v3-root-components-pkg.branch.autoscout24.dev/?path=/docs/components-forms-switch--documentation)

## After

[Post-migration font size is 16px - this pr branch env](https://switch-label-font-size-components-pkg.branch.autoscout24.dev/?path=/docs/components-forms-switch--documentation)

## How to test

- https://switch-label-font-size-components-pkg.branch.autoscout24.dev/?path=/docs/components-forms-switch--documentation


[VSST-4652]: https://smg-au.atlassian.net/browse/VSST-4652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ