### PR TITLE
fix: footer layout

### DIFF
--- a/src/components/navigation/footer/Sections.tsx
+++ b/src/components/navigation/footer/Sections.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 
 import { useI18n } from 'src/utilities/i18nInit';
 import { chunkArray } from 'src/utilities/chunkArray';
+import useMediaQuery from 'src/hooks/useMediaQuery';
 import { MobileOnlyAccordionPanel } from 'src/components/mobileOnlyAccordion/MobileOnlyAccordionPanel';
 import { MobileOnlyAccordionItem } from 'src/components/mobileOnlyAccordion/MobileOnlyAccordionItem';
 import { MobileOnlyAccordionButton } from 'src/components/mobileOnlyAccordion/MobileOnlyAccordionButton';
@@ -24,6 +25,8 @@ export const FooterSections: FC<FooterSectionsProps> = ({ config }) => {
     chunkSize: 2,
   });
 
+  const isAboveMd = useMediaQuery({ above: 'md' });
+
   return (
     <>
       {sectionChunks.map((sectionChunk, chunkIndex) => {
@@ -36,6 +39,7 @@ export const FooterSections: FC<FooterSectionsProps> = ({ config }) => {
                     key={`footerSection-${chunkIndex}-${sectionIndex}`}
                     borderTop="none"
                     borderBottom="1px"
+                    marginBottom={isAboveMd ? 'lg' : '0'}
                     borderBottomColor="gray.700"
                     value={`footerSection-${chunkIndex}-${sectionIndex}`}
                   >


### PR DESCRIPTION
[FED-1035](https://smg-au.atlassian.net/browse/FED-1035?atlOrigin=eyJpIjoiOWU5YjJjOGU5MjJhNDJjZjhhYzIzZDQxODRhYjBkNTUiLCJwIjoiaiJ9)

## Motivation and context

The footer layout needed some improvements 

## Before

<img width="1728" height="472" alt="Screenshot 2026-03-06 at 12 33 23" src="https://github.com/user-attachments/assets/308cf68b-7c79-4cff-bec3-51469b8d312a" />

## After

<img width="1084" height="618" alt="Screenshot 2026-03-25 at 09 12 11" src="https://github.com/user-attachments/assets/969b4b7b-23cc-48c3-8e1e-d9e8a1bad978" />

## How to test

You can test here: https://fed-1035-components-pkg.branch.autoscout24.dev/?path=/docs/patterns-navigation-footer--documentation

Thank you


[FED-1035]: https://smg-au.atlassian.net/browse/FED-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ