### PR TITLE
feat: useClipboard hook

### DIFF
--- a/src/hooks/__tests__/useClipboard.Test.ts
+++ b/src/hooks/__tests__/useClipboard.Test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook } from '@/jest-utils';
+
+import useClipboard from '../useClipboard';
+
+type ClipboardMock = {
+  writeText?: jest.Mock<Promise<void>, [string]>;
+};
+
+const setClipboard = (clipboard?: ClipboardMock) => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: clipboard,
+  });
+};
+
+const setExecCommand = (successful: boolean) => {
+  const execCommand = jest.fn(() => successful);
+
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    value: execCommand,
+  });
+
+  return execCommand;
+};
+
+describe('useClipboard', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    setClipboard();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(document, 'execCommand');
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('should copy text using the Clipboard API and reset hasCopied after the timeout', async () => {
+    const writeText = jest.fn<Promise<void>, [string]>().mockResolvedValue();
+    setClipboard({ writeText });
+
+    const { result } = renderHook(() =>
+      useClipboard('Copied value', { timeout: 500 }),
+    );
+
+    let copied = false;
+
+    await act(async () => {
+      copied = await result.current.onCopy();
+    });
+
+    expect(copied).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('Copied value');
+    expect(result.current.hasCopied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.hasCopied).toBe(false);
+  });
+
+  it('should fall back to execCommand when the Clipboard API is not available', async () => {
+    const execCommand = setExecCommand(true);
+
+    const { result } = renderHook(() => useClipboard('Fallback value'));
+
+    let copied = false;
+
+    await act(async () => {
+      copied = await result.current.onCopy();
+    });
+
+    expect(copied).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(result.current.hasCopied).toBe(true);
+  });
+
+  it('should fall back to execCommand when the Clipboard API rejects', async () => {
+    const writeText = jest
+      .fn<Promise<void>, [string]>()
+      .mockRejectedValue(new Error('Clipboard unavailable'));
+    const execCommand = setExecCommand(true);
+    setClipboard({ writeText });
+
+    const { result } = renderHook(() => useClipboard('Rejected value'));
+
+    let copied = false;
+
+    await act(async () => {
+      copied = await result.current.onCopy();
+    });
+
+    expect(copied).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('Rejected value');
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(result.current.hasCopied).toBe(true);
+  });
+
+  it('should return false and keep hasCopied false when copying fails', async () => {
+    setExecCommand(false);
+
+    const { result } = renderHook(() => useClipboard('Failed value'));
+
+    let copied = true;
+
+    await act(async () => {
+      copied = await result.current.onCopy();
+    });
+
+    expect(copied).toBe(false);
+    expect(result.current.hasCopied).toBe(false);
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { default as useDebouncedOnChange } from './useDebouncedOnChange';
 export { default as useBreakpointValue } from './useBreakpointValue';
 export { default as useToken } from './useToken';
 export { default as useToast } from './useToast';
+export { default as useClipboard } from './useClipboard';

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type UseClipboardOptions = {
+  timeout?: number;
+};
+
+type UseClipboardReturn = {
+  hasCopied: boolean;
+  onCopy: () => Promise<boolean>;
+};
+
+const fallbackCopy = (text: string): boolean => {
+  if (typeof document === 'undefined') return false;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let successful = false;
+
+  try {
+    successful = document.execCommand('copy');
+  } catch {
+    successful = false;
+  }
+
+  document.body.removeChild(textarea);
+  return successful;
+};
+
+const copyWithClipboardAPI = async (text: string): Promise<boolean> => {
+  if (typeof window === 'undefined') return false;
+
+  const nav = window.navigator as Navigator & {
+    clipboard?: {
+      writeText?: (value: string) => Promise<void>;
+    };
+  };
+
+  if (!nav.clipboard || typeof nav.clipboard.writeText !== 'function') {
+    return false;
+  }
+
+  await nav.clipboard.writeText(text);
+  return true;
+};
+
+const useClipboard = (
+  value: string,
+  options: UseClipboardOptions = {},
+): UseClipboardReturn => {
+  const { timeout = 1500 } = options;
+  const [hasCopied, setHasCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const onCopy = useCallback(async (): Promise<boolean> => {
+    let copied = false;
+
+    try {
+      copied = await copyWithClipboardAPI(value);
+
+      if (!copied) {
+        copied = fallbackCopy(value);
+      }
+    } catch {
+      copied = fallbackCopy(value);
+    }
+
+    if (!copied) {
+      setHasCopied(false);
+      return false;
+    }
+
+    setHasCopied(true);
+
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      setHasCopied(false);
+      timeoutRef.current = null;
+    }, timeout);
+
+    return true;
+  }, [timeout, value]);
+
+  return {
+    hasCopied,
+    onCopy,
+  };
+};
+
+export default useClipboard;


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Adds a new `useClipboard` hook for copying text to the user’s clipboard.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
