### PR TITLE
feat(SecuritySettings): add header link

### DIFF
--- a/src/components/navigation/header/config/DrawerNodeItems.tsx
+++ b/src/components/navigation/header/config/DrawerNodeItems.tsx
@@ -15,6 +15,7 @@ import {
   getFavoritesLinkConfig,
   getLogoutLinkConfig,
   savedSearchesLinkConfig,
+  securitySettingsLinkConfig,
 } from './user';
 import {
   autoScoutTopVehiclesLinkConfig,
@@ -175,6 +176,7 @@ const getUserNodeItems = ({
     translationKey: 'header.userMenu.accountSettings',
     items: [
       editUsersLinkConfig,
+      securitySettingsLinkConfig,
       changeLanguageLinkConfig,
       getLogoutLinkConfig({ onLogout }),
     ],

--- a/src/components/navigation/header/config/user.ts
+++ b/src/components/navigation/header/config/user.ts
@@ -43,6 +43,27 @@ export const editUsersLinkConfig: NavigationLinkConfigProps = {
   },
 };
 
+export const securitySettingsLinkConfig: NavigationLinkConfigProps = {
+  translationKey: 'header.userMenu.securitySettings',
+  link: {
+    de: '/de/account/security-settings',
+    en: '/en/account/security-settings',
+    fr: '/fr/account/security-settings',
+    it: '/it/account/security-settings',
+  },
+  visibilitySettings: {
+    userType: {
+      private: true,
+      professional: true,
+    },
+    brand: {
+      autoscout24: true,
+      motoscout24: true,
+    },
+  },
+  projectIdentifier: 'seller-web',
+};
+
 export const changeLanguageLinkConfig: NavigationLinkConfigProps = {
   translationKey: 'header.userMenu.userLanguage',
   link: {

--- a/src/locales/de/dict.json
+++ b/src/locales/de/dict.json
@@ -195,6 +195,7 @@
       "qualityLogo": "Qualitätslogo",
       "requisitions": "Suchaufträge",
       "reviews": "Bewertungen",
+      "securitySettings": "Anmeldung und Sicherheit",
       "settings": "Einstellungen",
       "toolsForPurchasing": "Tools für den Einkauf",
       "toolsForSelling": "Tools für den Verkauf",

--- a/src/locales/en/dict.json
+++ b/src/locales/en/dict.json
@@ -195,6 +195,7 @@
       "qualityLogo": "Quality logo",
       "requisitions": "Saved searches",
       "reviews": "Reviews",
+      "securitySettings": "Login & security",
       "settings": "Settings",
       "toolsForPurchasing": "Buying tools",
       "toolsForSelling": "Selling tools",

--- a/src/locales/fr/dict.json
+++ b/src/locales/fr/dict.json
@@ -195,6 +195,7 @@
       "qualityLogo": "Sigle de qualité",
       "requisitions": "Profil de recherche",
       "reviews": "Évaluations",
+      "securitySettings": "Connexion et sécurité",
       "settings": "Préférences",
       "toolsForPurchasing": "Outils pour l'achat",
       "toolsForSelling": "Outils pour la vente",

--- a/src/locales/it/dict.json
+++ b/src/locales/it/dict.json
@@ -195,6 +195,7 @@
       "qualityLogo": "Sigillo qualità",
       "requisitions": "Ordini di ricerca",
       "reviews": "Valutazioni",
+      "securitySettings": "Accesso e sicurezza",
       "settings": "Preferenze",
       "toolsForPurchasing": "Strumenti per l'acquisto",
       "toolsForSelling": "Gestire veicoli",


### PR DESCRIPTION
- [x] I hereby solemnly swear that I will sync these changes to the [chakra-integration](/tree/chakra-integration) branch right after merging this to main.

## Motivation and context

- Add a link to the security settings page to the header

## How to test

- Verify that a link to the security settings page exists in the header
