### PR TITLE
fix: make drawer close button sticky

### DIFF
--- a/src/themes/shared/slotRecipes/drawer.ts
+++ b/src/themes/shared/slotRecipes/drawer.ts
@@ -31,6 +31,9 @@ export const drawerRecipe = defineSlotRecipe({
     content: {
       bg: 'white',
       boxShadow: 'xs',
+      overflow: 'auto',
+      display: 'flex',
+      flexDirection: 'column',
     },
     body: {
       flex: 1,


### PR DESCRIPTION
## Motivation and context

Drawer close button should be sticky, with scrollable content behind it.
Reported bug (8. Missing sticky X button): https://smg-au.atlassian.net/browse/FED-1064

## Before

Drawer close button not sticky.

## After

Drawer close button sticky.

## How to test

https://drawer-close-components-pkg.branch.autoscout24.dev/?path=/docs/components-data-display-drawer--documentation