### PR TITLE
fix: Popover filter content padding.

### DIFF
--- a/src/themes/shared/slotRecipes/popoverFilter.ts
+++ b/src/themes/shared/slotRecipes/popoverFilter.ts
@@ -30,6 +30,7 @@ const baseContentStyle = defineStyle({
   borderRadius: 'sm',
   backgroundColor: 'white',
   shadow: 'md',
+  padding: 0,
   _open: {
     animationName: 'fade-in',
     animationDuration: 'normal',


### PR DESCRIPTION
## Motivation and context

Padding X is added on body of popover filter. Content padding is redudant

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
