### PR TITLE
feat: Migrate Radio component

### DIFF
--- a/src/components/radio/__tests__/Radio.Test.tsx
+++ b/src/components/radio/__tests__/Radio.Test.tsx
@@ -3,36 +3,31 @@ import userEvent from '@testing-library/user-event';
 
 import { render, screen } from 'jest-utils';
 
-import { Radio } from '..';
+import { Radio, RadioItemProps } from '..';
 
 const renderWrapper = (
   props: Partial<{
     name: string;
     onChange: jest.Mock;
     label: string;
-    value: string;
-    isDisabled: boolean;
-    isChecked: boolean;
+    items: RadioItemProps[];
+    value?: string;
   }> = {},
 ) => {
   const {
     name = 'Radio',
     onChange = jest.fn(),
-    label = 'Option',
-    value = 'Option',
-    isDisabled = false,
-    isChecked = false,
+    value,
+    items = [
+      {
+        value: 'Option',
+        label: 'Option',
+      },
+    ],
   } = props;
 
   return render(
-    <Radio
-      name={name}
-      value={value}
-      onChange={onChange}
-      label={label}
-      disabled={isDisabled}
-      checked={isChecked}
-    />,
+    <Radio name={name} value={value} onChange={onChange} items={items} />,
   );
 };
 
@@ -45,8 +40,11 @@ describe('<Radio>', () => {
   });
 
   it('is checked', async () => {
-    renderWrapper({ isChecked: true });
+    const user = userEvent.setup();
+    renderWrapper();
     const radio = await screen.findByRole('radio', { name: 'Option' });
+
+    await user.click(radio);
 
     expect(radio).toBeChecked();
   });
@@ -68,7 +66,10 @@ describe('<Radio>', () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
 
-    renderWrapper({ onChange, isDisabled: true });
+    renderWrapper({
+      onChange,
+      items: [{ value: 'Option', label: 'Option', disabled: true }],
+    });
 
     const radio = await screen.findByRole('radio', { name: 'Option' });
 

--- a/src/components/radio/index.stories.tsx
+++ b/src/components/radio/index.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from '@storybook/preview-api';
 import { action } from '@storybook/addon-actions';
+import { Grid } from '@chakra-ui/react';
 
 import { radioRecipe } from 'src/themes/shared/slotRecipes/radio';
-
 import { getRecipeControls } from '.storybook/preview/controls/recipe';
 
 import { Radio, RadioProps } from './index';
@@ -17,8 +17,7 @@ const Template = (props: RadioProps) => {
       {...props}
       {...args}
       onChange={(e) => {
-        const next = !(args.checked ?? false); // toggle
-        updateArgs({ checked: next });
+        updateArgs({ value: e.target.value });
         action('onChange')(e);
       }}
     />
@@ -29,36 +28,126 @@ const meta: Meta<typeof Radio> = {
   title: 'Components/Forms/Radio',
   component: Radio,
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          'Radio renders a Chakra `RadioGroup.Root` plus the radio items.',
+          '',
+          '### Layout (default vs render prop)',
+          '- **Default (no `children`)**: items are wrapped in an internal `Stack` whose direction is controlled by `orientation`.',
+          '- **Render prop (`children`)**: pass `children={(renderedItems) => ...}` to provide your own wrapper/layout (for example, `Grid`).',
+        ].join('\n'),
+      },
+    },
+  },
   args: {
-    value: 'option',
-    label: 'Radio',
+    value: undefined,
     name: '',
-    checked: false,
-    disabled: false,
-    invalid: false,
     size: 'md',
     variant: 'fontRegular',
+    orientation: 'horizontal',
+    items: [
+      { value: 'option-1', label: 'Radio 1' },
+      { value: 'option-2', label: 'Radio 2' },
+      { value: 'option-3', label: 'Radio 3' },
+    ],
   },
   argTypes: {
     ...getRecipeControls(radioRecipe),
+    children: {
+      control: false,
+      description:
+        'Optional render prop: `(renderedItems) => ReactNode`. If omitted, the component uses the default internal Stack wrapper based on `orientation`.',
+      table: {
+        type: { summary: '(renderedItems: ReactNode) => ReactNode' },
+      },
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Radio>;
 
-export const Default: Story = { name: 'Radio (single)' };
+export const Default: Story = { name: 'Default (uses internal Stack)' };
+
+export const OrientationHorizontal: Story = {
+  name: 'Orientation › horizontal (Stack row)',
+  args: { orientation: 'horizontal' },
+};
+
+export const OrientationVertical: Story = {
+  name: 'Orientation › vertical (Stack column)',
+  args: { orientation: 'vertical' },
+};
+
+export const CustomWrapperGrid: Story = {
+  name: 'Custom wrapper via children (Grid)',
+  render: (args) => (
+    <Radio {...args}>
+      {(renderedItems) => (
+        <Grid
+          templateColumns={{ base: '1fr', sm: 'repeat(3, max-content)' }}
+          gap={{ base: 'md', sm: 'xl' }}
+          alignItems="center"
+        >
+          {renderedItems}
+        </Grid>
+      )}
+    </Radio>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Uses the **render prop** (`children`) to replace the default internal Stack wrapper with a Grid.',
+          'Only the layout changes—radio items remain the same.',
+        ].join('\n'),
+      },
+      source: {
+        code: `<Radio {...args}>{
+    (renderedItems) => (
+        <Grid
+          templateColumns={{ base: '1fr', sm: 'repeat(3, max-content)' }}
+          gap={{ base: 'md', sm: 'xl' }}
+          alignItems="center"
+        >
+          {renderedItems}
+        </Grid>
+      )}
+    </Radio>`,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
 export const SizeBase: Story = { name: 'Size › base', args: { size: 'base' } };
 export const SizeMd: Story = { name: 'Size › md', args: { size: 'md' } };
-export const StateDisabled: Story = {
-  name: 'State › disabled',
-  args: { disabled: true },
-};
-export const StateInvalid: Story = {
-  name: 'State › invalid',
-  args: { invalid: true },
-};
+
 export const VariantBold: Story = {
   name: 'Variant › fontBold',
   args: { variant: 'fontBold' },
+};
+
+export const StateDisabled: Story = {
+  name: 'State › disabled',
+  args: {
+    items: [
+      { value: 'option-1', label: 'Radio 1', disabled: true },
+      { value: 'option-2', label: 'Radio 2', disabled: true },
+      { value: 'option-3', label: 'Radio 3', disabled: true },
+    ],
+  },
+};
+
+export const StateInvalid: Story = {
+  name: 'State › invalid',
+  args: {
+    items: [
+      { value: 'option-1', label: 'Radio 1', invalid: true },
+      { value: 'option-2', label: 'Radio 2', invalid: true },
+      { value: 'option-3', label: 'Radio 3', invalid: true },
+    ],
+  },
 };

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -1,72 +1,92 @@
 'use client';
 
-import React, { ChangeEvent, forwardRef } from 'react';
+import React, { ChangeEvent, forwardRef, ReactNode } from 'react';
 import {
   RadioGroup,
   RecipeVariantProps,
+  Stack,
   useSlotRecipe,
 } from '@chakra-ui/react';
 
 import { radioRecipe } from 'src/themes/shared/slotRecipes/radio';
 
-export type RadioProps = RecipeVariantProps<typeof radioRecipe> & {
+export type RadioItemProps = {
   value: string;
   label?: string;
-  name?: string;
-  checked?: boolean;
-  disabled?: boolean;
   invalid?: boolean;
+  disabled?: boolean;
+};
+
+export type RadioRenderFn = (renderedItems: ReactNode) => ReactNode;
+
+export type RadioProps = RecipeVariantProps<typeof radioRecipe> & {
+  value?: string;
+  items: RadioItemProps[];
+  orientation?: 'horizontal' | 'vertical';
+  name?: string;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  children?: RadioRenderFn;
 };
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   const recipe = useSlotRecipe({ key: 'radio' });
-
   const [recipeProps, restProps] = recipe.splitVariantProps(props);
-
   const styles = recipe(recipeProps);
 
   const {
     value,
-    label = 'Radio',
     name,
-    checked = false,
-    disabled = false,
-    invalid = false,
     onChange,
+    items,
+    orientation = 'horizontal',
+    children,
     ...rootDomProps
   } = restProps;
 
-  const isChecked = !!checked;
+  const renderedItems = items.map((item) => (
+    <RadioGroup.Item
+      key={item.value}
+      value={item.value}
+      disabled={item.disabled}
+      invalid={item.invalid}
+      css={styles.item}
+    >
+      <RadioGroup.ItemControl css={styles.control}>
+        <RadioGroup.ItemIndicator css={styles.indicator} />
+      </RadioGroup.ItemControl>
+      <RadioGroup.ItemText css={styles.label}>{item.label}</RadioGroup.ItemText>
+      <RadioGroup.ItemHiddenInput ref={ref} />
+    </RadioGroup.Item>
+  ));
+
+  const defaultWrapped = (
+    <Stack
+      direction={orientation === 'horizontal' ? 'row' : 'column'}
+      gap="2xl"
+    >
+      {renderedItems}
+    </Stack>
+  );
+
+  const content = children ? children(renderedItems) : defaultWrapped;
 
   return (
     <RadioGroup.Root
       name={name}
-      value={isChecked ? value : undefined}
-      onValueChange={() => {
+      value={value}
+      onValueChange={(details) => {
         if (!onChange) return;
         const target = {
-          value,
-          checked: !isChecked,
+          value: details.value,
           name,
+          checked: details.value === value,
         } as unknown as EventTarget & HTMLInputElement;
         onChange({ target } as ChangeEvent<HTMLInputElement>);
       }}
       css={styles.root}
       {...rootDomProps}
     >
-      <RadioGroup.Item
-        value={value}
-        disabled={disabled}
-        invalid={invalid}
-        css={styles.item}
-      >
-        <RadioGroup.ItemControl css={styles.control}>
-          <RadioGroup.ItemIndicator css={styles.indicator} />
-        </RadioGroup.ItemControl>
-        <RadioGroup.ItemText css={styles.label}>{label}</RadioGroup.ItemText>
-        <RadioGroup.ItemHiddenInput ref={ref} />
-      </RadioGroup.Item>
+      {content}
     </RadioGroup.Root>
   );
 });


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Migrate Radio component to support multiple items, added orientation and children props, updated tests and stories accordingly

## Before

- Radio button supported only one radio element

## After

- Supports multiple radio items and render callback function.

## How to test

[Add a deep link and instructions how to verify the new behavior]
