### PR TITLE
fix: switch sizing

### DIFF
--- a/src/themes/shared/slotRecipes/switch.ts
+++ b/src/themes/shared/slotRecipes/switch.ts
@@ -17,8 +17,8 @@ export const switchRecipe = defineSlotRecipe({
       '--checkmark-border-style': 'solid',
       '--checkmark-border-width': '0 2px 2px 0',
       '--switch-diff': 'calc(var(--switch-width) - var(--switch-height))',
-      '--switch-width': '2.5rem',
-      '--switch-height': '1.25rem',
+      '--switch-width': '1.875rem',
+      '--switch-height': '1rem',
       '--switch-x': {
         base: 'var(--switch-diff)',
         _rtl: 'calc(var(--switch-diff) * -1)',
@@ -29,6 +29,8 @@ export const switchRecipe = defineSlotRecipe({
       cursor: 'pointer',
       borderRadius: 'full',
       position: 'relative',
+      padding: 'xxs',
+      boxSizing: 'content-box',
       width: 'var(--switch-width)',
       height: 'var(--switch-height)',
       _hover: {


### PR DESCRIPTION
References [VSST-4652](https://smg-au.atlassian.net/browse/VSST-4652)

## Motivation and context

Adjusts switch component width/height to match that of v2 implementation.

## Before

Inconsistent switch width and height between v2 and v3 chakra implementations.

## After

Exact same width and height.

## How to test

Verify width and height is same between v2 and v3 (migrated) variant
- v2: https://main-components-pkg.branch.autoscout24.dev/?path=/docs/components-forms-switch--documentation
- v3: https://switch-styles-alignment-components-pkg.branch.autoscout24.dev/?path=/docs/components-forms-switch--documentation

[VSST-4652]: https://smg-au.atlassian.net/browse/VSST-4652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ