### PR TITLE
fix: extend input invalid state adapter

### DIFF
--- a/src/components/adapter/Input/index.tsx
+++ b/src/components/adapter/Input/index.tsx
@@ -3,9 +3,10 @@ import React, { forwardRef } from 'react';
 import { Input as InputComponents, InputProps } from 'src/components/input';
 
 type AdapterType<T> = T extends unknown
-  ? Omit<T, 'disabled' | 'readOnly'> & {
+  ? Omit<T, 'disabled' | 'readOnly' | 'invalid'> & {
       isDisabled?: boolean;
       isReadOnly?: boolean;
+      isInvalid?: boolean;
       textColor?: InputProps['color'];
     }
   : never;
@@ -13,12 +14,13 @@ type AdapterType<T> = T extends unknown
 type Props = AdapterType<InputProps>;
 
 export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { isDisabled, isReadOnly, textColor, ...rest } = props;
+  const { isDisabled, isReadOnly, isInvalid, textColor, ...rest } = props;
 
   return (
     <InputComponents
       color={textColor}
       {...(isReadOnly ? { readOnly: true } : {})}
+      {...(isInvalid ? { invalid: true } : {})}
       disabled={isDisabled}
       ref={ref}
       {...rest}


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Expose `isInvalid` prop for Input component.

## Before

`seller-web` component `shared/components/insertion/imageUpload/VideoUrlInput.tsx` fails to set prop `isInvalid` on Input component.

## After

`seller-web` component `shared/components/insertion/imageUpload/VideoUrlInput.tsx` can set prop `isInvalid` on Input component.

## How to test

tbd