### PR TITLE
[codex] Add brand-specific theme provider exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,33 @@ Theme objects can also be imported directly from the package (for showcasing, de
 import { autoScout24Theme } from '@smg-automotive/components';
 ```
 
+For single-brand applications, prefer the brand-specific provider entrypoints so the
+application only imports the selected brand theme:
+
+```tsx
+import { AutoScout24ThemeProvider } from '@smg-automotive/components/theme-provider/autoscout24';
+
+const App = ({ Component, pageProps }) => {
+  return (
+    <AutoScout24ThemeProvider>
+      <Component {...pageProps} />
+    </AutoScout24ThemeProvider>
+  );
+};
+```
+
+```tsx
+import { MotoScout24Providers } from '@smg-automotive/components/theme-provider/motoscout24';
+
+const App = ({ Component, pageProps }) => {
+  return (
+    <MotoScout24Providers>
+      <Component {...pageProps} />
+    </MotoScout24Providers>
+  );
+};
+```
+
 ### Switching themes in storybook
 
 We leverage [a theming addon](https://storybook.js.org/addons/storybook-addon-themes#custom-decorator) in storybook.

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ const App = ({ Component, pageProps }) => {
 ```
 
 ```tsx
-import { MotoScout24Providers } from '@smg-automotive/components/theme-provider/motoscout24';
+import { MotoScout24ThemeProvider } from '@smg-automotive/components/theme-provider/motoscout24';
 
 const App = ({ Component, pageProps }) => {
   return (
-    <MotoScout24Providers>
+    <MotoScout24ThemeProvider>
       <Component {...pageProps} />
-    </MotoScout24Providers>
+    </MotoScout24ThemeProvider>
   );
 };
 ```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,26 @@
         "types": "./dist/fonts/esm/types/Hosted.d.ts",
         "default": "./dist/fonts/cjs/Hosted.js"
       }
+    },
+    "./theme-provider/autoscout24": {
+      "import": {
+        "types": "./dist/components/themeProvider/AutoScout24ThemeProvider.d.mts",
+        "default": "./dist/esm/components/themeProvider/AutoScout24ThemeProvider.js"
+      },
+      "require": {
+        "types": "./dist/components/themeProvider/AutoScout24ThemeProvider.d.ts",
+        "default": "./dist/cjs/components/themeProvider/AutoScout24ThemeProvider.js"
+      }
+    },
+    "./theme-provider/motoscout24": {
+      "import": {
+        "types": "./dist/components/themeProvider/MotoScout24ThemeProvider.d.mts",
+        "default": "./dist/esm/components/themeProvider/MotoScout24ThemeProvider.js"
+      },
+      "require": {
+        "types": "./dist/components/themeProvider/MotoScout24ThemeProvider.d.ts",
+        "default": "./dist/cjs/components/themeProvider/MotoScout24ThemeProvider.js"
+      }
     }
   },
   "types": "dist/index.d.ts",
@@ -31,6 +51,12 @@
     "*": {
       "fonts/hosted": [
         "dist/fonts/esm/types/Hosted"
+      ],
+      "theme-provider/autoscout24": [
+        "dist/components/themeProvider/AutoScout24ThemeProvider"
+      ],
+      "theme-provider/motoscout24": [
+        "dist/components/themeProvider/MotoScout24ThemeProvider"
       ]
     }
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,7 +4,7 @@ import executable from 'rollup-plugin-executable';
 import dts from 'rollup-plugin-dts';
 import copy from 'rollup-plugin-copy';
 import shebang from 'rollup-plugin-add-shebang';
-import { dirname } from 'path';
+import { basename, dirname } from 'path';
 import typescript from '@rollup/plugin-typescript';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
@@ -33,6 +33,17 @@ const fontsHostedRequire = packageJson.exports[
 const fontsHostedImport = packageJson.exports[
   './fonts/hosted'
 ].import.default.replace(/^.\//, '');
+
+const themeProviderEntries = [
+  {
+    input: 'src/components/themeProvider/AutoScout24ThemeProvider.tsx',
+    exportPath: './theme-provider/autoscout24',
+  },
+  {
+    input: 'src/components/themeProvider/MotoScout24ThemeProvider.tsx',
+    exportPath: './theme-provider/motoscout24',
+  },
+];
 
 const resolveOptions = { moduleDirectories: ['.', 'node_modules'] };
 const rootDir = dirname(fileURLToPath(import.meta.url));
@@ -189,6 +200,73 @@ const hostedFontsEsm = {
   onwarn,
 };
 
+const createThemeProviderJsBuild = ({ input, exportPath }, condition) => {
+  const outputFile = packageJson.exports[exportPath][condition].default.replace(
+    /^.\//,
+    '',
+  );
+
+  return {
+    input,
+    output: [
+      {
+        file: outputFile,
+        format: condition === 'require' ? 'cjs' : 'esm',
+        ...(condition === 'require' ? { exports: 'named' } : {}),
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      ...jsPlugins,
+      typescript({
+        tsconfig: './tsconfig.build.json',
+        compilerOptions: {
+          declaration: false,
+          declarationMap: false,
+          outDir: dirname(outputFile),
+        },
+      }),
+    ],
+    external,
+    onwarn,
+  };
+};
+
+const createThemeProviderTypesBuild = ({ input, exportPath }) => {
+  const typeFile = packageJson.exports[exportPath].require.types.replace(
+    /^.\//,
+    '',
+  );
+  const moduleTypeFile = packageJson.exports[exportPath].import.types.replace(
+    /^.\//,
+    '',
+  );
+
+  return {
+    input,
+    output: [{ file: typeFile, format: 'esm' }],
+    plugins: [
+      dts({ tsconfig: './tsconfig.build.json' }),
+      copy({
+        targets: [
+          {
+            src: typeFile,
+            dest: dirname(moduleTypeFile),
+            rename: basename(moduleTypeFile),
+          },
+        ],
+        hook: 'writeBundle',
+      }),
+    ],
+  };
+};
+
+const themeProviderBuilds = themeProviderEntries.flatMap((entry) => [
+  createThemeProviderTypesBuild(entry),
+  createThemeProviderJsBuild(entry, 'require'),
+  createThemeProviderJsBuild(entry, 'import'),
+]);
+
 const cli = {
   input: 'src/lib/cli/index.ts',
   output: [
@@ -236,5 +314,6 @@ export default [
   hostedFontsTypes,
   hostedFontsCjs,
   hostedFontsEsm,
+  ...themeProviderBuilds,
   cli,
 ];

--- a/src/components/themeProvider/AutoScout24ThemeProvider.tsx
+++ b/src/components/themeProvider/AutoScout24ThemeProvider.tsx
@@ -1,0 +1,18 @@
+import React, { type FC, type PropsWithChildren } from 'react';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import { theme } from '@/src/themes/autoscout24';
+
+export type AutoScout24ThemeProviderProps = PropsWithChildren;
+
+export const AutoScout24ThemeProvider: FC<AutoScout24ThemeProviderProps> = ({
+  children,
+}) => {
+  return (
+    <ChakraProvider theme={theme} resetCSS={true}>
+      {children}
+    </ChakraProvider>
+  );
+};
+
+export default AutoScout24ThemeProvider;

--- a/src/components/themeProvider/MotoScout24ThemeProvider.tsx
+++ b/src/components/themeProvider/MotoScout24ThemeProvider.tsx
@@ -15,6 +15,4 @@ export const MotoScout24ThemeProvider: FC<MotoScout24ThemeProviderProps> = ({
   );
 };
 
-export const MotoScout24Providers = MotoScout24ThemeProvider;
-
 export default MotoScout24ThemeProvider;

--- a/src/components/themeProvider/MotoScout24ThemeProvider.tsx
+++ b/src/components/themeProvider/MotoScout24ThemeProvider.tsx
@@ -1,0 +1,20 @@
+import React, { type FC, type PropsWithChildren } from 'react';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import { theme } from '@/src/themes/motoscout24';
+
+export type MotoScout24ThemeProviderProps = PropsWithChildren;
+
+export const MotoScout24ThemeProvider: FC<MotoScout24ThemeProviderProps> = ({
+  children,
+}) => {
+  return (
+    <ChakraProvider theme={theme} resetCSS={true}>
+      {children}
+    </ChakraProvider>
+  );
+};
+
+export const MotoScout24Providers = MotoScout24ThemeProvider;
+
+export default MotoScout24ThemeProvider;

--- a/src/components/themeProvider/__tests__/BrandThemeProvider.Test.tsx
+++ b/src/components/themeProvider/__tests__/BrandThemeProvider.Test.tsx
@@ -1,0 +1,41 @@
+import React, { type FC, type PropsWithChildren } from 'react';
+import { useTheme } from '@chakra-ui/react';
+
+import { theme as motoScout24Theme } from '@/src/themes/motoscout24';
+import { theme as autoScout24Theme } from '@/src/themes/autoscout24';
+
+import { screen, testingLibraryRender } from '@/jest-utils';
+
+import { MotoScout24Providers } from '../MotoScout24ThemeProvider';
+import AutoScout24ThemeProvider from '../AutoScout24ThemeProvider';
+
+const TestComponent: FC = () => {
+  const theme = useTheme();
+
+  return <div>{theme.colors.brand[100]}</div>;
+};
+
+const renderWrapper = (Provider: FC<PropsWithChildren>) =>
+  testingLibraryRender(
+    <Provider>
+      <TestComponent />
+    </Provider>,
+  );
+
+describe('brand-specific theme providers', () => {
+  it('provides autoscout24 theme without the generic provider', () => {
+    renderWrapper(AutoScout24ThemeProvider);
+
+    expect(
+      screen.getByText(autoScout24Theme.colors.brand[100]),
+    ).toBeInTheDocument();
+  });
+
+  it('provides motoscout24 theme without the generic provider', () => {
+    renderWrapper(MotoScout24Providers);
+
+    expect(
+      screen.getByText(motoScout24Theme.colors.brand[100]),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/themeProvider/__tests__/BrandThemeProvider.Test.tsx
+++ b/src/components/themeProvider/__tests__/BrandThemeProvider.Test.tsx
@@ -6,7 +6,7 @@ import { theme as autoScout24Theme } from '@/src/themes/autoscout24';
 
 import { screen, testingLibraryRender } from '@/jest-utils';
 
-import { MotoScout24Providers } from '../MotoScout24ThemeProvider';
+import { MotoScout24ThemeProvider } from '../MotoScout24ThemeProvider';
 import AutoScout24ThemeProvider from '../AutoScout24ThemeProvider';
 
 const TestComponent: FC = () => {
@@ -32,7 +32,7 @@ describe('brand-specific theme providers', () => {
   });
 
   it('provides motoscout24 theme without the generic provider', () => {
-    renderWrapper(MotoScout24Providers);
+    renderWrapper(MotoScout24ThemeProvider);
 
     expect(
       screen.getByText(motoScout24Theme.colors.brand[100]),

--- a/src/components/themeProvider/__tests__/ThemeProvider.Test.tsx
+++ b/src/components/themeProvider/__tests__/ThemeProvider.Test.tsx
@@ -2,7 +2,8 @@ import React, { FC } from 'react';
 import { useTheme } from '@chakra-ui/react';
 
 import { Brand } from '@/src/types/brand';
-import { autoScout24Theme, motoScout24Theme } from '@/src/themes';
+import { theme as motoScout24Theme } from '@/src/themes/motoscout24';
+import { theme as autoScout24Theme } from '@/src/themes/autoscout24';
 
 import { screen, testingLibraryRender } from '@/jest-utils';
 

--- a/src/components/themeProvider/index.tsx
+++ b/src/components/themeProvider/index.tsx
@@ -3,7 +3,8 @@ import { ChakraProvider } from '@chakra-ui/react';
 
 import { Brand } from '@/src/types/brand';
 
-import { autoScout24Theme, motoScout24Theme } from '@/src/themes';
+import { theme as motoScout24Theme } from '@/src/themes/motoscout24';
+import { theme as autoScout24Theme } from '@/src/themes/autoscout24';
 
 export type Props = {
   // Theme to use


### PR DESCRIPTION
References: No ticket

## Motivation and context

Consumers that know their brand at build time need a way to import only the selected brand theme provider instead of using the generic runtime `ThemeProvider`, which statically reaches both brand themes.

This adds brand-specific provider entrypoints for AutoScout24 and MotoScout24 and wires the package build so each subpath emits its own ESM, CJS, and type artifacts.

## Before

`ThemeProvider` selected the brand from a runtime map and imported both AS24 and MS24 themes into the same module graph.

## After

Consumers can import a brand-specific provider from:

- `@smg-automotive/components/theme-provider/autoscout24`
- `@smg-automotive/components/theme-provider/motoscout24`

Each entrypoint imports only its respective brand theme module while keeping the existing generic `ThemeProvider` intact for runtime switching.

## How to test

- `npm test -- ThemeProvider`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `node -e "const as24 = require('@smg-automotive/components/theme-provider/autoscout24'); const ms24 = require('@smg-automotive/components/theme-provider/motoscout24'); console.log(Boolean(as24.AutoScout24ThemeProvider), Boolean(ms24.MotoScout24Providers));"`
- `node --input-type=module -e "import { AutoScout24ThemeProvider } from '@smg-automotive/components/theme-provider/autoscout24'; import { MotoScout24Providers } from '@smg-automotive/components/theme-provider/motoscout24'; console.log(Boolean(AutoScout24ThemeProvider), Boolean(MotoScout24Providers));"`