### PR TITLE
feat: add link to ombudsman's office in footer

### DIFF
--- a/src/components/navigation/footer/config/index.ts
+++ b/src/components/navigation/footer/config/index.ts
@@ -260,6 +260,19 @@ export const footerConfig = (): FooterConfigInterface => ({
           },
           target: '_blank',
         },
+        {
+          translationKey: 'footer.sections.aboutUs.ombudsmanOffice',
+          visibilitySettings: {
+            brand: { [Brand.AutoScout24]: true, [Brand.MotoScout24]: true },
+          },
+          link: {
+            de: 'https://konsum.ch/de/ombudsstellen/ombudsstelle-mobilitaetsplattformen/',
+            en: 'https://konsum.ch/en/ombudsmans-office-for-mobility-platforms/',
+            fr: 'https://konsum.ch/fr/service-de-mediation-pour-les-plateformes-de-mobilite/',
+            it: 'https://konsum.ch/it/ufficio-del-mediatore-per-le-piattaforme-di-mobilita/',
+          },
+          target: '_blank',
+        },
       ],
     },
     {

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -98,6 +98,7 @@
         "factsAndFigures": "Portfolio",
         "jobs": "Offene Stellen",
         "newsletter": "Newsletter",
+        "ombudsmanOffice": "Ombudsstelle",
         "title": "Über uns"
       },
       "advertisement": {

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -98,6 +98,7 @@
         "factsAndFigures": "Portfolio",
         "jobs": "Careers",
         "newsletter": "Newsletter",
+        "ombudsmanOffice": "Ombudsman’s Office",
         "title": "About Us"
       },
       "advertisement": {

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -98,6 +98,7 @@
         "factsAndFigures": "Portefeuille",
         "jobs": "Postes vacants",
         "newsletter": "Newsletter",
+        "ombudsmanOffice": "Service de médiation",
         "title": "A propos de nous"
       },
       "advertisement": {

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -98,6 +98,7 @@
         "factsAndFigures": "Portafoglio",
         "jobs": "Lavori",
         "newsletter": "Newsletter",
+        "ombudsmanOffice": "Ufficio del mediatore",
         "title": "Chi siamo"
       },
       "advertisement": {


### PR DESCRIPTION
References [[link the ticket here]](https://smg-au.atlassian.net/browse/DM-5294)

## Motivation and context

The Ombudsstelle for mobility platforms supports customers in resolving complaints or issues related to platforms like AutoScout24 and MotoScout24. It acts as a neutral mediator between users and platform providers, working towards fair and mutually acceptable solutions.

What do we need?
We would like to add “Ombudsstelle” to the footer of AutoScout24 and MotoScout24, linking to the official Ombudsstelle website (DE, EN, FR, IT). My suggestion would be to place it under “About us” on both platforms.

Timeline:
We would need this implemented by the end of April. It is important that the Ombudsstelle is available before the communication of the upcoming price adjustments. 
