### PR TITLE
fix: extend TextareaProps with padding and onKeyDown props

### DIFF
--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -23,7 +23,7 @@ export interface TextareaProps {
   textStyle?: 'body' | 'body-small';
   minHeight?: HTMLChakraProps<'textarea'>['minHeight'];
   maxHeight?: HTMLChakraProps<'textarea'>['maxHeight'];
-  padding: HTMLChakraProps<'textarea'>['padding'];
+  padding?: HTMLChakraProps<'textarea'>['padding'];
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -2,6 +2,7 @@ import React, {
   ChangeEventHandler,
   FocusEventHandler,
   forwardRef,
+  KeyboardEventHandler,
 } from 'react';
 
 import { Textarea as ChakraTextarea, HTMLChakraProps } from '@chakra-ui/react';
@@ -16,6 +17,7 @@ export interface TextareaProps {
   onBlur?: FocusEventHandler<HTMLTextAreaElement>;
   onFocus?: FocusEventHandler<HTMLTextAreaElement>;
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
   rows?: number;
   cols?: number;
   textStyle?: 'body' | 'body-small';

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -21,7 +21,7 @@ export interface TextareaProps {
   textStyle?: 'body' | 'body-small';
   minHeight?: HTMLChakraProps<'textarea'>['minHeight'];
   maxHeight?: HTMLChakraProps<'textarea'>['maxHeight'];
-  paddingRight?: HTMLChakraProps<'textarea'>['paddingRight'];
+  padding: HTMLChakraProps<'textarea'>['padding'];
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(


### PR DESCRIPTION
References [link the ticket here]

- [ ] I hereby solemnly swear that I will sync these changes to the [chakra-integration](/tree/chakra-integration) branch right after merging this to main.

## Motivation and context

[Describe the problem we're solving and lay out the solution]

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
