### PR TITLE
fix: tooltip overflow issue

### DIFF
--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,6 +1,7 @@
 import React, { cloneElement, FC, ReactNode, useState } from 'react';
 
 import {
+  Portal,
   TooltipArrow,
   TooltipArrowTip,
   TooltipContent,
@@ -43,14 +44,16 @@ export const Tooltip: FC<TooltipProps> = ({
       open={isOpen}
     >
       <TooltipTrigger asChild={true}>{childrenWithProps}</TooltipTrigger>
-      <TooltipPositioner>
-        <TooltipContent maxWidth={maxWidth}>
-          <TooltipArrow>
-            <TooltipArrowTip />
-          </TooltipArrow>
-          {label}
-        </TooltipContent>
-      </TooltipPositioner>
+      <Portal>
+        <TooltipPositioner>
+          <TooltipContent maxWidth={maxWidth}>
+            <TooltipArrow>
+              <TooltipArrowTip />
+            </TooltipArrow>
+            {label}
+          </TooltipContent>
+        </TooltipPositioner>
+      </Portal>
     </TooltipRoot>
   );
 };


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Render `TooltipPositioner` through a Chakra `Portal` in the shared `Tooltip` component.

#### Why

Tooltips were being rendered inline with their trigger. When a tooltip appeared inside a parent with `overflow: hidden`, such as an accordion panel, the tooltip content could be clipped and not fully visible.

Using a portal lets the floating tooltip content escape clipping containers while keeping the trigger in its original layout position.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
