### PR TITLE
fix: carousel arrows visible on mobile

### DIFF
--- a/src/components/carousel/NavigationButton.tsx
+++ b/src/components/carousel/NavigationButton.tsx
@@ -34,7 +34,12 @@ export const NavigationButton: FC<Props> = ({
       aria-label={`${direction} slide`}
       css={{
         ...styles.buttonContainer,
-        ...(isHovered ? { visibility: 'visible', pointerEvents: 'auto' } : {}),
+        ...(isHovered
+          ? {
+              visibility: { base: 'hidden', md: 'visible' },
+              pointerEvents: { base: 'none', md: 'auto' },
+            }
+          : {}),
         ...side,
       }}
     >

--- a/src/components/carousel/NavigationButton.tsx
+++ b/src/components/carousel/NavigationButton.tsx
@@ -12,14 +12,12 @@ interface Props {
   onClick: () => void;
   direction: Direction;
   fullScreen: boolean;
-  isHovered?: boolean;
 }
 
 export const NavigationButton: FC<Props> = ({
   direction,
   onClick,
   fullScreen,
-  isHovered = false,
 }) => {
   const recipe = useSlotRecipe({ key: 'carousel' });
   const styles = recipe(fullScreen ? { variant: 'fullScreen' } : {});
@@ -34,12 +32,6 @@ export const NavigationButton: FC<Props> = ({
       aria-label={`${direction} slide`}
       css={{
         ...styles.buttonContainer,
-        ...(isHovered
-          ? {
-              visibility: { base: 'hidden', md: 'visible' },
-              pointerEvents: { base: 'none', md: 'auto' },
-            }
-          : {}),
         ...side,
       }}
     >

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -199,10 +199,8 @@ export const Carousel: FC<CarouselProps> = (props) => {
     ? carouselHeightByPaginationTypeMap[PaginationType.Thumbnail]
     : carouselHeightByPaginationTypeMap[paginationType];
 
-  const [isHovered, setIsHovered] = useState(false);
-
   return (
-    <Box css={styles.container} data-group>
+    <Box css={styles.container}>
       {prerenderFallbackSlide ? (
         <Slide
           slideIndex={startIndex}
@@ -222,9 +220,7 @@ export const Carousel: FC<CarouselProps> = (props) => {
           aria-label="Carousel"
           aria-roledescription="Carousel"
           role="group"
-          data-group
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          className="group"
           height={'var(--carousel-height)'}
           css={{
             ...styles.carousel,
@@ -254,7 +250,6 @@ export const Carousel: FC<CarouselProps> = (props) => {
               onClick={scrollPrev}
               direction="previous"
               fullScreen={!!fullScreen}
-              isHovered={isHovered}
             />
           ) : null}
           {canScrollNext ? (
@@ -262,7 +257,6 @@ export const Carousel: FC<CarouselProps> = (props) => {
               onClick={scrollNext}
               direction="next"
               fullScreen={!!fullScreen}
-              isHovered={isHovered}
             />
           ) : null}
           {paginationType === PaginationType.Dot ? (

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -254,9 +254,7 @@ export const Carousel: FC<CarouselProps> = (props) => {
               onClick={scrollPrev}
               direction="previous"
               fullScreen={!!fullScreen}
-              isHovered={
-                isHovered || (!!fullScreen && !isSmallLandscapeViewport)
-              }
+              isHovered={isHovered}
             />
           ) : null}
           {canScrollNext ? (
@@ -264,9 +262,7 @@ export const Carousel: FC<CarouselProps> = (props) => {
               onClick={scrollNext}
               direction="next"
               fullScreen={!!fullScreen}
-              isHovered={
-                isHovered || (!!fullScreen && !isSmallLandscapeViewport)
-              }
+              isHovered={isHovered}
             />
           ) : null}
           {paginationType === PaginationType.Dot ? (


### PR DESCRIPTION
References [link the ticket here]

- [ ] I hereby solemnly swear that I will sync these changes to the [chakra-integration](/tree/chakra-integration) branch right after merging this to main.

## Motivation and context

This wasn't migrated quite right. As per V3, you need class group in order for it to work
https://chakra-ui.com/docs/styling/conditional-styles#group-selectors

Currently there is a bug in prod on seller-web that arrows are visible on mobile
