### PR TITLE
Nudge PR authors to be aware of Chakra v3 update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 References [link the ticket here]
 
-- [] I hereby solemnly swear that I will sync these changes to the [chakra-integration](https://github.com/smg-automotive/seller-web/pull/4351) branch right after merging this to main.
+- [ ] I hereby solemnly swear that I will sync these changes to the [chakra-integration](/tree/chakra-integration) branch right after merging this to main.
 
 ## Motivation and context
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 References [link the ticket here]
 
+- [] I hereby solemnly swear that I will sync these changes to the [chakra-integration](https://github.com/smg-automotive/seller-web/pull/4351) branch right after merging this to main.
+
 ## Motivation and context
 
 [Describe the problem we're solving and lay out the solution]


### PR DESCRIPTION
Added a line about syncing changes to the chakra-integration branch after merging to main.

- [ ] I hereby solemnly swear that I will sync these changes to the [chakra-integration](https://github.com/smg-automotive/seller-web/pull/4351) branch right after merging this to main.

References https://automotivesmg.slack.com/archives/C034EGP8GG0/p1778582706458069
