### PR TITLE
[codex] Add brand-specific Chakra v3 theme providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,33 @@ Theme objects can also be imported directly from the package (for showcasing, de
 import { autoScout24Theme } from '@smg-automotive/components/themes';
 ```
 
+For single-brand applications, prefer the brand-specific provider entrypoints so the
+application only imports the selected brand style system:
+
+```tsx
+import { AutoScout24ThemeProvider } from '@smg-automotive/components/theme-provider/autoscout24';
+
+const App = ({ Component, pageProps }) => {
+  return (
+    <AutoScout24ThemeProvider>
+      <Component {...pageProps} />
+    </AutoScout24ThemeProvider>
+  );
+};
+```
+
+```tsx
+import { MotoScout24ThemeProvider } from '@smg-automotive/components/theme-provider/motoscout24';
+
+const App = ({ Component, pageProps }) => {
+  return (
+    <MotoScout24ThemeProvider>
+      <Component {...pageProps} />
+    </MotoScout24ThemeProvider>
+  );
+};
+```
+
 ### Switching themes in storybook
 
 We leverage [a theming addon](https://storybook.js.org/addons/storybook-addon-themes#custom-decorator) in storybook.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,26 @@
         "default": "./dist/cjs/theme-provider.js"
       }
     },
+    "./theme-provider/autoscout24": {
+      "import": {
+        "types": "./dist/theme-provider/autoscout24.d.mts",
+        "default": "./dist/esm/components/themeProvider/AutoScout24ThemeProvider.js"
+      },
+      "require": {
+        "types": "./dist/theme-provider/autoscout24.d.ts",
+        "default": "./dist/cjs/theme-provider/autoscout24.js"
+      }
+    },
+    "./theme-provider/motoscout24": {
+      "import": {
+        "types": "./dist/theme-provider/motoscout24.d.mts",
+        "default": "./dist/esm/components/themeProvider/MotoScout24ThemeProvider.js"
+      },
+      "require": {
+        "types": "./dist/theme-provider/motoscout24.d.ts",
+        "default": "./dist/cjs/theme-provider/motoscout24.js"
+      }
+    },
     "./themes": {
       "import": {
         "types": "./dist/themes.d.mts",
@@ -67,6 +87,12 @@
       ],
       "theme-provider": [
         "dist/theme-provider.d.ts"
+      ],
+      "theme-provider/autoscout24": [
+        "dist/theme-provider/autoscout24.d.ts"
+      ],
+      "theme-provider/motoscout24": [
+        "dist/theme-provider/motoscout24.d.ts"
       ],
       "themes": [
         "dist/themes.d.ts"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,10 +15,14 @@ import alias from '@rollup/plugin-alias';
 
 import packageJson from './package.json' with { type: 'json' };
 
-const external = [
+const externalPackages = [
   ...Object.keys(packageJson.dependencies || {}),
   ...Object.keys(packageJson.peerDependencies || {}),
 ];
+const external = (id) =>
+  externalPackages.some((packageName) => {
+    return id === packageName || id.startsWith(`${packageName}/`);
+  });
 const onwarn = (warning, warn) => {
   if (warning.code === 'CIRCULAR_DEPENDENCY') {
     if (warning.message.includes('node_modules/yargs')) return;

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -45,6 +45,12 @@ const breakpointsRequire = packageJson.exports[
 const themeProviderRequire = packageJson.exports[
   './theme-provider'
 ].require.default.replace(/^.\//, '');
+const autoScout24ThemeProviderRequire = packageJson.exports[
+  './theme-provider/autoscout24'
+].require.default.replace(/^.\//, '');
+const motoScout24ThemeProviderRequire = packageJson.exports[
+  './theme-provider/motoscout24'
+].require.default.replace(/^.\//, '');
 const themesRequire = packageJson.exports['./themes'].require.default.replace(
   /^.\//,
   '',
@@ -92,6 +98,8 @@ const esm = {
     'src/index.ts',
     'src/breakpoints.ts',
     'src/themeProvider.ts',
+    'src/components/themeProvider/AutoScout24ThemeProvider.tsx',
+    'src/components/themeProvider/MotoScout24ThemeProvider.tsx',
     'src/themes/index.ts',
   ],
   output: [
@@ -178,6 +186,14 @@ const themeProviderCjs = createSubpathCjs(
   'src/themeProvider.ts',
   themeProviderRequire,
 );
+const autoScout24ThemeProviderCjs = createSubpathCjs(
+  'src/components/themeProvider/AutoScout24ThemeProvider.tsx',
+  autoScout24ThemeProviderRequire,
+);
+const motoScout24ThemeProviderCjs = createSubpathCjs(
+  'src/components/themeProvider/MotoScout24ThemeProvider.tsx',
+  motoScout24ThemeProviderRequire,
+);
 const themesCjs = createSubpathCjs('src/themes/index.ts', themesRequire);
 
 const types = {
@@ -201,6 +217,14 @@ const breakpointsTypes = createSubpathTypes(
 const themeProviderTypes = createSubpathTypes(
   'src/themeProvider.ts',
   'dist/theme-provider.d.ts',
+);
+const autoScout24ThemeProviderTypes = createSubpathTypes(
+  'src/components/themeProvider/AutoScout24ThemeProvider.tsx',
+  'dist/theme-provider/autoscout24.d.ts',
+);
+const motoScout24ThemeProviderTypes = createSubpathTypes(
+  'src/components/themeProvider/MotoScout24ThemeProvider.tsx',
+  'dist/theme-provider/motoscout24.d.ts',
 );
 const themesTypes = createSubpathTypes(
   'src/themes/index.ts',
@@ -347,9 +371,13 @@ export default [
   types,
   breakpointsCjs,
   themeProviderCjs,
+  autoScout24ThemeProviderCjs,
+  motoScout24ThemeProviderCjs,
   themesCjs,
   breakpointsTypes,
   themeProviderTypes,
+  autoScout24ThemeProviderTypes,
+  motoScout24ThemeProviderTypes,
   themesTypes,
   hostedFontsTypes,
   hostedFontsCjs,

--- a/src/components/themeProvider/AutoScout24ThemeProvider.tsx
+++ b/src/components/themeProvider/AutoScout24ThemeProvider.tsx
@@ -1,0 +1,12 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import autoScout24System from '@/src/themes/autoScout24';
+
+export type AutoScout24ThemeProviderProps = PropsWithChildren;
+
+export const AutoScout24ThemeProvider: FC<AutoScout24ThemeProviderProps> = ({
+  children,
+}) => {
+  return <ChakraProvider value={autoScout24System}>{children}</ChakraProvider>;
+};

--- a/src/components/themeProvider/MotoScout24ThemeProvider.tsx
+++ b/src/components/themeProvider/MotoScout24ThemeProvider.tsx
@@ -1,0 +1,12 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import motoScout24System from '@/src/themes/motoScout24';
+
+export type MotoScout24ThemeProviderProps = PropsWithChildren;
+
+export const MotoScout24ThemeProvider: FC<MotoScout24ThemeProviderProps> = ({
+  children,
+}) => {
+  return <ChakraProvider value={motoScout24System}>{children}</ChakraProvider>;
+};

--- a/src/components/themeProvider/__tests__/BrandThemeProvider.Test.tsx
+++ b/src/components/themeProvider/__tests__/BrandThemeProvider.Test.tsx
@@ -1,0 +1,42 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { useChakraContext } from '@chakra-ui/react';
+
+import motoScout24System from '@/src/themes/motoScout24';
+import autoScout24System from '@/src/themes/autoScout24';
+
+import { screen, testingLibraryRender } from '@/jest-utils';
+
+import { MotoScout24ThemeProvider } from '../MotoScout24ThemeProvider';
+import { AutoScout24ThemeProvider } from '../AutoScout24ThemeProvider';
+
+const TestComponent: FC = () => {
+  const context = useChakraContext();
+  const color = context.tokens.getByName('colors.brand.100')?.value;
+
+  return <div>{color}</div>;
+};
+
+const renderWrapper = (Provider: FC<PropsWithChildren>) =>
+  testingLibraryRender(
+    <Provider>
+      <TestComponent />
+    </Provider>,
+  );
+
+describe('brand-specific theme providers', () => {
+  it('provides autoscout24 theme without the generic provider', () => {
+    renderWrapper(AutoScout24ThemeProvider);
+    const expected =
+      autoScout24System.tokens.getByName('colors.brand.100')?.value;
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it('provides motoscout24 theme without the generic provider', () => {
+    renderWrapper(MotoScout24ThemeProvider);
+    const expected =
+      motoScout24System.tokens.getByName('colors.brand.100')?.value;
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
References: No ticket
Based on: #1185 (`chakra-v3/root`)
Supersedes the main-based provider PR #1847.

## Motivation and context

Consumers that know their brand at build time need a way to import only the selected brand Chakra v3 style system instead of using the generic runtime `ThemeProvider`, which reaches both brand systems.

This adds brand-specific provider entrypoints on top of the Chakra v3 root branch and uses the v3 provider API: `ChakraProvider value={...System}`.

## Before

The Chakra v3 branch exposes `@smg-automotive/components/theme-provider`, where the generic `ThemeProvider` selects between `autoScout24System` and `motoScout24System` from a runtime brand map.

## After

Consumers can import a brand-specific provider from:

- `@smg-automotive/components/theme-provider/autoscout24`
- `@smg-automotive/components/theme-provider/motoscout24`

The AutoScout24 entrypoint imports `src/themes/autoScout24` directly. The MotoScout24 entrypoint imports `src/themes/motoScout24` directly. The generic `ThemeProvider` remains unchanged for runtime brand switching.

## How to test

- `npm ci`
- `npm run typegen`
- `npm test -- ThemeProvider`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `node -e "const as24 = require('@smg-automotive/components/theme-provider/autoscout24'); const ms24 = require('@smg-automotive/components/theme-provider/motoscout24'); console.log(Boolean(as24.AutoScout24ThemeProvider), Boolean(ms24.MotoScout24ThemeProvider));"`

Notes:

- `npm run lint` passes with two existing TODO warnings in `src/components/input/index.stories.tsx`.
- `npm run build` passes with existing Rollup `use client` directive warnings from the Chakra v3 branch.
- A direct Node ESM smoke import currently hits the existing v3 branch preserved-modules issue where some `dist/esm` files reference `dist/esm/node_modules/...`; CJS subpath resolution passes.