### PR TITLE
Fix menu component

### DIFF
--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -5,7 +5,6 @@ import {
   MenuContentProps,
   MenuRootProps,
   MenuTriggerProps,
-  Portal,
   useSlotRecipe,
 } from '@chakra-ui/react';
 
@@ -77,37 +76,35 @@ export const Menu: FC<MenuProps> = ({
           );
         }}
       </ChakraMenu.Context>
-      <Portal>
-        <ChakraMenu.Positioner>
-          <ChakraMenu.Content css={styles.content}>
-            {items.map(({ onClick, text, value: itemValue }) => {
-              const optionColor = menuOptionColor || menuColor;
+      <ChakraMenu.Positioner>
+        <ChakraMenu.Content css={styles.content}>
+          {items.map(({ onClick, text, value: itemValue }) => {
+            const optionColor = menuOptionColor || menuColor;
 
-              return (
-                <ChakraMenu.Item
-                  key={`menuItem-${itemValue}`}
-                  value={itemValue}
-                  onSelect={onClick}
-                  css={styles.item}
-                  {...(optionColor && { color: optionColor })}
-                >
-                  {showOptionsCheckmark ? (
-                    <Box
-                      w="xs"
-                      display="flex"
-                      justifyContent="center"
-                      marginRight="sm"
-                    >
-                      {itemValue === value ? <CheckmarkIcon /> : null}
-                    </Box>
-                  ) : null}
-                  {text}
-                </ChakraMenu.Item>
-              );
-            })}
-          </ChakraMenu.Content>
-        </ChakraMenu.Positioner>
-      </Portal>
+            return (
+              <ChakraMenu.Item
+                key={`menuItem-${itemValue}`}
+                value={itemValue}
+                onSelect={onClick}
+                css={styles.item}
+                {...(optionColor && { color: optionColor })}
+              >
+                {showOptionsCheckmark ? (
+                  <Box
+                    w="xs"
+                    display="flex"
+                    justifyContent="center"
+                    marginRight="sm"
+                  >
+                    {itemValue === value ? <CheckmarkIcon /> : null}
+                  </Box>
+                ) : null}
+                {text}
+              </ChakraMenu.Item>
+            );
+          })}
+        </ChakraMenu.Content>
+      </ChakraMenu.Positioner>
     </ChakraMenu.Root>
   );
 };

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -85,7 +85,7 @@ export const Menu: FC<MenuProps> = ({
 
               return (
                 <ChakraMenu.Item
-                  key={`menuItem-${value}`}
+                  key={`menuItem-${itemValue}`}
                   value={itemValue}
                   onSelect={onClick}
                   css={styles.item}


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Initially we did not use Portal around Menu as it affects rendering the Menu component inside Dialog or other stacked UI elements. Menu has `z-index` which positions it above its parent, and Portal as not needed. When we migrated Menu, Portal was added and broke action links in Vehicle Pool. More info https://chakra-ui.com/docs/components/menu#open-from-dialog

MenuItems previously used `index` value to build a key, and now it uses `value` from the provided item object.

## Before

Portal wraps Menu.
MenuItems keys are duplicated.

## After

Portal removed from Menu.
MenuItems keys are correct and based on provided data.

## How to test

https://fix-menu-component-components-pkg.branch.autoscout24.dev/?path=/docs/patterns-data-display-menu--documentation
