### PR TITLE
fix: Box as Link/NextLink does not pass props properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b
+FROM node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
 
 WORKDIR /app
 ADD . /app

--- a/src/components/adapter/Box/index.tsx
+++ b/src/components/adapter/Box/index.tsx
@@ -13,10 +13,6 @@ type PolymorphicProps<
     keyof OwnProps | 'as' | 'children'
   >;
 
-/** Public adapter props:
- * - do NOT expose `css` (compat layer is sx-only)
- * - keep textColor/spacing mappings
- */
 type Props = Omit<BoxProps, 'color'> & {
   textColor?: BoxProps['color'];
   spacing?: BoxProps['gap'];
@@ -30,27 +26,60 @@ export type BoxAdapterProps<E extends ElementType = 'div'> = PolymorphicProps<
 export const Box = React.forwardRef(function BoxAdapter<
   E extends ElementType = 'div',
 >(props: BoxAdapterProps<E>, ref: React.ForwardedRef<unknown>) {
-  const { as, textColor, spacing, color, sx, children, ...rest } = props;
+  const {
+    as,
+    textColor,
+    spacing,
+    color,
+    sx,
+    children,
+
+    // Link-like props, e.g. NextLink
+    href,
+    prefetch,
+
+    ...rest
+  } = props;
+
+  const boxProps = {
+    ...rest,
+    sx,
+    ...(color !== undefined ? { color } : {}),
+    ...(textColor !== undefined ? { color: textColor } : {}),
+    ...(spacing !== undefined ? { gap: spacing } : {}),
+  };
+
+  const isLinkLike =
+    as !== undefined && (href !== undefined || prefetch !== undefined);
 
   if (!as) {
     return (
-      <BoxComponents
-        {...rest}
-        {...(color ? { color } : {})}
-        {...(textColor ? { color: textColor } : {})}
-        {...(spacing ? { gap: spacing } : {})}
-        ref={ref}
-      >
+      <BoxComponents {...boxProps} ref={ref}>
         {children}
       </BoxComponents>
     );
   }
 
-  const AsComp = as as ElementType; // relies on your existing approach
+  const AsComp = as as ElementType;
+
+  if (isLinkLike) {
+    return (
+      <BoxComponents {...boxProps} asChild ref={ref}>
+        <AsComp
+          {...{
+            href,
+            prefetch,
+          }}
+        >
+          {children}
+        </AsComp>
+      </BoxComponents>
+    );
+  }
 
   return (
-    <BoxComponents {...props} asChild ref={ref}>
-      <AsComp>{children}</AsComp>
+    <BoxComponents {...boxProps} as={AsComp} ref={ref}>
+      {children}
     </BoxComponents>
   );
 }) as <E extends ElementType = 'div'>(

--- a/src/components/adapter/Box/index.tsx
+++ b/src/components/adapter/Box/index.tsx
@@ -50,7 +50,9 @@ export const Box = React.forwardRef(function BoxAdapter<
   };
 
   const isLinkLike =
-    as !== undefined && (href !== undefined || prefetch !== undefined);
+    as !== undefined &&
+    typeof as !== 'string' &&
+    (href !== undefined || prefetch !== undefined);
 
   if (!as) {
     return (


### PR DESCRIPTION
## Motivation and context

When Box is being used in combination with `as` prop for `NextLink`, `NextLink` specific props were not passed properly.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
