### PR TITLE
fix: center tabs label

### DIFF
--- a/src/themes/shared/slotRecipes/tabs.ts
+++ b/src/themes/shared/slotRecipes/tabs.ts
@@ -104,6 +104,8 @@ export const tabsRecipe = defineSlotRecipe({
       fullWidth: {
         trigger: {
           flex: 1,
+          justifyContent: 'center',
+          textAlign: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },

--- a/src/themes/shared/slotRecipes/tabs.ts
+++ b/src/themes/shared/slotRecipes/tabs.ts
@@ -2,6 +2,9 @@ import { defineSlotRecipe, defineStyle } from '@chakra-ui/react';
 
 const baseTriggerStyle = defineStyle({
   textStyle: 'body',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   transitionProperty: 'common',
   transitionDuration: 'normal',
   '--tabs-border-width': '3px',
@@ -50,7 +53,6 @@ export const tabsRecipe = defineSlotRecipe({
     variant: {
       default: {
         trigger: {
-          justifyContent: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },
@@ -61,7 +63,6 @@ export const tabsRecipe = defineSlotRecipe({
           justifyContent: 'space-between',
         },
         trigger: {
-          justifyContent: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },
@@ -72,7 +73,6 @@ export const tabsRecipe = defineSlotRecipe({
           justifyContent: 'space-around',
         },
         trigger: {
-          justifyContent: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },
@@ -83,7 +83,6 @@ export const tabsRecipe = defineSlotRecipe({
           borderBottom: 'none',
         },
         trigger: {
-          justifyContent: 'center',
           color: 'gray.700',
           fontWeight: 'bold',
           flexBasis: 'full',
@@ -108,7 +107,6 @@ export const tabsRecipe = defineSlotRecipe({
       fullWidth: {
         trigger: {
           flex: 1,
-          justifyContent: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },

--- a/src/themes/shared/slotRecipes/tabs.ts
+++ b/src/themes/shared/slotRecipes/tabs.ts
@@ -50,6 +50,7 @@ export const tabsRecipe = defineSlotRecipe({
     variant: {
       default: {
         trigger: {
+          justifyContent: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },
@@ -60,6 +61,7 @@ export const tabsRecipe = defineSlotRecipe({
           justifyContent: 'space-between',
         },
         trigger: {
+          justifyContent: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },
@@ -70,6 +72,7 @@ export const tabsRecipe = defineSlotRecipe({
           justifyContent: 'space-around',
         },
         trigger: {
+          justifyContent: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },
@@ -80,6 +83,7 @@ export const tabsRecipe = defineSlotRecipe({
           borderBottom: 'none',
         },
         trigger: {
+          justifyContent: 'center',
           color: 'gray.700',
           fontWeight: 'bold',
           flexBasis: 'full',
@@ -105,7 +109,6 @@ export const tabsRecipe = defineSlotRecipe({
         trigger: {
           flex: 1,
           justifyContent: 'center',
-          textAlign: 'center',
           _selected: {
             borderBottomColor: 'currentColor',
           },


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Label should be centered for all variants. It was like that on previous version of components pkg
## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
