### PR TITLE
fix: radio button render function type

### DIFF
--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -17,7 +17,7 @@ export type RadioItemProps = {
   disabled?: boolean;
 };
 
-type RadioRenderFn = (renderedItems: React.ReactElement[]) => ReactNode;
+export type RadioRenderFn = (renderedItems: React.ReactElement[]) => ReactNode;
 
 export type RadioProps = RecipeVariantProps<typeof radioRecipe> & {
   value?: string;

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -17,7 +17,7 @@ export type RadioItemProps = {
   disabled?: boolean;
 };
 
-export type RadioRenderFn = (renderedItems: ReactNode) => ReactNode;
+type RadioRenderFn = (renderedItems: React.ReactElement[]) => ReactNode;
 
 export type RadioProps = RecipeVariantProps<typeof radioRecipe> & {
   value?: string;


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Radio creates renderedItems internally by mapping items to concrete JSX radio elements. Typing the argument as ReactElement[] instead of ReactNode to better matche the actual API and avoids consumers needing local casts when wrapping or arranging the rendered radio items.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
