### PR TITLE
fix!: remove toast hosts from AppLayout

### DIFF
--- a/src/components/layout/app/AppLayout.tsx
+++ b/src/components/layout/app/AppLayout.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, PropsWithChildren } from 'react';
 
-import { TopRightToast, TopToast } from '@/src/components/toast';
 import { Grid, GridProps } from '@/src/components/grid';
 
 const pageGridArea = `
@@ -23,8 +22,6 @@ export const AppLayout = forwardRef<
       textStyle="body"
       {...rest}
     >
-      <TopRightToast />
-      <TopToast />
       {children}
     </Grid>
   );

--- a/src/components/layout/app/__tests__/AppLayout.Test.tsx
+++ b/src/components/layout/app/__tests__/AppLayout.Test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { render, screen } from '@/jest-utils';
+
+import { AppLayoutHeader } from '../Header';
+import { AppLayoutFooter } from '../Footer';
+import { AppLayoutContent } from '../Content';
+import { AppLayout } from '../AppLayout';
+
+describe('AppLayout', () => {
+  it('renders layout regions and content', () => {
+    render(
+      <AppLayout>
+        <AppLayoutHeader>Header</AppLayoutHeader>
+        <AppLayoutContent>Page content</AppLayoutContent>
+        <AppLayoutFooter>Footer</AppLayoutFooter>
+      </AppLayout>,
+    );
+
+    expect(screen.getByText('Header')).toBeInTheDocument();
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+    expect(screen.getByText('Footer')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Remove implicit `TopRightToast` and `TopToast` mounting from `AppLayout`.
- Keep `AppLayout` focused on layout structure only.
- Add coverage that `AppLayout` renders header/content/footer regions.

## Reasoning

`AppLayout` currently mounts toast hosts as a hidden side effect of rendering layout chrome. That makes the toast lifecycle depend on where a consuming app places `AppLayout`, even though toast hosts are global UI infrastructure rather than page layout content.

In seller-web, `AppLayoutWrapper` is currently created from page-level composition. During navigation, that can remount the layout while the toast store/toaster instances still keep module-level state from the components package. The result is that a toast triggered on one page can be replayed or visually duplicated after navigating to another page, because a new toast host appears and subscribes to existing toaster state.

Moving toast host ownership out of `AppLayout` makes the boundary explicit:

- `AppLayout` owns header/content/footer layout structure.
- The consuming application owns where global toast hosts are mounted.
- Apps can mount `TopToast` and `TopRightToast` once in their root/app shell so they stay stable across page navigation.

This also makes future seller-web architecture cleaner: route/page layouts can control header/footer/focus/chromeless shell variants without accidentally creating new toast containers.

## Breaking Change

`AppLayout` no longer mounts `TopToast` or `TopRightToast` automatically. Consumers must mount toast hosts explicitly where needed, for example at their app shell/root layout level.
