### PR TITLE
fix: button support for NextLink

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -17,7 +17,9 @@ type Never<Source> = { [P in keyof Source]?: never };
 type LinkButton = {
   href?: string;
   isExternal?: boolean;
+  prefetch?: boolean;
   rel?: string;
+  replace?: boolean;
 };
 
 type IconButton = {
@@ -84,13 +86,56 @@ export const Button = forwardRef<HTMLButtonElement, UnifiedButtonProps>(
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
 
-    const { as = 'button', disabled, ...rest } = restProps;
+    const {
+      as = 'button',
+      disabled,
+      href,
+      isExternal,
+      prefetch,
+      rel,
+      replace,
+      ...rest
+    } = restProps;
 
     const asLinkProps = {
-      target: props.isExternal ? '_blank' : undefined,
-      rel: props.rel || (props.isExternal ? 'noopener noreferrer' : undefined),
+      target: isExternal ? '_blank' : undefined,
+      rel: rel || (isExternal ? 'noopener noreferrer' : undefined),
       ...(props.disabled ? { 'aria-disabled': true } : {}),
     };
+
+    const content = (
+      <>
+        {props.leftIcon ? props.leftIcon : props.icon}
+        {props.children}
+        {props.rightIcon ? props.rightIcon : undefined}
+      </>
+    );
+
+    const isComponentAs = Boolean(as) && typeof as !== 'string';
+
+    if (isComponentAs) {
+      const AsComp = as as React.ElementType;
+
+      return (
+        <ChakraButton
+          ref={ref}
+          css={styles}
+          asChild
+          disabled={disabled}
+          aria-label={props.children ? undefined : props.ariaLabel}
+          {...rest}
+        >
+          <AsComp
+            href={href}
+            prefetch={prefetch}
+            replace={replace}
+            onClick={props.onClick}
+          >
+            {content}
+          </AsComp>
+        </ChakraButton>
+      );
+    }
 
     return (
       <ChakraButton
@@ -100,18 +145,16 @@ export const Button = forwardRef<HTMLButtonElement, UnifiedButtonProps>(
         disabled={disabled}
         aria-label={props.children ? undefined : props.ariaLabel}
         {...rest}
-        {...(props.as === 'a' ? asLinkProps : {})}
+        {...(as === 'a' ? asLinkProps : {})}
         onClick={(e) => {
-          if (props.as === 'a' && props.href && disabled) {
+          if (as === 'a' && href && disabled) {
             e.preventDefault();
           } else {
             props.onClick?.(e);
           }
         }}
       >
-        {props.leftIcon ? props.leftIcon : props.icon}
-        {props.children}
-        {props.rightIcon ? props.rightIcon : undefined}
+        {content}
       </ChakraButton>
     );
   },

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -98,9 +98,19 @@ export const Button = forwardRef<HTMLButtonElement, UnifiedButtonProps>(
     } = restProps;
 
     const asLinkProps = {
+      href,
       target: isExternal ? '_blank' : undefined,
       rel: rel || (isExternal ? 'noopener noreferrer' : undefined),
-      ...(props.disabled ? { 'aria-disabled': true } : {}),
+      ...(disabled ? { 'aria-disabled': true } : {}),
+    };
+
+    const handleClick: ChakraButtonProps['onClick'] = (e) => {
+      if (href && disabled) {
+        e.preventDefault();
+        return;
+      }
+
+      props.onClick?.(e);
     };
 
     const content = (
@@ -126,10 +136,10 @@ export const Button = forwardRef<HTMLButtonElement, UnifiedButtonProps>(
           {...rest}
         >
           <AsComp
-            href={href}
+            {...asLinkProps}
             prefetch={prefetch}
             replace={replace}
-            onClick={props.onClick}
+            onClick={handleClick}
           >
             {content}
           </AsComp>
@@ -146,13 +156,7 @@ export const Button = forwardRef<HTMLButtonElement, UnifiedButtonProps>(
         aria-label={props.children ? undefined : props.ariaLabel}
         {...rest}
         {...(as === 'a' ? asLinkProps : {})}
-        onClick={(e) => {
-          if (as === 'a' && href && disabled) {
-            e.preventDefault();
-          } else {
-            props.onClick?.(e);
-          }
-        }}
+        onClick={handleClick}
       >
         {content}
       </ChakraButton>


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Fixes insertion navigation getting stuck in a checkout/features back-loop for professional sellers.

The root cause is that insertion navigation Back links rely on Button as={NextLink} replace, but the current @smg-automotive/components Button does not explicitly support forwarding NextLink-only props like replace when rendered with a custom as component. As a result, clicking Back from checkout pushes /features onto history instead of replacing /checkout, so clicking Back again from /features returns to checkout.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
