### PR TITLE
Fix popover hover mobile

### DIFF
--- a/src/components/adapter/Popover/index.tsx
+++ b/src/components/adapter/Popover/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useMediaQuery } from '@chakra-ui/react';
 
 import {
   Popover as PopoverComponents,
@@ -17,16 +18,27 @@ type Props = PopoverProps & {
 
 export const Popover: React.FC<Props> = ({ trigger = 'hover', ...props }) => {
   const { onOpen, onClose, isOpen, closeOnBlur, ...rest } = props;
-  if (trigger === 'hover') {
+  const [internalIsOpen, setInternalIsOpen] = React.useState(false);
+  const [supportsHover] = useMediaQuery(['(hover: hover) and (pointer: fine)']);
+  // Touch devices cannot reliably open hover cards, so hover-triggered popovers
+  // fall back to a click popover that owns its open state when uncontrolled.
+  const usesHoverCard = trigger === 'hover' && supportsHover;
+  const isControlled = isOpen !== undefined;
+
+  if (usesHoverCard) {
     return <HoverCard {...rest} />;
   }
 
   return (
     <PopoverComponents
       {...rest}
-      open={isOpen}
-      closeOnInteractOutside={closeOnBlur}
+      open={isControlled ? isOpen : internalIsOpen}
+      closeOnInteractOutside={closeOnBlur ?? trigger === 'hover'}
       onOpenChange={({ open }) => {
+        if (!isControlled) {
+          setInternalIsOpen(open);
+        }
+
         if (open) {
           onOpen?.();
         } else {

--- a/src/components/adapter/Popover/index.tsx
+++ b/src/components/adapter/Popover/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useMediaQuery } from '@chakra-ui/react';
 
 import {
   Popover as PopoverComponents,
@@ -16,17 +17,37 @@ type Props = PopoverProps & {
 };
 
 export const Popover: React.FC<Props> = ({ trigger = 'hover', ...props }) => {
-  const { onOpen, onClose, isOpen, closeOnBlur, ...rest } = props;
-  if (trigger === 'hover') {
+  const {
+    onOpen,
+    onClose,
+    isOpen,
+    closeOnBlur,
+    closeOnInteractOutside,
+    ...rest
+  } = props;
+  const [internalIsOpen, setInternalIsOpen] = React.useState(false);
+  const [supportsHover] = useMediaQuery(['(hover: hover) and (pointer: fine)']);
+  // Touch devices cannot reliably open hover cards, so hover-triggered popovers
+  // fall back to a click popover that owns its open state when uncontrolled.
+  const usesHoverCard = trigger === 'hover' && supportsHover;
+  const isControlled = isOpen !== undefined;
+
+  if (usesHoverCard) {
     return <HoverCard {...rest} />;
   }
 
   return (
     <PopoverComponents
       {...rest}
-      open={isOpen}
-      closeOnInteractOutside={closeOnBlur}
+      open={isControlled ? isOpen : internalIsOpen}
+      closeOnInteractOutside={
+        closeOnInteractOutside ?? closeOnBlur ?? trigger === 'hover'
+      }
       onOpenChange={({ open }) => {
+        if (!isControlled) {
+          setInternalIsOpen(open);
+        }
+
         if (open) {
           onOpen?.();
         } else {


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Fixes touch-device behavior for Popover trigger="hover" by falling back to a click-based popover when hover is not supported.

What Changed

- Updated the Popover adapter to detect hover-capable devices with: '(hover: hover) and (pointer: fine)'
- Keeps existing HoverCard behavior for desktop mouse/trackpad users.
- Uses the click popover path on touch devices so tooltip-style popovers can open via tap.
- Added internal open state for uncontrolled fallback popovers.
- Preserves explicit outside-click behavior by respecting closeOnInteractOutside before falling back to closeOnBlur or the hover fallback default.

Some consumers use Popover trigger="hover" for tooltip-like content. This works on desktop, but touch devices cannot reliably trigger hover, so tapping the icon did not show the popover content.

While testing the fallback, we also found that explicit closeOnInteractOutside={true} was being overwritten in the adapter, which prevented click popovers like cockpit “View settings” from closing on outside click.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
