### PR TITLE
fix: extend popover adapter to handle close on blur

### DIFF
--- a/src/components/adapter/Popover/index.tsx
+++ b/src/components/adapter/Popover/index.tsx
@@ -12,10 +12,11 @@ type Props = PopoverProps & {
   onOpen?: () => void;
   onClose?: () => void;
   isOpen?: boolean;
+  closeOnBlur?: boolean;
 };
 
 export const Popover: React.FC<Props> = ({ trigger = 'click', ...props }) => {
-  const { onOpen, onClose, isOpen, ...rest } = props;
+  const { onOpen, onClose, isOpen, closeOnBlur, ...rest } = props;
   if (trigger === 'hover') {
     return <HoverCard {...rest} />;
   }
@@ -24,6 +25,7 @@ export const Popover: React.FC<Props> = ({ trigger = 'click', ...props }) => {
     <PopoverComponents
       {...rest}
       open={isOpen}
+      closeOnInteractOutside={closeOnBlur}
       onOpenChange={({ open }) => {
         if (open) {
           onOpen?.();


### PR DESCRIPTION
## Motivation and context

Expose `closeOnBlur` prop for Popover component.

## Before

`seller-web` component `shared/components/insertion/direct/imagesUpload/requiredImagesSection/Dropzone.tsx` fails to set prop `closeOnBlur` on Popover component.

## After

`seller-web` component `shared/components/insertion/direct/imagesUpload/requiredImagesSection/Dropzone.tsx` can set prop `closeOnBlur` on Popover component.