### PR TITLE
fix: Gallery header background

### DIFF
--- a/src/components/galleryHeader/Content.tsx
+++ b/src/components/galleryHeader/Content.tsx
@@ -37,8 +37,7 @@ const GalleryHeaderContent: FC<PropsWithChildren<GalleryHeaderProps>> = ({
       left={0}
       right={0}
       zIndex={1}
-      background="black"
-      opacity={0.5}
+      bg="blackAlpha.600"
     >
       <SimpleGrid
         columns={{

--- a/src/components/galleryHeader/Content.tsx
+++ b/src/components/galleryHeader/Content.tsx
@@ -37,6 +37,8 @@ const GalleryHeaderContent: FC<PropsWithChildren<GalleryHeaderProps>> = ({
       left={0}
       right={0}
       zIndex={1}
+      background="black"
+      opacity={0.5}
     >
       <SimpleGrid
         columns={{


### PR DESCRIPTION
References [JIRA](https://smg-au.atlassian.net/browse/DM-5247)

## Motivation and context

Due to new feature on fullscreen gallery, zoom, on mobile when picture is zoomed header controls are not visible. 

## Before

- No background 

## After

- Background with opacity

<img width="1728" height="853" alt="Screenshot 2026-05-13 at 09 54 29" src="https://github.com/user-attachments/assets/da1f7fe2-f0c1-44a3-949e-0b41fd412f93" />
<img width="1728" height="853" alt="Screenshot 2026-05-13 at 09 54 42" src="https://github.com/user-attachments/assets/da7043a1-5efe-4310-bd61-57664a9a84e5" />
